### PR TITLE
build: Add vsce to dev dependencies

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -5,7 +5,10 @@
   "version": "0.1.10-beta",
   "publisher": "Angular",
   "icon": "angular.png",
-  "keywords": ["Angular", "multi-root ready"],
+  "keywords": [
+    "Angular",
+    "multi-root ready"
+  ],
   "engines": {
     "vscode": "^1.4.0"
   },
@@ -45,6 +48,7 @@
   "devDependencies": {
     "@types/node": "^10.7.1",
     "typescript": "^2.7.x",
+    "vsce": "^1.46.0",
     "vscode": "^1.1.21"
   },
   "dependencies": {

--- a/scripts/ci/build.sh
+++ b/scripts/ci/build.sh
@@ -35,5 +35,5 @@ cd ../..
   rm -rf dist && mkdir dist
   cd client
 
-  vsce package --out ../dist/ngls.vsix
+  $(yarn bin)/vsce package --out ../dist/ngls.vsix
 )


### PR DESCRIPTION
The build script assumes that vsce is available in the global directory.
This commit adds vsce to the dev dependencies and invoke the local copy
instead.