### PR TITLE
build: remove test yarn.lock from git tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ client/out/
 client/server/
 server/node_modules/
 dist/
+tests/**/yarn.lock
 .DS_Store


### PR DESCRIPTION
`yarn.lock` files are left in the tree during testing. They should be ignored.