### PR TITLE
Update Versions and fix type errors

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -5,12 +5,15 @@
   "version": "0.1.9",
   "publisher": "Angular",
   "icon": "angular.png",
-  "keywords": ["Angular", "multi-root ready"],
+  "keywords": [
+    "Angular",
+    "multi-root ready"
+  ],
   "engines": {
-    "vscode": "^1.4.0"
+    "vscode": "^1.22.0"
   },
   "categories": [
-    "Languages"
+    "Programming Languages"
   ],
   "activationEvents": [
     "onLanguage:ng-template",
@@ -43,13 +46,13 @@
     "postinstall": "node ./node_modules/vscode/bin/install"
   },
   "devDependencies": {
-    "@types/node": "^6.0.38",
-    "typescript": "^2.3.4",
-    "vscode": "^1.1.0"
+    "@types/node": "^10.5.0",
+    "typescript": "^2.9.2",
+    "vscode": "^1.1.18"
   },
   "dependencies": {
-    "vscode-languageclient": "~3.2.2",
-    "vscode-jsonrpc": "~3.2.0"
+    "vscode-languageclient": "^4.2.1",
+    "vscode-jsonrpc": "~3.6.2"
   },
   "repository": {
     "type": "git",

--- a/server/package.json
+++ b/server/package.json
@@ -14,19 +14,19 @@
   },
   "dependencies": {
     "@angular/language-service": "angular/language-service-builds#63940f8ce4222b9f3d89812a5f92ed61c75efe90",
-    "typescript": "2.6.x",
-    "vscode-jsonrpc": "^3.2.0",
-    "vscode-languageserver": "^3.2.2"
+    "typescript": "^2.9.2",
+    "vscode-jsonrpc": "^3.6.2",
+    "vscode-languageserver": "^4.2.1"
   },
   "devDependencies": {
-    "@angular/compiler": "5.2.x",
-    "@angular/compiler-cli": "5.2.x",
-    "@angular/core": "5.2.x",
+    "@angular/compiler": "^6.0.7",
+    "@angular/compiler-cli": "^6.0.7",
+    "@angular/core": "^6.0.7",
     "@types/jasmine": "^2.5.38",
-    "@types/node": "^6.0.46",
+    "@types/node": "^10.5.0",
     "jasmine": "^2.5.2",
-    "rxjs": "^5.0",
-    "zone.js": "^0.7.2"
+    "rxjs": "^6.2.1",
+    "zone.js": "^0.8.26"
   },
   "repository": {
     "type": "git",

--- a/server/src/editorServices.ts
+++ b/server/src/editorServices.ts
@@ -2056,7 +2056,7 @@ export class CompilerService {
       if (typeof result === 'function') {
           // The language service bundle exposes a function to allow hooking module dependencies
           // such as TypeScript.
-          result = result({typescript: ts});
+          result = (<any>result)({typescript: ts});
       }
       return result;
   }

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -7,7 +7,7 @@
 /// <reference path="../node_modules/@types/node/index.d.ts" />
 
 // Force TypeScript to use the non-polling version of the file watchers.
-process.env["TSC_NONPOLLING_WATCHER"] = true;
+(<any>process.env)["TSC_NONPOLLING_WATCHER"] = true;
 
 import * as ng from '@angular/language-service';
 


### PR DESCRIPTION
- All package versions updated except jasmine.
- Required min version for vs code changed to 1.22
- Fixed typing errors. 

**Did not look at tests** 

Works fine for me running 1.24 / 1.25-insider with Angular-Cli 6.0.7 