### PR TITLE
fix: TSC_NONPOLLING_WATCHER should be set when process is spawned

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -5,19 +5,27 @@ import { LanguageClient, LanguageClientOptions, ServerOptions, TransportKind, Re
 
 export function activate(context: ExtensionContext) {
   // The server is implemented in node
-  let serverModule = context.asAbsolutePath(path.join('server', 'server.js'));
-  // The debug options for the server
-  let debugOptions = { execArgv: ["--nolazy", "--debug=6009"] };
+  const serverModule = context.asAbsolutePath(path.join('server', 'server.js'));
+  const options = {
+    module: serverModule,
+    transport: TransportKind.ipc,
+    options: {
+      env: {
+        // Force TypeScript to use the non-polling version of the file watchers.
+        TSC_NONPOLLING_WATCHER: true,
+      },
+    },
+  };
 
   // If the extension is launched in debug mode then the debug server options are used
   // Otherwise the run options are used
-  let serverOptions: ServerOptions = {
-    run : { module: serverModule, transport: TransportKind.ipc },
-    debug: { module: serverModule, transport: TransportKind.ipc /* *, options: debugOptions /* */ }
+  const serverOptions: ServerOptions = {
+    run : options,
+    debug: options,
   }
 
   // Options to control the language client
-  let clientOptions: LanguageClientOptions = {
+  const clientOptions: LanguageClientOptions = {
     // Register the server for Angular templates
     documentSelector: ['ng-template', 'html', 'typescript'],
 
@@ -34,7 +42,7 @@ export function activate(context: ExtensionContext) {
   }
 
   // Create the language client and start the client.
-  let disposable = new LanguageClient('Angular Language Service', serverOptions, clientOptions, true).start();
+  const disposable = new LanguageClient('Angular Language Service', serverOptions, clientOptions, true).start();
 
   // Push the disposable to the context's subscriptions so that the
   // client can be deactivated on extension deactivation

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -4,11 +4,6 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 
-
-
-// Force TypeScript to use the non-polling version of the file watchers.
-process.env["TSC_NONPOLLING_WATCHER"] = String(true);
-
 import * as ng from '@angular/language-service';
 
 import {


### PR DESCRIPTION
Setting the environment variable in the code after the process is
launched is too late. It has no effect. Instead, the parameter should be
specified as part of the server process spawn options.