### PR TITLE
release: cut the `0.1.7` release

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "ng-language-service",
+  "name": "ng-template",
   "displayName": "Angular Language Service",
   "description": "Editor services for Angular templates",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "publisher": "Angular",
   "icon": "angular.png",
   "engines": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "ng-language-service",
+  "name": "ng-template",
   "description": "Angular Language Service.",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "author": "Angular",
   "license": "MIT",
   "engines": {

--- a/server/src/editorServices.ts
+++ b/server/src/editorServices.ts
@@ -2749,6 +2749,7 @@ export class LineNode implements LineCollection {
       // assume (rangeStart < this.totalChars) && (rangeLength <= this.totalChars)
       let childIndex = 0;
       let child = this.children[0];
+      if (!child) return;
       let childCharCount = child.charCount();
       // find sub-tree containing start
       let adjustedStart = rangeStart;
@@ -2757,6 +2758,7 @@ export class LineNode implements LineCollection {
           adjustedStart -= childCharCount;
           childIndex++;
           child = this.children[childIndex];
+          if (!child) break;
           childCharCount = child.charCount();
       }
       // Case I: both start and end of range in same subtree
@@ -2781,6 +2783,7 @@ export class LineNode implements LineCollection {
               adjustedLength -= childCharCount;
               childIndex++;
               child = this.children[childIndex];
+              if (!child) break;
               childCharCount = child.charCount();
           }
           if (adjustedLength > 0) {


### PR DESCRIPTION
Fixes the package name to remove duplicate market place entry.
Harden against common a null encountered in the wild.
Update to 0.1.7

Fixes: #157, #156