### PR TITLE
Reverting name change, made by mistake

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ng-language-service",
+  "name": "ng-template",
   "displayName": "Angular Language Service",
   "description": "Editor services for Angular templates",
   "version": "0.1.5",


### PR DESCRIPTION
Name change made when trying to make the app more closely match the microsoft example. In theirs, I noticed the client and server shared a name.