### PR TITLE
update extension to support server cmd flags

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -5,12 +5,20 @@ import { LanguageClient, LanguageClientOptions, ServerOptions, TransportKind, Re
 
 export function activate(context: ExtensionContext) {
 
+  // Log file does not yet exist on disk. It is up to the server to create the
+  // file.
+  const logFile = path.join(context.logPath, 'nglangsvc.log');
+
   // If the extension is launched in debug mode then the debug server options are used
   // Otherwise the run options are used
   const serverOptions: ServerOptions = {
     run : {
       module: context.asAbsolutePath(path.join('server', 'server.js')),
       transport: TransportKind.ipc,
+      args: [
+        '--logFile', logFile,
+        // TODO: Might want to turn off logging completely.
+      ],
       options: {
         env: {
           // Force TypeScript to use the non-polling version of the file watchers.
@@ -21,6 +29,10 @@ export function activate(context: ExtensionContext) {
     debug: {
       module: context.asAbsolutePath(path.join('server', 'out', 'server.js')),
       transport: TransportKind.ipc,
+      args: [
+        '--logFile', logFile,
+        '--logVerbosity', 'verbose',
+      ],
       options: {
         env: {
           // Force TypeScript to use the non-polling version of the file watchers.
@@ -28,7 +40,10 @@ export function activate(context: ExtensionContext) {
           NG_DEBUG: true,
         },
         execArgv: [
-          "--inspect=6009",	// If this is changed, update .vscode/launch.json as well
+          // do not lazily evaluate the code so all breakpoints are respected
+          '--nolazy',
+          // If debugging port is changed, update .vscode/launch.json as well
+          '--inspect=6009',
         ]
       },
     },
@@ -36,14 +51,18 @@ export function activate(context: ExtensionContext) {
 
   // Options to control the language client
   const clientOptions: LanguageClientOptions = {
-    // Register the server for Angular templates
-    documentSelector: ['ng-template', 'html', 'typescript'],
+    // Register the server for Angular templates and TypeScript documents
+    documentSelector: [
+      // scheme: 'file' means listen to changes to files on disk only
+      // other option is 'untitled', for buffer in the editor (like a new doc)
+      {scheme: 'file', language: 'html'},
+      {scheme: 'file', language: 'typescript'},
+    ],
 
-    // Information in the TypeScript project is necessary to generate Angular template completions
     synchronize: {
       fileEvents: [
+        // Notify the server about file changes to tsconfig.json contained in the workspace
         workspace.createFileSystemWatcher('**/tsconfig.json'),
-        workspace.createFileSystemWatcher('**/*.ts')
       ]
     },
 
@@ -52,7 +71,8 @@ export function activate(context: ExtensionContext) {
   }
 
   // Create the language client and start the client.
-  const disposable = new LanguageClient('Angular Language Service', serverOptions, clientOptions).start();
+  const client = new LanguageClient('Angular Language Service', serverOptions, clientOptions);
+  const disposable = client.start();
 
   // Push the disposable to the context's subscriptions so that the
   // client can be deactivated on extension deactivation


### PR DESCRIPTION
This commit updates the client options and server options in the
extension in preparation for the migration to the new server.

New server supports two command line arguments:
1. `--logFile <path>`
2. `--logVerbosity <verbose, normal, terse>`

These flags are same as the ones in tsserver.js