### PR TITLE
release: version 0.1.10-beta to 0.1.10

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -2,7 +2,7 @@
   "name": "ng-template",
   "displayName": "Angular Language Service",
   "description": "Editor services for Angular templates",
-  "version": "0.1.10-beta",
+  "version": "0.1.10",
   "publisher": "Angular",
   "icon": "angular.png",
   "keywords": ["Angular", "multi-root ready"],


### PR DESCRIPTION
This commit removes "beta" from the version as it does not conform to
the version string format specified by VSCode marketplace.