### PR TITLE
Update packages and vsocde language server. Also update node types to…

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -10,7 +10,7 @@
     "vscode": "^1.4.0"
   },
   "categories": [
-    "Languages"
+    "Programming Languages"
   ],
   "activationEvents": [
     "onLanguage:ng-template",
@@ -43,13 +43,13 @@
     "postinstall": "node ./node_modules/vscode/bin/install"
   },
   "devDependencies": {
-    "@types/node": "^6.0.38",
-    "typescript": "^2.3.4",
+    "@types/node": "^8.0.47",
+    "typescript": "^2.9.2",
     "vscode": "^1.1.0"
   },
   "dependencies": {
-    "vscode-languageclient": "~3.2.2",
-    "vscode-jsonrpc": "~3.2.0"
+    "vscode-languageclient": "^4.2.1",
+    "vscode-jsonrpc": "^3.6.2"
   },
   "repository": {
     "type": "git",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@types/node@^6.0.38":
-  version "6.0.85"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-6.0.85.tgz#ec02bfe54a61044f2be44f13b389c6a0e8ee05ae"
+"@types/node@^8.0.47":
+  version "8.10.20"
+  resolved "https://registry.npmjs.org/@types/node/-/node-8.10.20.tgz#fe674ea52e13950ab10954433a7824438aabbcac"
 
 ajv@^4.9.1:
   version "4.11.8"
@@ -1443,9 +1443,9 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
 
-typescript@^2.3.4:
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.4.2.tgz#f8395f85d459276067c988aa41837a8f82870844"
+typescript@^2.9.2:
+  version "2.9.2"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz#1cbf61d05d6b96269244eb6a3bce4bd914e0f00c"
 
 unique-stream@^2.0.2:
   version "2.2.1"
@@ -1545,20 +1545,26 @@ vinyl@~2.0.1:
     remove-trailing-separator "^1.0.1"
     replace-ext "^1.0.0"
 
-vscode-jsonrpc@^3.2.0, vscode-jsonrpc@~3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-3.2.0.tgz#c92b946ac385c8b41439b842b6bd07d517b64a7d"
+vscode-jsonrpc@^3.6.2:
+  version "3.6.2"
+  resolved "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-3.6.2.tgz#3b5eef691159a15556ecc500e9a8a0dd143470c8"
 
-vscode-languageclient@~3.2.2:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/vscode-languageclient/-/vscode-languageclient-3.2.2.tgz#7843839614aa099f172b4e5f8967d42b58d77f0d"
+vscode-languageclient@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-4.2.1.tgz#26fb0fd18687fcb2b81f358e4e7375a17ac42515"
   dependencies:
-    vscode-jsonrpc "^3.2.0"
-    vscode-languageserver-types "^3.2.0"
+    vscode-languageserver-protocol "^3.8.1"
 
-vscode-languageserver-types@^3.2.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.3.0.tgz#8964dc7c2247536fbefd2d6836bf3febac80dd00"
+vscode-languageserver-protocol@^3.8.1:
+  version "3.8.1"
+  resolved "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.8.1.tgz#ee3ce042f7f49f559a6a552e3f505001fa565154"
+  dependencies:
+    vscode-jsonrpc "^3.6.2"
+    vscode-languageserver-types "^3.8.1"
+
+vscode-languageserver-types@^3.8.1:
+  version "3.8.2"
+  resolved "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.8.2.tgz#2550b8d852195328a735c56dbf4e72b8da31613f"
 
 vscode@^1.1.0:
   version "1.1.4"

--- a/server/package.json
+++ b/server/package.json
@@ -10,23 +10,26 @@
   "scripts": {
     "compile": "installServerIntoExtension ../client ./package.json ./tsconfig-build.json && cp yarn.lock ../client/server && tsc -p tsconfig-build.json",
     "watch": "installServerIntoExtension ../client ./package.json ./tsconfig.json && cp yarn.lock ../client/server && tsc --watch -p .",
+    "compile-windows": "installServerIntoExtension ..\\client .\\package.json .\\tsconfig-build.json && xcopy yarn.lock ..\\client\\server /s /e && tsc -p tsconfig-build.json ",
+    "watch-windows": "installServerIntoExtension ..\\client .\\package.json .\\tsconfig.json && xcopy yarn.lock ..\\client\\server /s /e && tsc --watch -p .",
     "test": "tsc -p . && jasmine dist/**/*_spec.js"
   },
   "dependencies": {
-    "@angular/language-service": "angular/language-service-builds#63940f8ce4222b9f3d89812a5f92ed61c75efe90",
-    "typescript": "2.6.x",
-    "vscode-jsonrpc": "^3.2.0",
-    "vscode-languageserver": "^3.2.2"
+    "@angular/language-service": "angular/language-service-builds#6dfb4aed7cd5c5766f6d170ab498bc22a0c392bd",
+    "typescript": "2.8.x",
+    "vscode-jsonrpc": "^3.6.2",
+    "vscode-languageserver": "^4.2.1",
+    "tslib": "^1.9.3"
   },
   "devDependencies": {
-    "@angular/compiler": "5.2.x",
-    "@angular/compiler-cli": "5.2.x",
-    "@angular/core": "5.2.x",
+    "@angular/compiler": "6.1.0-beta.2",
+    "@angular/compiler-cli": "6.1.0-beta.2",
+    "@angular/core": "6.1.0-beta.2",
     "@types/jasmine": "^2.5.38",
-    "@types/node": "^6.0.46",
+    "@types/node": "^8.0.47",
     "jasmine": "^2.5.2",
-    "rxjs": "^5.0",
-    "zone.js": "^0.7.2"
+    "rxjs": "^6.2.1",
+    "zone.js": "^0.8.26"
   },
   "repository": {
     "type": "git",

--- a/server/src/editorServices.ts
+++ b/server/src/editorServices.ts
@@ -2040,7 +2040,7 @@ export class CompilerService {
   resolveLanguageServiceModule(): typeof ng {
       const host = path.resolve(this.host.getCurrentDirectory(), 'main.ts');
       const modules = this.host.resolveModuleNames(['@angular/language-service'], host);
-      let result = ng;
+      let result = ng as any; // fix inferred never type
       if (modules && modules[0]) {
         const resolvedModule = modules[0];
         const moduleName = path.dirname(resolvedModule.resolvedFileName);

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -7,7 +7,7 @@
 /// <reference path="../node_modules/@types/node/index.d.ts" />
 
 // Force TypeScript to use the non-polling version of the file watchers.
-process.env["TSC_NONPOLLING_WATCHER"] = true;
+(<any>process.env["TSC_NONPOLLING_WATCHER"]) = true;
 
 import * as ng from '@angular/language-service';
 

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -2,38 +2,38 @@
 # yarn lockfile v1
 
 
-"@angular/compiler-cli@5.2.x":
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/@angular/compiler-cli/-/compiler-cli-5.2.1.tgz#9ee3431d937767a4f4ae401f172b507b5db6456e"
+"@angular/compiler-cli@6.1.0-beta.2":
+  version "6.1.0-beta.2"
+  resolved "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-6.1.0-beta.2.tgz#08e7c449d33011884d4a1ba4f40d43ad899f627a"
   dependencies:
     chokidar "^1.4.2"
     minimist "^1.2.0"
     reflect-metadata "^0.1.2"
-    tsickle "^0.26.0"
+    tsickle "^0.29.0"
 
-"@angular/compiler@5.2.x":
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/@angular/compiler/-/compiler-5.2.1.tgz#758ed236c361cff018699e041fabbc4bcb7cdc72"
+"@angular/compiler@6.1.0-beta.2":
+  version "6.1.0-beta.2"
+  resolved "https://registry.npmjs.org/@angular/compiler/-/compiler-6.1.0-beta.2.tgz#593c1ea3fe38d86ad6350148580f6c342d8ffe3c"
   dependencies:
-    tslib "^1.7.1"
+    tslib "^1.9.0"
 
-"@angular/core@5.2.x":
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/@angular/core/-/core-5.2.1.tgz#47347e4098b0e997220d77652f4d9ca44dda8923"
+"@angular/core@6.1.0-beta.2":
+  version "6.1.0-beta.2"
+  resolved "https://registry.npmjs.org/@angular/core/-/core-6.1.0-beta.2.tgz#d94459158426c5bebc84e13f38c05b201a97ac94"
   dependencies:
-    tslib "^1.7.1"
+    tslib "^1.9.0"
 
-"@angular/language-service@angular/language-service-builds#63940f8ce4222b9f3d89812a5f92ed61c75efe90":
-  version "5.2.2-250c8da"
-  resolved "https://codeload.github.com/angular/language-service-builds/tar.gz/63940f8ce4222b9f3d89812a5f92ed61c75efe90"
+"@angular/language-service@angular/language-service-builds#6dfb4aed7cd5c5766f6d170ab498bc22a0c392bd":
+  version "6.1.0-beta.2"
+  resolved "https://codeload.github.com/angular/language-service-builds/tar.gz/6dfb4aed7cd5c5766f6d170ab498bc22a0c392bd"
 
 "@types/jasmine@^2.5.38":
   version "2.8.3"
   resolved "https://registry.yarnpkg.com/@types/jasmine/-/jasmine-2.8.3.tgz#f910edc67d69393d562d10f8f3d205ea3f3306bf"
 
-"@types/node@^6.0.46":
-  version "6.0.95"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-6.0.95.tgz#0d027612a77c55b84497ff90a4a7d597e5ac0fab"
+"@types/node@^8.0.47":
+  version "8.10.20"
+  resolved "https://registry.npmjs.org/@types/node/-/node-8.10.20.tgz#fe674ea52e13950ab10954433a7824438aabbcac"
 
 abbrev@1:
   version "1.1.1"
@@ -150,6 +150,10 @@ braces@^1.8.2:
     expand-range "^1.8.1"
     preserve "^0.2.0"
     repeat-element "^1.1.2"
+
+buffer-from@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.0.tgz#87fcaa3a298358e0ade6e442cfce840740d1ad04"
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -824,11 +828,11 @@ rimraf@2, rimraf@^2.5.1, rimraf@^2.6.1:
   dependencies:
     glob "^7.0.5"
 
-rxjs@^5.0:
-  version "5.5.6"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.6.tgz#e31fb96d6fd2ff1fd84bcea8ae9c02d007179c02"
+rxjs@^6.2.1:
+  version "6.2.1"
+  resolved "https://registry.npmjs.org/rxjs/-/rxjs-6.2.1.tgz#246cebec189a6cbc143a3ef9f62d6f4c91813ca1"
   dependencies:
-    symbol-observable "1.0.1"
+    tslib "^1.9.0"
 
 safe-buffer@^5.0.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
@@ -856,15 +860,16 @@ sntp@1.x.x:
   dependencies:
     hoek "2.x.x"
 
-source-map-support@^0.4.2:
-  version "0.4.18"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.18.tgz#0286a6de8be42641338594e97ccea75f0a2c585f"
+source-map-support@^0.5.0:
+  version "0.5.6"
+  resolved "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.6.tgz#4435cee46b1aab62b8e8610ce60f788091c51c13"
   dependencies:
-    source-map "^0.5.6"
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
 
-source-map@^0.5.6:
-  version "0.5.7"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
+source-map@^0.6.0:
+  version "0.6.1"
+  resolved "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 
 sshpk@^1.7.0:
   version "1.13.1"
@@ -908,10 +913,6 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
-symbol-observable@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.1.tgz#8340fc4702c3122df5d22288f88283f513d3fdd4"
-
 tar-pack@^3.4.0:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/tar-pack/-/tar-pack-3.4.1.tgz#e1dbc03a9b9d3ba07e896ad027317eb679a10a1f"
@@ -939,18 +940,18 @@ tough-cookie@~2.3.0:
   dependencies:
     punycode "^1.4.1"
 
-tsickle@^0.26.0:
-  version "0.26.0"
-  resolved "https://registry.yarnpkg.com/tsickle/-/tsickle-0.26.0.tgz#40b30a2dd6abcb33b182e37596674bd1cfe4039c"
+tsickle@^0.29.0:
+  version "0.29.0"
+  resolved "https://registry.npmjs.org/tsickle/-/tsickle-0.29.0.tgz#812806554bb46c1aa16eb0fe2a051da95ca8f5a4"
   dependencies:
     minimist "^1.2.0"
     mkdirp "^0.5.1"
-    source-map "^0.5.6"
-    source-map-support "^0.4.2"
+    source-map "^0.6.0"
+    source-map-support "^0.5.0"
 
-tslib@^1.7.1:
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.8.1.tgz#6946af2d1d651a7b1863b531d6e5afa41aa44eac"
+tslib@^1.9.0, tslib@^1.9.3:
+  version "1.9.3"
+  resolved "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
 
 tunnel-agent@^0.6.0:
   version "0.6.0"
@@ -962,9 +963,9 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
 
-typescript@2.6.x:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.6.2.tgz#3c5b6fd7f6de0914269027f03c0946758f7673a4"
+typescript@2.8.x:
+  version "2.8.4"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-2.8.4.tgz#0b1db68e6bdfb0b767fa2ab642136a35b059b199"
 
 uid-number@^0.0.6:
   version "0.0.6"
@@ -986,31 +987,31 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-vscode-jsonrpc@^3.2.0, vscode-jsonrpc@^3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-3.5.0.tgz#87239d9e166b2d7352245b8a813597804c1d63aa"
+vscode-jsonrpc@^3.6.2:
+  version "3.6.2"
+  resolved "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-3.6.2.tgz#3b5eef691159a15556ecc500e9a8a0dd143470c8"
 
-vscode-languageserver-protocol@^3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.5.0.tgz#067c5cbe27709795398d119692c97ebba1452209"
+vscode-languageserver-protocol@^3.8.1:
+  version "3.8.1"
+  resolved "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.8.1.tgz#ee3ce042f7f49f559a6a552e3f505001fa565154"
   dependencies:
-    vscode-jsonrpc "^3.5.0"
-    vscode-languageserver-types "^3.5.0"
+    vscode-jsonrpc "^3.6.2"
+    vscode-languageserver-types "^3.8.1"
 
-vscode-languageserver-types@^3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.5.0.tgz#e48d79962f0b8e02de955e3f524908e2b19c0374"
+vscode-languageserver-types@^3.8.1:
+  version "3.8.2"
+  resolved "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.8.2.tgz#2550b8d852195328a735c56dbf4e72b8da31613f"
 
-vscode-languageserver@^3.2.2:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver/-/vscode-languageserver-3.5.0.tgz#d28099bc6ddda8c1dd16b707e454e1b1ddae0dba"
+vscode-languageserver@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-4.2.1.tgz#96b60785c299ba5eed22173a0f9cc64c8f5fda4d"
   dependencies:
-    vscode-languageserver-protocol "^3.5.0"
-    vscode-uri "^1.0.1"
+    vscode-languageserver-protocol "^3.8.1"
+    vscode-uri "^1.0.3"
 
-vscode-uri@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-1.0.1.tgz#11a86befeac3c4aa3ec08623651a3c81a6d0bbc8"
+vscode-uri@^1.0.3:
+  version "1.0.5"
+  resolved "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.5.tgz#3b899a8ef71c37f3054d79bdbdda31c7bf36f20d"
 
 wide-align@^1.1.0:
   version "1.1.2"
@@ -1022,6 +1023,6 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
 
-zone.js@^0.7.2:
-  version "0.7.8"
-  resolved "https://registry.yarnpkg.com/zone.js/-/zone.js-0.7.8.tgz#4f3fe8834d44597f2639053a0fa438df34fffded"
+zone.js@^0.8.26:
+  version "0.8.26"
+  resolved "https://registry.npmjs.org/zone.js/-/zone.js-0.8.26.tgz#7bdd72f7668c5a7ad6b118148b4ea39c59d08d2d"


### PR DESCRIPTION
Node types updated to latest LTS (8.x)

Update typesript files to match new strict code analysis on 2.7+ typescript.
Update angular language service to 6.1.0-beta.2+11.sha-637805a from release repo.

Added scripts for building on windows. For now working OK except you need to run `yarn` in client/server after build to create node_modules,
since all commands on Windows I tried don't copy node_modules good recursively if you have deeply nested path (NTFS limitation).