### PR TITLE
fix: avoid close project while saving file

### DIFF
--- a/server/src/documents.ts
+++ b/server/src/documents.ts
@@ -211,9 +211,7 @@ export class TextDocuments {
       this.changeNumber++;
       const file = uriToFileName(event.textDocument.uri);
       if (file) {
-        const savedContent = this.host.readFile(file);
-        this.projectService.closeClientFile(file);
-        this.projectService.openClientFile(file, savedContent);
+        this.projectService.reloadScript(file);
         this.changeNumber++;
       }
     }));

--- a/server/src/editorServices.ts
+++ b/server/src/editorServices.ts
@@ -1641,6 +1641,15 @@ export class ProjectService {
       this.report("change", file, project);
   }
 
+  reloadScript(filename: string): void {
+    const info: ScriptInfo = this.filenameToScriptInfo[filename];
+    if (info) {
+        info.svc.reloadFromFile(filename);
+        this.changeSeq++;
+        this.report("change", info.fileName)
+    }
+  }
+
   forcedGetProjectForFile(fileName: string): Project {
     const file = normalizePath(fileName);
     const info = this.filenameToScriptInfo[file];


### PR DESCRIPTION
Currently the extension destroys project service while saving last opened file. This PR fixes this bug.
