### PR TITLE
fix: Flaky test on CI due to mock-host timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 sudo: false
 
 node_js:
-  - '6.9'
+  - '8.11'
 
 env:
   matrix:

--- a/tests/tools/mock-host/index.ts
+++ b/tests/tools/mock-host/index.ts
@@ -41,18 +41,18 @@ try {
     content = content.replace(RE_PWD, args['pwd']);
   }
   const json = JSON.parse(content);
-  
+
   if (Array.isArray(json)) {
     for (const message of json) {
       writer.write(message as any);
     }
   }
 
-  // Do not terminate the process for 5 seconds to allow messages to
+  // Do not terminate the process for 10 seconds to allow messages to
   // propagate. vscode-jsonrpc detects the process exit and terminates
   // the service. This prevents the detection from causing the test
   // to fail.
-  setTimeout(() => {}, 5000);
+  setTimeout(() => {}, 10000);
 } catch(e) {
   console.error(`Error: ${e.message}`);
   process.exit(2);


### PR DESCRIPTION
This commit fixes the flaky CI test due to the termination of JSON-RPC
client (mock-host) before the server actually processes all requests.