### PR TITLE
docs: add documentation about new `clang-format` formatter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,6 @@ integration/out
 dist/
 **/.idea/
 **/tsconfig.tsbuildinfo
+.vscode/settings.json
 .vimrc
 .nvimrc

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ integration/out
 dist/
 **/.idea/
 **/tsconfig.tsbuildinfo
+.vimrc
+.nvimrc

--- a/.vscode/recommended-settings.json
+++ b/.vscode/recommended-settings.json
@@ -3,7 +3,7 @@
   "tslint.enable": true,
   "typescript.tsc.autoDetect": "off",
   "typescript.preferences.quoteStyle": "single",
-  "//format-on-save-comment": "Format ts files on save with `clang-format.executable`. If `clang-format.executable` is not being used, these two settings should be removed otherwise it will break existing formatting. You can instead run `yarn format` to manually format your code.",
+  "//format-on-save-comment": "Format ts files on save with `clang-format.executable`. If `clang-format.executable` is not being used, this setting should be removed. You can instead run `yarn format` to manually format your code.",
   "[typescript]": {
     "editor.formatOnSave": true
   },

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,11 @@
   "editor.insertSpaces": true,
   "tslint.enable": true,
   "typescript.tsc.autoDetect": "off",
-  "typescript.preferences.quoteStyle": "single"
+  "typescript.preferences.quoteStyle": "single",
+  "//format-on-save-comment": "Format ts files on save with `clang-format.executable`. If `clang-format.executable` is not being used, these two settings should be removed otherwise it will break existing formatting. You can instead run `yarn format` to manually format your code.",
+  "[typescript]": {
+    "editor.formatOnSave": true
+  },
+  "//clang-format-comment": "Please install https://marketplace.visualstudio.com/items?itemName=xaver.clang-format to take advantage of `clang-format` in VSCode. (See https://clang.llvm.org/docs/ClangFormat.html for more info `clang-format`.)",
+  "clang-format.executable": "${workspaceRoot}/node_modules/.bin/clang-format"
 }

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -1,0 +1,33 @@
+## Formatting source code
+
+This repository uses the [NPM distribution](https://www.npmjs.com/package/clang-format) of
+[`clang-format`](http://clang.llvm.org/docs/ClangFormat.html) to format source code.
+
+Code is automatically formatted by running `yarn format`. You can also set up your IDE to format
+files on each save.
+
+### VS Code
+
+1. Install the
+[`Clang-Format` extension](https://marketplace.visualstudio.com/items?itemName=xaver.clang-format)
+for VS Code.
+
+VS Code will automatically pick up relevant settings from this repository's
+[`.vscode/settings.json`](./.vscode/settings.json).
+
+### WebStorm / IntelliJ
+
+1. Install the [`ClangFormatIJ`](https://plugins.jetbrains.com/plugin/8396-clangformatij) plugin for
+   IntelliJ IDEs.
+2. Open `Preferences->Tools->clang-format`.
+3. Set the field named "PATH" to `<PATH_TO_REPOSITORY>/node_modules/.bin/`.
+
+### Vim
+
+1. Install [Vim Clang-Format](https://github.com/rhysd/vim-clang-format).
+2. Create a [project-specific `.vimrc`](https://andrew.stwrt.ca/posts/project-specific-vimrc/) in
+   the repository root directory containing
+
+```vim
+let g:clang_format#command = '<PATH_TO_REPOSITORY>/node_modules/.bin/clang-format'
+```

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -11,9 +11,9 @@ files on each save.
 1. Install the
 [`Clang-Format` extension](https://marketplace.visualstudio.com/items?itemName=xaver.clang-format)
 for VS Code.
-
-VS Code will automatically pick up relevant settings from this repository's
-[`.vscode/settings.json`](./.vscode/settings.json).
+2. Copy [`.vscode/recommended-settings.json`](./.vscode/recommended-settings.json) to a new
+   `.vscode/settings.json` file. VS Code will automatically pick up relevant formatting options for
+   the workspace from this file.
 
 ### WebStorm / IntelliJ
 


### PR DESCRIPTION
Document how to use the `clang-format` formatter added to this
repository in #372. Include instructions for formatting files on save
in VS Code, IntelliJ IDEs, and Vim.

Add a VS Code workspace setting configuration for enabling automatic
source code formatting with the `clang-format` VS Code extension.

Add `.vimrc` and `.nvimrc` so Vim and Neovim configurations of the
formatter are local-only.

Part of #373.