### PR TITLE
docs(readme): experimental version install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ This plugin to VS Code provides Angular language services for Angular.
 
 This plugin will provide completions in template files and template strings.
 
+## Installation
+
+To install the current experimental version, download the latest `ngls.vsix` file https://github.com/angular/vscode-ng-language-service/releases, then select "Install from VSIX" under the extensions menu to install it.
+
 ## Limitations
 
 - The language service is a separate service from TypeScript and runs a duplicate


### PR DESCRIPTION
Added some quick instructions that were in the releases tab to the README to help people in finding out how to install it.

Great work btw Chuck!