### PR TITLE
feat: Backwards compat with new TS LS interface

### DIFF
--- a/server/src/editorServices.ts
+++ b/server/src/editorServices.ts
@@ -1528,11 +1528,23 @@ export class ProjectService {
 
       // Update Angular summaries
       let start = Date.now();
-      for (let project of this.configuredProjects) {
-          project.compilerService.ngHost.updateAnalyzedModules();
+      for (const project of this.configuredProjects) {
+          const ngHost = project.compilerService.ngHost;
+          if (ngHost.updateAnalyzedModules) {
+              // For backwards compatibility
+              ngHost.updateAnalyzedModules();
+          } else {
+              ngHost.getAnalyzedModules();
+          }
       }
-      for (let project of this.inferredProjects) {
-          project.compilerService.ngHost.updateAnalyzedModules();
+      for (const project of this.inferredProjects) {
+          const ngHost = project.compilerService.ngHost;
+          if (ngHost.updateAnalyzedModules) {
+              // For backwards compatibility
+              ngHost.updateAnalyzedModules();
+          } else {
+              ngHost.getAnalyzedModules();
+          }
       }
       this.log(`updated: ng - ${Date.now() - start}ms`, "Info");
 


### PR DESCRIPTION
https://github.com/angular/angular/pull/32115 updates the interface
for ng.getDiagnostics() to return ts.Diagnostics[] whereas
https://github.com/angular/angular/pull/32115 updates the interface
for ng.getCompletions() to return ts.CompletionInfo.

This PR makes the extension backwards compatible with the older
interface.