### PR TITLE
fix: force TypeScript to use the non-polling file and directory watchers

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -7,6 +7,9 @@
 /// <reference path="../typings/promise.d.ts" />
 /// <reference path="../node_modules/@types/node/index.d.ts" />
 
+// Force TypeScript to use the non-polling version of the file watchers.
+process.env["TSC_NONPOLLING_WATCHER"] = true;
+
 import * as ng from '@angular/language-service';
 
 import 'reflect-metadata';


### PR DESCRIPTION
The file watchers of TypeScript defaults to using polling (avoiding a watch bug in certain versions of node) which causes the language service to consume about %10 of the CPU checking for file and directory changes. The Code Helper does not have the watch bugs so shouldn't use polling.

This forces TypeScript to use `fs.watchFile` and `fs.watchDirectory` instead.