### PR TITLE
style: add clang-format for TypeScript formatting

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,3 @@
+Language:        JavaScript
+BasedOnStyle:    Google
+ColumnLimit:     100

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "compile": "tsc -b",
     "compile:test": "tsc -b server/src/tests",
     "compile:integration": "tsc -b integration",
+    "format": "scripts/format.sh",
     "watch": "tsc -b -w",
     "postinstall": "vscode-install && cd client && yarn && cd ../server && yarn && cd ..",
     "package": "rm -rf dist && node scripts/package.js",
@@ -38,6 +39,7 @@
   "devDependencies": {
     "@types/jasmine": "^3.4.0",
     "@types/node": "^10.9.4",
+    "clang-format": "^1.2.4",
     "jasmine": "^3.4.0",
     "tslint": "^5.19.0",
     "tslint-eslint-rules": "^5.4.0",

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -ex -o pipefail
+
+yarn clang-format -i client/**/*.ts
+yarn clang-format -i integration/**/*.ts
+yarn clang-format -i server/**/*.ts

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -2,6 +2,8 @@
 
 set -ex -o pipefail
 
-yarn clang-format -i client/**/*.ts
-yarn clang-format -i integration/**/*.ts
-yarn clang-format -i server/**/*.ts
+find . -name "*.ts" \
+  -not -path "*/project/*" \
+  -not -path "*/node_modules/*" \
+  -not -path "*/out/*" \
+  -exec yarn clang-format -i {} +

--- a/yarn.lock
+++ b/yarn.lock
@@ -76,6 +76,11 @@ assert-plus@1.0.0, assert-plus@^1.0.0:
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
   integrity sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=
 
+async@^1.5.2:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
+  integrity sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=
+
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
@@ -171,6 +176,15 @@ cheerio@^1.0.0-rc.1:
     htmlparser2 "^3.9.1"
     lodash "^4.15.0"
     parse5 "^3.0.1"
+
+clang-format@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/clang-format/-/clang-format-1.2.4.tgz#4bb4b0a98180428deb093cf20982e9fc1af20b6c"
+  integrity sha512-sw+nrGUp3hvmANd1qF8vZPuezSYQAiXgGBiEtkXTtJnnu6b00fCqkkDIsnRKrNgg4nv6NYZE92ejvOMIXZoejw==
+  dependencies:
+    async "^1.5.2"
+    glob "^7.0.0"
+    resolve "^1.1.6"
 
 color-convert@^1.9.0:
   version "1.9.3"
@@ -444,7 +458,7 @@ glob@7.1.2:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.6, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3:
+glob@^7.0.0, glob@^7.0.6, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3:
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.4.tgz#aa608a2f6c577ad357e1ae5a5c26d9a8d1969255"
   integrity sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==
@@ -849,7 +863,7 @@ requires-port@^1.0.0:
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
 
-resolve@^1.3.2:
+resolve@^1.1.6, resolve@^1.3.2:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.12.0.tgz#3fc644a35c84a48554609ff26ec52b66fa577df6"
   integrity sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==


### PR DESCRIPTION
Adds clang-format via the clang-format NPM package with Google JS/TS
formatting configuration set to 100 columns. Includes a script for
in-place formatting of TS files in the `client/`, `integration/`, and
`server/` directories. Includes a `yarn format` command that aliases
this script.

Part of #373.