### PR TITLE
test: add test for clang-format formatted files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ script:
   - ./scripts/lint.sh
   - ./scripts/build.sh
   - ./scripts/test.sh
+  - ./scripts/format.sh && git diff --diff-filter=ACMRT --exit-code || (echo "Files not formatted; please run 'yarn format'." && exit 1)
 
 after_script:
   - ./scripts/cleanup.sh

--- a/client/src/protocol.ts
+++ b/client/src/protocol.ts
@@ -6,9 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import { NotificationType } from 'vscode-languageclient';
+import {NotificationType} from 'vscode-languageclient';
 
 export const projectLoadingNotification = {
-  start: new NotificationType<string,string>('angular-language-service/projectLoadingStart'),
-  finish: new NotificationType<string,string>('angular-language-service/projectLoadingFinish')
+  start: new NotificationType<string, string>('angular-language-service/projectLoadingStart'),
+  finish: new NotificationType<string, string>('angular-language-service/projectLoadingFinish')
 };

--- a/integration/e2e/definition.test.ts
+++ b/integration/e2e/definition.test.ts
@@ -1,6 +1,7 @@
-import * as vscode from 'vscode';
-import * as path from 'path';
 import * as assert from 'assert';
+import * as path from 'path';
+import * as vscode from 'vscode';
+
 import {activate} from './helper';
 
 const DEFINITION_COMMAND = 'vscode.executeDefinitionProvider';
@@ -20,10 +21,7 @@ describe('Angular LS', () => {
     // For a complete list of standard commands, see
     // https://code.visualstudio.com/api/references/commands
     const definitions = await vscode.commands.executeCommand(
-      DEFINITION_COMMAND,
-      docUri,
-      position
-    ) as vscode.Location[];
+                            DEFINITION_COMMAND, docUri, position) as vscode.Location[];
     assert.equal(definitions.length, 1);
     const def = definitions[0];
     assert.equal(def.uri.fsPath, docPath);  // in the same document

--- a/integration/e2e/helper.ts
+++ b/integration/e2e/helper.ts
@@ -1,5 +1,5 @@
-import * as vscode from 'vscode';
 import * as path from 'path';
+import * as vscode from 'vscode';
 
 function sleep(ms: number) {
   return new Promise(resolve => setTimeout(resolve, ms));
@@ -11,10 +11,8 @@ export async function activate(uri: vscode.Uri) {
   try {
     const doc = await vscode.workspace.openTextDocument(uri);
     const editor = await vscode.window.showTextDocument(doc);
-    await sleep(2000); // Wait for server activation
-  }
-  catch (e) {
+    await sleep(2000);  // Wait for server activation
+  } catch (e) {
     console.error(e);
   }
-
 }

--- a/integration/e2e/index.ts
+++ b/integration/e2e/index.ts
@@ -3,10 +3,6 @@ import * as testRunner from 'vscode/lib/testrunner';
 // This is the entry point of the test.
 // The test runner provided by vscode uses Mocha.
 // Check output in `Debug Console` of the main vscode window.
-testRunner.configure({
-    ui: 'bdd',
-    useColors: true,
-    timeout: 100000
-});
+testRunner.configure({ui: 'bdd', useColors: true, timeout: 100000});
 
 module.exports = testRunner;

--- a/integration/lsp/smoke_spec.ts
+++ b/integration/lsp/smoke_spec.ts
@@ -93,10 +93,8 @@ describe('Angular Language Service', () => {
       'result': {
         'capabilities': {
           'textDocumentSync': 2,
-          'completionProvider': {
-            'resolveProvider': false,
-            'triggerCharacters': ['<', '.', '*', '[', '(']
-          },
+          'completionProvider':
+              {'resolveProvider': false, 'triggerCharacters': ['<', '.', '*', '[', '(']},
           'definitionProvider': true,
           'hoverProvider': true
         }
@@ -123,10 +121,8 @@ describe('Angular Language Service', () => {
       'result': {
         'capabilities': {
           'textDocumentSync': 2,
-          'completionProvider': {
-            'resolveProvider': false,
-            'triggerCharacters': ['<', '.', '*', '[', '(']
-          },
+          'completionProvider':
+              {'resolveProvider': false, 'triggerCharacters': ['<', '.', '*', '[', '(']},
           'definitionProvider': true,
           'hoverProvider': true
         }
@@ -150,15 +146,9 @@ describe('Angular Language Service', () => {
       'jsonrpc': '2.0',
       'method': 'textDocument/didChange',
       'params': {
-        'textDocument': {
-          'uri': `file://${PROJECT_PATH}/app/app.component.ts`,
-          'version': 2
-        },
+        'textDocument': {'uri': `file://${PROJECT_PATH}/app/app.component.ts`, 'version': 2},
         'contentChanges': [{
-          'range': {
-            'start': {'line': 4, 'character': 29},
-            'end': {'line': 4, 'character': 29}
-          },
+          'range': {'start': {'line': 4, 'character': 29}, 'end': {'line': 4, 'character': 29}},
           'rangeLength': 0,
           'text': '.'
         }]
@@ -176,767 +166,407 @@ describe('Angular Language Service', () => {
     });
     // TODO: Match the response with a golden file instead of hardcoding result.
     expect(response).toEqual({
-      "jsonrpc": "2.0",
-      "id": 1,
-      "result": [
+      'jsonrpc': '2.0',
+      'id': 1,
+      'result': [
         {
-          "label": "toString",
-          "kind": 2,
-          "detail": "method",
-          "sortText": "toString",
-          "textEdit": {
-            "range": {
-              "start": {
-                "line": 4,
-                "character": 30
-              },
-              "end": {
-                "line": 4,
-                "character": 30
-              }
-            },
-            "newText": "toString"
+          'label': 'toString',
+          'kind': 2,
+          'detail': 'method',
+          'sortText': 'toString',
+          'textEdit': {
+            'range': {'start': {'line': 4, 'character': 30}, 'end': {'line': 4, 'character': 30}},
+            'newText': 'toString'
           }
         },
         {
-          "label": "charAt",
-          "kind": 2,
-          "detail": "method",
-          "sortText": "charAt",
-          "textEdit": {
-            "range": {
-              "start": {
-                "line": 4,
-                "character": 30
-              },
-              "end": {
-                "line": 4,
-                "character": 30
-              }
-            },
-            "newText": "charAt"
+          'label': 'charAt',
+          'kind': 2,
+          'detail': 'method',
+          'sortText': 'charAt',
+          'textEdit': {
+            'range': {'start': {'line': 4, 'character': 30}, 'end': {'line': 4, 'character': 30}},
+            'newText': 'charAt'
           }
         },
         {
-          "label": "charCodeAt",
-          "kind": 2,
-          "detail": "method",
-          "sortText": "charCodeAt",
-          "textEdit": {
-            "range": {
-              "start": {
-                "line": 4,
-                "character": 30
-              },
-              "end": {
-                "line": 4,
-                "character": 30
-              }
-            },
-            "newText": "charCodeAt"
+          'label': 'charCodeAt',
+          'kind': 2,
+          'detail': 'method',
+          'sortText': 'charCodeAt',
+          'textEdit': {
+            'range': {'start': {'line': 4, 'character': 30}, 'end': {'line': 4, 'character': 30}},
+            'newText': 'charCodeAt'
           }
         },
         {
-          "label": "concat",
-          "kind": 2,
-          "detail": "method",
-          "sortText": "concat",
-          "textEdit": {
-            "range": {
-              "start": {
-                "line": 4,
-                "character": 30
-              },
-              "end": {
-                "line": 4,
-                "character": 30
-              }
-            },
-            "newText": "concat"
+          'label': 'concat',
+          'kind': 2,
+          'detail': 'method',
+          'sortText': 'concat',
+          'textEdit': {
+            'range': {'start': {'line': 4, 'character': 30}, 'end': {'line': 4, 'character': 30}},
+            'newText': 'concat'
           }
         },
         {
-          "label": "indexOf",
-          "kind": 2,
-          "detail": "method",
-          "sortText": "indexOf",
-          "textEdit": {
-            "range": {
-              "start": {
-                "line": 4,
-                "character": 30
-              },
-              "end": {
-                "line": 4,
-                "character": 30
-              }
-            },
-            "newText": "indexOf"
+          'label': 'indexOf',
+          'kind': 2,
+          'detail': 'method',
+          'sortText': 'indexOf',
+          'textEdit': {
+            'range': {'start': {'line': 4, 'character': 30}, 'end': {'line': 4, 'character': 30}},
+            'newText': 'indexOf'
           }
         },
         {
-          "label": "lastIndexOf",
-          "kind": 2,
-          "detail": "method",
-          "sortText": "lastIndexOf",
-          "textEdit": {
-            "range": {
-              "start": {
-                "line": 4,
-                "character": 30
-              },
-              "end": {
-                "line": 4,
-                "character": 30
-              }
-            },
-            "newText": "lastIndexOf"
+          'label': 'lastIndexOf',
+          'kind': 2,
+          'detail': 'method',
+          'sortText': 'lastIndexOf',
+          'textEdit': {
+            'range': {'start': {'line': 4, 'character': 30}, 'end': {'line': 4, 'character': 30}},
+            'newText': 'lastIndexOf'
           }
         },
         {
-          "label": "localeCompare",
-          "kind": 2,
-          "detail": "method",
-          "sortText": "localeCompare",
-          "textEdit": {
-            "range": {
-              "start": {
-                "line": 4,
-                "character": 30
-              },
-              "end": {
-                "line": 4,
-                "character": 30
-              }
-            },
-            "newText": "localeCompare"
+          'label': 'localeCompare',
+          'kind': 2,
+          'detail': 'method',
+          'sortText': 'localeCompare',
+          'textEdit': {
+            'range': {'start': {'line': 4, 'character': 30}, 'end': {'line': 4, 'character': 30}},
+            'newText': 'localeCompare'
           }
         },
         {
-          "label": "match",
-          "kind": 2,
-          "detail": "method",
-          "sortText": "match",
-          "textEdit": {
-            "range": {
-              "start": {
-                "line": 4,
-                "character": 30
-              },
-              "end": {
-                "line": 4,
-                "character": 30
-              }
-            },
-            "newText": "match"
+          'label': 'match',
+          'kind': 2,
+          'detail': 'method',
+          'sortText': 'match',
+          'textEdit': {
+            'range': {'start': {'line': 4, 'character': 30}, 'end': {'line': 4, 'character': 30}},
+            'newText': 'match'
           }
         },
         {
-          "label": "replace",
-          "kind": 2,
-          "detail": "method",
-          "sortText": "replace",
-          "textEdit": {
-            "range": {
-              "start": {
-                "line": 4,
-                "character": 30
-              },
-              "end": {
-                "line": 4,
-                "character": 30
-              }
-            },
-            "newText": "replace"
+          'label': 'replace',
+          'kind': 2,
+          'detail': 'method',
+          'sortText': 'replace',
+          'textEdit': {
+            'range': {'start': {'line': 4, 'character': 30}, 'end': {'line': 4, 'character': 30}},
+            'newText': 'replace'
           }
         },
         {
-          "label": "search",
-          "kind": 2,
-          "detail": "method",
-          "sortText": "search",
-          "textEdit": {
-            "range": {
-              "start": {
-                "line": 4,
-                "character": 30
-              },
-              "end": {
-                "line": 4,
-                "character": 30
-              }
-            },
-            "newText": "search"
+          'label': 'search',
+          'kind': 2,
+          'detail': 'method',
+          'sortText': 'search',
+          'textEdit': {
+            'range': {'start': {'line': 4, 'character': 30}, 'end': {'line': 4, 'character': 30}},
+            'newText': 'search'
           }
         },
         {
-          "label": "slice",
-          "kind": 2,
-          "detail": "method",
-          "sortText": "slice",
-          "textEdit": {
-            "range": {
-              "start": {
-                "line": 4,
-                "character": 30
-              },
-              "end": {
-                "line": 4,
-                "character": 30
-              }
-            },
-            "newText": "slice"
+          'label': 'slice',
+          'kind': 2,
+          'detail': 'method',
+          'sortText': 'slice',
+          'textEdit': {
+            'range': {'start': {'line': 4, 'character': 30}, 'end': {'line': 4, 'character': 30}},
+            'newText': 'slice'
           }
         },
         {
-          "label": "split",
-          "kind": 2,
-          "detail": "method",
-          "sortText": "split",
-          "textEdit": {
-            "range": {
-              "start": {
-                "line": 4,
-                "character": 30
-              },
-              "end": {
-                "line": 4,
-                "character": 30
-              }
-            },
-            "newText": "split"
+          'label': 'split',
+          'kind': 2,
+          'detail': 'method',
+          'sortText': 'split',
+          'textEdit': {
+            'range': {'start': {'line': 4, 'character': 30}, 'end': {'line': 4, 'character': 30}},
+            'newText': 'split'
           }
         },
         {
-          "label": "substring",
-          "kind": 2,
-          "detail": "method",
-          "sortText": "substring",
-          "textEdit": {
-            "range": {
-              "start": {
-                "line": 4,
-                "character": 30
-              },
-              "end": {
-                "line": 4,
-                "character": 30
-              }
-            },
-            "newText": "substring"
+          'label': 'substring',
+          'kind': 2,
+          'detail': 'method',
+          'sortText': 'substring',
+          'textEdit': {
+            'range': {'start': {'line': 4, 'character': 30}, 'end': {'line': 4, 'character': 30}},
+            'newText': 'substring'
           }
         },
         {
-          "label": "toLowerCase",
-          "kind": 2,
-          "detail": "method",
-          "sortText": "toLowerCase",
-          "textEdit": {
-            "range": {
-              "start": {
-                "line": 4,
-                "character": 30
-              },
-              "end": {
-                "line": 4,
-                "character": 30
-              }
-            },
-            "newText": "toLowerCase"
+          'label': 'toLowerCase',
+          'kind': 2,
+          'detail': 'method',
+          'sortText': 'toLowerCase',
+          'textEdit': {
+            'range': {'start': {'line': 4, 'character': 30}, 'end': {'line': 4, 'character': 30}},
+            'newText': 'toLowerCase'
           }
         },
         {
-          "label": "toLocaleLowerCase",
-          "kind": 2,
-          "detail": "method",
-          "sortText": "toLocaleLowerCase",
-          "textEdit": {
-            "range": {
-              "start": {
-                "line": 4,
-                "character": 30
-              },
-              "end": {
-                "line": 4,
-                "character": 30
-              }
-            },
-            "newText": "toLocaleLowerCase"
+          'label': 'toLocaleLowerCase',
+          'kind': 2,
+          'detail': 'method',
+          'sortText': 'toLocaleLowerCase',
+          'textEdit': {
+            'range': {'start': {'line': 4, 'character': 30}, 'end': {'line': 4, 'character': 30}},
+            'newText': 'toLocaleLowerCase'
           }
         },
         {
-          "label": "toUpperCase",
-          "kind": 2,
-          "detail": "method",
-          "sortText": "toUpperCase",
-          "textEdit": {
-            "range": {
-              "start": {
-                "line": 4,
-                "character": 30
-              },
-              "end": {
-                "line": 4,
-                "character": 30
-              }
-            },
-            "newText": "toUpperCase"
+          'label': 'toUpperCase',
+          'kind': 2,
+          'detail': 'method',
+          'sortText': 'toUpperCase',
+          'textEdit': {
+            'range': {'start': {'line': 4, 'character': 30}, 'end': {'line': 4, 'character': 30}},
+            'newText': 'toUpperCase'
           }
         },
         {
-          "label": "toLocaleUpperCase",
-          "kind": 2,
-          "detail": "method",
-          "sortText": "toLocaleUpperCase",
-          "textEdit": {
-            "range": {
-              "start": {
-                "line": 4,
-                "character": 30
-              },
-              "end": {
-                "line": 4,
-                "character": 30
-              }
-            },
-            "newText": "toLocaleUpperCase"
+          'label': 'toLocaleUpperCase',
+          'kind': 2,
+          'detail': 'method',
+          'sortText': 'toLocaleUpperCase',
+          'textEdit': {
+            'range': {'start': {'line': 4, 'character': 30}, 'end': {'line': 4, 'character': 30}},
+            'newText': 'toLocaleUpperCase'
           }
         },
         {
-          "label": "trim",
-          "kind": 2,
-          "detail": "method",
-          "sortText": "trim",
-          "textEdit": {
-            "range": {
-              "start": {
-                "line": 4,
-                "character": 30
-              },
-              "end": {
-                "line": 4,
-                "character": 30
-              }
-            },
-            "newText": "trim"
+          'label': 'trim',
+          'kind': 2,
+          'detail': 'method',
+          'sortText': 'trim',
+          'textEdit': {
+            'range': {'start': {'line': 4, 'character': 30}, 'end': {'line': 4, 'character': 30}},
+            'newText': 'trim'
           }
         },
         {
-          "label": "length",
-          "kind": 10,
-          "detail": "property",
-          "sortText": "length",
-          "textEdit": {
-            "range": {
-              "start": {
-                "line": 4,
-                "character": 30
-              },
-              "end": {
-                "line": 4,
-                "character": 30
-              }
-            },
-            "newText": "length"
+          'label': 'length',
+          'kind': 10,
+          'detail': 'property',
+          'sortText': 'length',
+          'textEdit': {
+            'range': {'start': {'line': 4, 'character': 30}, 'end': {'line': 4, 'character': 30}},
+            'newText': 'length'
           }
         },
         {
-          "label": "substr",
-          "kind": 2,
-          "detail": "method",
-          "sortText": "substr",
-          "textEdit": {
-            "range": {
-              "start": {
-                "line": 4,
-                "character": 30
-              },
-              "end": {
-                "line": 4,
-                "character": 30
-              }
-            },
-            "newText": "substr"
+          'label': 'substr',
+          'kind': 2,
+          'detail': 'method',
+          'sortText': 'substr',
+          'textEdit': {
+            'range': {'start': {'line': 4, 'character': 30}, 'end': {'line': 4, 'character': 30}},
+            'newText': 'substr'
           }
         },
         {
-          "label": "valueOf",
-          "kind": 2,
-          "detail": "method",
-          "sortText": "valueOf",
-          "textEdit": {
-            "range": {
-              "start": {
-                "line": 4,
-                "character": 30
-              },
-              "end": {
-                "line": 4,
-                "character": 30
-              }
-            },
-            "newText": "valueOf"
+          'label': 'valueOf',
+          'kind': 2,
+          'detail': 'method',
+          'sortText': 'valueOf',
+          'textEdit': {
+            'range': {'start': {'line': 4, 'character': 30}, 'end': {'line': 4, 'character': 30}},
+            'newText': 'valueOf'
           }
         },
         {
-          "label": "codePointAt",
-          "kind": 2,
-          "detail": "method",
-          "sortText": "codePointAt",
-          "textEdit": {
-            "range": {
-              "start": {
-                "line": 4,
-                "character": 30
-              },
-              "end": {
-                "line": 4,
-                "character": 30
-              }
-            },
-            "newText": "codePointAt"
+          'label': 'codePointAt',
+          'kind': 2,
+          'detail': 'method',
+          'sortText': 'codePointAt',
+          'textEdit': {
+            'range': {'start': {'line': 4, 'character': 30}, 'end': {'line': 4, 'character': 30}},
+            'newText': 'codePointAt'
           }
         },
         {
-          "label": "includes",
-          "kind": 2,
-          "detail": "method",
-          "sortText": "includes",
-          "textEdit": {
-            "range": {
-              "start": {
-                "line": 4,
-                "character": 30
-              },
-              "end": {
-                "line": 4,
-                "character": 30
-              }
-            },
-            "newText": "includes"
+          'label': 'includes',
+          'kind': 2,
+          'detail': 'method',
+          'sortText': 'includes',
+          'textEdit': {
+            'range': {'start': {'line': 4, 'character': 30}, 'end': {'line': 4, 'character': 30}},
+            'newText': 'includes'
           }
         },
         {
-          "label": "endsWith",
-          "kind": 2,
-          "detail": "method",
-          "sortText": "endsWith",
-          "textEdit": {
-            "range": {
-              "start": {
-                "line": 4,
-                "character": 30
-              },
-              "end": {
-                "line": 4,
-                "character": 30
-              }
-            },
-            "newText": "endsWith"
+          'label': 'endsWith',
+          'kind': 2,
+          'detail': 'method',
+          'sortText': 'endsWith',
+          'textEdit': {
+            'range': {'start': {'line': 4, 'character': 30}, 'end': {'line': 4, 'character': 30}},
+            'newText': 'endsWith'
           }
         },
         {
-          "label": "normalize",
-          "kind": 2,
-          "detail": "method",
-          "sortText": "normalize",
-          "textEdit": {
-            "range": {
-              "start": {
-                "line": 4,
-                "character": 30
-              },
-              "end": {
-                "line": 4,
-                "character": 30
-              }
-            },
-            "newText": "normalize"
+          'label': 'normalize',
+          'kind': 2,
+          'detail': 'method',
+          'sortText': 'normalize',
+          'textEdit': {
+            'range': {'start': {'line': 4, 'character': 30}, 'end': {'line': 4, 'character': 30}},
+            'newText': 'normalize'
           }
         },
         {
-          "label": "repeat",
-          "kind": 2,
-          "detail": "method",
-          "sortText": "repeat",
-          "textEdit": {
-            "range": {
-              "start": {
-                "line": 4,
-                "character": 30
-              },
-              "end": {
-                "line": 4,
-                "character": 30
-              }
-            },
-            "newText": "repeat"
+          'label': 'repeat',
+          'kind': 2,
+          'detail': 'method',
+          'sortText': 'repeat',
+          'textEdit': {
+            'range': {'start': {'line': 4, 'character': 30}, 'end': {'line': 4, 'character': 30}},
+            'newText': 'repeat'
           }
         },
         {
-          "label": "startsWith",
-          "kind": 2,
-          "detail": "method",
-          "sortText": "startsWith",
-          "textEdit": {
-            "range": {
-              "start": {
-                "line": 4,
-                "character": 30
-              },
-              "end": {
-                "line": 4,
-                "character": 30
-              }
-            },
-            "newText": "startsWith"
+          'label': 'startsWith',
+          'kind': 2,
+          'detail': 'method',
+          'sortText': 'startsWith',
+          'textEdit': {
+            'range': {'start': {'line': 4, 'character': 30}, 'end': {'line': 4, 'character': 30}},
+            'newText': 'startsWith'
           }
         },
         {
-          "label": "anchor",
-          "kind": 2,
-          "detail": "method",
-          "sortText": "anchor",
-          "textEdit": {
-            "range": {
-              "start": {
-                "line": 4,
-                "character": 30
-              },
-              "end": {
-                "line": 4,
-                "character": 30
-              }
-            },
-            "newText": "anchor"
+          'label': 'anchor',
+          'kind': 2,
+          'detail': 'method',
+          'sortText': 'anchor',
+          'textEdit': {
+            'range': {'start': {'line': 4, 'character': 30}, 'end': {'line': 4, 'character': 30}},
+            'newText': 'anchor'
           }
         },
         {
-          "label": "big",
-          "kind": 2,
-          "detail": "method",
-          "sortText": "big",
-          "textEdit": {
-            "range": {
-              "start": {
-                "line": 4,
-                "character": 30
-              },
-              "end": {
-                "line": 4,
-                "character": 30
-              }
-            },
-            "newText": "big"
+          'label': 'big',
+          'kind': 2,
+          'detail': 'method',
+          'sortText': 'big',
+          'textEdit': {
+            'range': {'start': {'line': 4, 'character': 30}, 'end': {'line': 4, 'character': 30}},
+            'newText': 'big'
           }
         },
         {
-          "label": "blink",
-          "kind": 2,
-          "detail": "method",
-          "sortText": "blink",
-          "textEdit": {
-            "range": {
-              "start": {
-                "line": 4,
-                "character": 30
-              },
-              "end": {
-                "line": 4,
-                "character": 30
-              }
-            },
-            "newText": "blink"
+          'label': 'blink',
+          'kind': 2,
+          'detail': 'method',
+          'sortText': 'blink',
+          'textEdit': {
+            'range': {'start': {'line': 4, 'character': 30}, 'end': {'line': 4, 'character': 30}},
+            'newText': 'blink'
           }
         },
         {
-          "label": "bold",
-          "kind": 2,
-          "detail": "method",
-          "sortText": "bold",
-          "textEdit": {
-            "range": {
-              "start": {
-                "line": 4,
-                "character": 30
-              },
-              "end": {
-                "line": 4,
-                "character": 30
-              }
-            },
-            "newText": "bold"
+          'label': 'bold',
+          'kind': 2,
+          'detail': 'method',
+          'sortText': 'bold',
+          'textEdit': {
+            'range': {'start': {'line': 4, 'character': 30}, 'end': {'line': 4, 'character': 30}},
+            'newText': 'bold'
           }
         },
         {
-          "label": "fixed",
-          "kind": 2,
-          "detail": "method",
-          "sortText": "fixed",
-          "textEdit": {
-            "range": {
-              "start": {
-                "line": 4,
-                "character": 30
-              },
-              "end": {
-                "line": 4,
-                "character": 30
-              }
-            },
-            "newText": "fixed"
+          'label': 'fixed',
+          'kind': 2,
+          'detail': 'method',
+          'sortText': 'fixed',
+          'textEdit': {
+            'range': {'start': {'line': 4, 'character': 30}, 'end': {'line': 4, 'character': 30}},
+            'newText': 'fixed'
           }
         },
         {
-          "label": "fontcolor",
-          "kind": 2,
-          "detail": "method",
-          "sortText": "fontcolor",
-          "textEdit": {
-            "range": {
-              "start": {
-                "line": 4,
-                "character": 30
-              },
-              "end": {
-                "line": 4,
-                "character": 30
-              }
-            },
-            "newText": "fontcolor"
+          'label': 'fontcolor',
+          'kind': 2,
+          'detail': 'method',
+          'sortText': 'fontcolor',
+          'textEdit': {
+            'range': {'start': {'line': 4, 'character': 30}, 'end': {'line': 4, 'character': 30}},
+            'newText': 'fontcolor'
           }
         },
         {
-          "label": "fontsize",
-          "kind": 2,
-          "detail": "method",
-          "sortText": "fontsize",
-          "textEdit": {
-            "range": {
-              "start": {
-                "line": 4,
-                "character": 30
-              },
-              "end": {
-                "line": 4,
-                "character": 30
-              }
-            },
-            "newText": "fontsize"
+          'label': 'fontsize',
+          'kind': 2,
+          'detail': 'method',
+          'sortText': 'fontsize',
+          'textEdit': {
+            'range': {'start': {'line': 4, 'character': 30}, 'end': {'line': 4, 'character': 30}},
+            'newText': 'fontsize'
           }
         },
         {
-          "label": "italics",
-          "kind": 2,
-          "detail": "method",
-          "sortText": "italics",
-          "textEdit": {
-            "range": {
-              "start": {
-                "line": 4,
-                "character": 30
-              },
-              "end": {
-                "line": 4,
-                "character": 30
-              }
-            },
-            "newText": "italics"
+          'label': 'italics',
+          'kind': 2,
+          'detail': 'method',
+          'sortText': 'italics',
+          'textEdit': {
+            'range': {'start': {'line': 4, 'character': 30}, 'end': {'line': 4, 'character': 30}},
+            'newText': 'italics'
           }
         },
         {
-          "label": "link",
-          "kind": 2,
-          "detail": "method",
-          "sortText": "link",
-          "textEdit": {
-            "range": {
-              "start": {
-                "line": 4,
-                "character": 30
-              },
-              "end": {
-                "line": 4,
-                "character": 30
-              }
-            },
-            "newText": "link"
+          'label': 'link',
+          'kind': 2,
+          'detail': 'method',
+          'sortText': 'link',
+          'textEdit': {
+            'range': {'start': {'line': 4, 'character': 30}, 'end': {'line': 4, 'character': 30}},
+            'newText': 'link'
           }
         },
         {
-          "label": "small",
-          "kind": 2,
-          "detail": "method",
-          "sortText": "small",
-          "textEdit": {
-            "range": {
-              "start": {
-                "line": 4,
-                "character": 30
-              },
-              "end": {
-                "line": 4,
-                "character": 30
-              }
-            },
-            "newText": "small"
+          'label': 'small',
+          'kind': 2,
+          'detail': 'method',
+          'sortText': 'small',
+          'textEdit': {
+            'range': {'start': {'line': 4, 'character': 30}, 'end': {'line': 4, 'character': 30}},
+            'newText': 'small'
           }
         },
         {
-          "label": "strike",
-          "kind": 2,
-          "detail": "method",
-          "sortText": "strike",
-          "textEdit": {
-            "range": {
-              "start": {
-                "line": 4,
-                "character": 30
-              },
-              "end": {
-                "line": 4,
-                "character": 30
-              }
-            },
-            "newText": "strike"
+          'label': 'strike',
+          'kind': 2,
+          'detail': 'method',
+          'sortText': 'strike',
+          'textEdit': {
+            'range': {'start': {'line': 4, 'character': 30}, 'end': {'line': 4, 'character': 30}},
+            'newText': 'strike'
           }
         },
         {
-          "label": "sub",
-          "kind": 2,
-          "detail": "method",
-          "sortText": "sub",
-          "textEdit": {
-            "range": {
-              "start": {
-                "line": 4,
-                "character": 30
-              },
-              "end": {
-                "line": 4,
-                "character": 30
-              }
-            },
-            "newText": "sub"
+          'label': 'sub',
+          'kind': 2,
+          'detail': 'method',
+          'sortText': 'sub',
+          'textEdit': {
+            'range': {'start': {'line': 4, 'character': 30}, 'end': {'line': 4, 'character': 30}},
+            'newText': 'sub'
           }
         },
         {
-          "label": "sup",
-          "kind": 2,
-          "detail": "method",
-          "sortText": "sup",
-          "textEdit": {
-            "range": {
-              "start": {
-                "line": 4,
-                "character": 30
-              },
-              "end": {
-                "line": 4,
-                "character": 30
-              }
-            },
-            "newText": "sup"
+          'label': 'sup',
+          'kind': 2,
+          'detail': 'method',
+          'sortText': 'sup',
+          'textEdit': {
+            'range': {'start': {'line': 4, 'character': 30}, 'end': {'line': 4, 'character': 30}},
+            'newText': 'sup'
           }
         }
       ]

--- a/server/src/completion.ts
+++ b/server/src/completion.ts
@@ -28,8 +28,7 @@ enum CompletionKind {
  * Convert Angular's CompletionKind to LSP CompletionItemKind.
  * @param kind Angular's CompletionKind
  */
-function ngCompletionKindToLspCompletionItemKind(kind: CompletionKind):
-    lsp.CompletionItemKind {
+function ngCompletionKindToLspCompletionItemKind(kind: CompletionKind): lsp.CompletionItemKind {
   switch (kind) {
     case CompletionKind.attribute:
     case CompletionKind.htmlAttribute:

--- a/server/src/diagnostic.ts
+++ b/server/src/diagnostic.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import * as ts from 'typescript/lib/tsserverlibrary'; // used as value
+import * as ts from 'typescript/lib/tsserverlibrary';  // used as value
 import * as lsp from 'vscode-languageserver';
 import {tsTextSpanToLspRange} from './utils';
 
@@ -14,8 +14,7 @@ import {tsTextSpanToLspRange} from './utils';
  * Convert ts.DiagnosticCategory to lsp.DiagnosticSeverity
  * @param category diagnostic category
  */
-function tsDiagnosticCategoryToLspDiagnosticSeverity(
-    category: ts.DiagnosticCategory) {
+function tsDiagnosticCategoryToLspDiagnosticSeverity(category: ts.DiagnosticCategory) {
   switch (category) {
     case ts.DiagnosticCategory.Warning:
       return lsp.DiagnosticSeverity.Warning;

--- a/server/src/logger.ts
+++ b/server/src/logger.ts
@@ -8,7 +8,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import * as ts from 'typescript/lib/tsserverlibrary'; // used as value
+import * as ts from 'typescript/lib/tsserverlibrary';  // used as value
 
 // NOTES:
 // Be very careful about logging. There are two types of logging:
@@ -34,8 +34,7 @@ import * as ts from 'typescript/lib/tsserverlibrary'; // used as value
  * @param options Logging options.
  */
 export function createLogger(options: Map<string, string>) {
-  const logFile = options.get('logFile') ||
-      path.join(fs.mkdtempSync('ng_'), 'ngserver.log');
+  const logFile = options.get('logFile') || path.join(fs.mkdtempSync('ng_'), 'ngserver.log');
   const logVerbosity = options.get('logVerbosity') || 'normal';
   let logLevel: ts.server.LogLevel;
   switch (logVerbosity) {
@@ -65,8 +64,7 @@ function noop(_?: {}|null|undefined): void {}  // tslint:disable-line no-empty
 function nowString() {
   // E.g. "12:34:56.789"
   const d = new Date();
-  return `${d.getHours()}:${d.getMinutes()}:${d.getSeconds()}.${
-      d.getMilliseconds()}`;
+  return `${d.getHours()}:${d.getMinutes()}:${d.getSeconds()}.${d.getMilliseconds()}`;
 }
 
 export class Logger implements ts.server.Logger {
@@ -76,8 +74,7 @@ export class Logger implements ts.server.Logger {
   private firstInGroup = true;
 
   constructor(
-      private readonly logFilename: string,
-      private readonly traceToConsole: boolean,
+      private readonly logFilename: string, private readonly traceToConsole: boolean,
       private readonly level: ts.server.LogLevel) {
     if (logFilename) {
       try {
@@ -140,8 +137,7 @@ export class Logger implements ts.server.Logger {
 
     s = `[${nowString()}] ${s}\n`;
     if (!this.inGroup || this.firstInGroup) {
-      const prefix =
-          Logger.padStringRight(type + ' ' + this.seq.toString(), '          ');
+      const prefix = Logger.padStringRight(type + ' ' + this.seq.toString(), '          ');
       s = prefix + s;
     }
     this.write(s);
@@ -158,8 +154,7 @@ export class Logger implements ts.server.Logger {
     if (this.fd >= 0) {
       const buf = Buffer.from(s);
       // tslint:disable-next-line no-null-keyword
-      fs.writeSync(
-          this.fd, buf, 0, buf.length, /*position*/ null!);  // TODO: GH#18217
+      fs.writeSync(this.fd, buf, 0, buf.length, /*position*/ null!);  // TODO: GH#18217
     }
     if (this.traceToConsole) {
       console.warn(s);

--- a/server/src/project_service.ts
+++ b/server/src/project_service.ts
@@ -6,11 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import * as ts from 'typescript/lib/tsserverlibrary'; // used as value
+import * as ts from 'typescript/lib/tsserverlibrary';  // used as value
 import * as lsp from 'vscode-languageserver';
+
 import {tsDiagnosticToLspDiagnostic} from './diagnostic';
+import {projectLoadingNotification} from './protocol';
 import {filePathToUri} from './utils';
-import { projectLoadingNotification } from './protocol';
 
 // NOTE:
 // There are three types of `project`:
@@ -44,8 +45,7 @@ export class ProjectService {
   ) {
     const pluginProbeLocation =
         options.get('pluginProbeLocation') || serverHost.getCurrentDirectory();
-    connection.console.info(
-        `Angular LS probe location: ${pluginProbeLocation}`);
+    connection.console.info(`Angular LS probe location: ${pluginProbeLocation}`);
     // TODO: Should load TypeScript from workspace.
     this.tsProjSvc = new ts.server.ProjectService({
       host: serverHost,
@@ -88,8 +88,7 @@ export class ProjectService {
    * an inferred project.
    * @param scriptInfo
    */
-  getDefaultProjectForScriptInfo(scriptInfo: ts.server.ScriptInfo): ts.server.Project
-      |undefined {
+  getDefaultProjectForScriptInfo(scriptInfo: ts.server.ScriptInfo): ts.server.Project|undefined {
     let project = this.tsProjSvc.getDefaultProjectForFile(
         scriptInfo.fileName,
         // ensureProject tries to find a default project for the scriptInfo if
@@ -128,11 +127,11 @@ export class ProjectService {
     switch (event.eventName) {
       case ts.server.ProjectLoadingStartEvent:
         this.connection.sendNotification(
-          projectLoadingNotification.start, event.data.project.projectName);
+            projectLoadingNotification.start, event.data.project.projectName);
         break;
       case ts.server.ProjectLoadingFinishEvent:
         this.connection.sendNotification(
-          projectLoadingNotification.finish, event.data.project.projectName);
+            projectLoadingNotification.finish, event.data.project.projectName);
         break;
       case ts.server.ProjectsUpdatedInBackgroundEvent:
         // ProjectsUpdatedInBackgroundEvent is sent whenever diagnostics are
@@ -141,7 +140,7 @@ export class ProjectService {
         break;
     }
   }
-  
+
   private refreshDiagnostics(openFiles: string[]) {
     for (const fileName of openFiles) {
       const scriptInfo = this.tsProjSvc.getScriptInfo(fileName);
@@ -158,8 +157,7 @@ export class ProjectService {
       // not be updated.
       this.connection.sendDiagnostics({
         uri: filePathToUri(fileName),
-        diagnostics:
-            diagnostics.map(d => tsDiagnosticToLspDiagnostic(d, scriptInfo)),
+        diagnostics: diagnostics.map(d => tsDiagnosticToLspDiagnostic(d, scriptInfo)),
       });
     }
   }

--- a/server/src/protocol.ts
+++ b/server/src/protocol.ts
@@ -6,9 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import { NotificationType } from 'vscode-languageserver';
+import {NotificationType} from 'vscode-languageserver';
 
 export const projectLoadingNotification = {
-  start: new NotificationType<string,string>('angular-language-service/projectLoadingStart'),
-  finish: new NotificationType<string,string>('angular-language-service/projectLoadingFinish')
+  start: new NotificationType<string, string>('angular-language-service/projectLoadingStart'),
+  finish: new NotificationType<string, string>('angular-language-service/projectLoadingFinish')
 };

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -6,13 +6,14 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import * as ts from 'typescript/lib/tsserverlibrary';  // used as value
 import * as lsp from 'vscode-languageserver';
-import * as ts from 'typescript/lib/tsserverlibrary'; // used as value
-import {createLogger} from './logger';
-import {ServerHost} from './server_host';
-import {ProjectService} from './project_service';
-import {uriToFilePath, filePathToUri, tsTextSpanToLspRange, lspRangeToTsPositions, lspPositionToTsPosition} from './utils';
+
 import {tsCompletionEntryToLspCompletionItem} from './completion';
+import {createLogger} from './logger';
+import {ProjectService} from './project_service';
+import {ServerHost} from './server_host';
+import {filePathToUri, lspPositionToTsPosition, lspRangeToTsPositions, tsTextSpanToLspRange, uriToFilePath} from './utils';
 
 enum LanguageId {
   TS = 'typescript',
@@ -45,10 +46,11 @@ const {tsProjSvc} = projSvc;
 // Log initialization info
 connection.console.info(`Log file: ${logger.getLogFileName()}`);
 if (process.env.NG_DEBUG) {
-  logger.info("Angular Language Service is under DEBUG mode");
+  logger.info('Angular Language Service is under DEBUG mode');
 }
 if (process.env.TSC_NONPOLLING_WATCHER !== 'true') {
-  connection.console.warn(`Using less efficient polling watcher. Set TSC_NONPOLLING_WATCHER to true.`);
+  connection.console.warn(
+      `Using less efficient polling watcher. Set TSC_NONPOLLING_WATCHER to true.`);
 }
 
 // After the server has started the client sends an initilize request.
@@ -92,8 +94,8 @@ connection.onDidOpenTextDocument((params: lsp.DidOpenTextDocumentParams) => {
     connection.console.error(`Failed to find project for ${filePath}`);
     return;
   }
-  project.markAsDirty();	// Must mark project as dirty to rebuild the program.
-  project.refreshDiagnostics();	// Show initial diagnostics
+  project.markAsDirty();         // Must mark project as dirty to rebuild the program.
+  project.refreshDiagnostics();  // Show initial diagnostics
 });
 
 connection.onDidCloseTextDocument((params: lsp.DidCloseTextDocumentParams) => {
@@ -136,8 +138,7 @@ connection.onDidSaveTextDocument((params: lsp.DidSaveTextDocumentParams) => {
   }
   if (text) {
     scriptInfo.open(text);
-  }
-  else {
+  } else {
     scriptInfo.reloadFromFile();
   }
 });
@@ -203,8 +204,7 @@ connection.onHover((params: lsp.TextDocumentPositionParams) => {
     // displayParts does not contain info about kindModifiers
     // but displayParts does contain info about kind
     desc += displayParts.map(dp => dp.text).join('');
-  }
-  else {
+  } else {
     desc += kind;
   }
   const contents: lsp.MarkedString[] = [{
@@ -240,9 +240,11 @@ connection.onCompletion((params: lsp.CompletionParams) => {
   }
   const offset = lspPositionToTsPosition(scriptInfo, position);
   const langSvc = project.getLanguageService();
-  const completions = langSvc.getCompletionsAtPosition(fileName, offset, {
-    // options
-  });
+  const completions = langSvc.getCompletionsAtPosition(
+      fileName, offset,
+      {
+          // options
+      });
   if (!completions || !completions.entries.length) {
     return;
   }

--- a/server/src/server_host.ts
+++ b/server/src/server_host.ts
@@ -6,12 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import * as ts from 'typescript/lib/tsserverlibrary'; // used as value
+import * as ts from 'typescript/lib/tsserverlibrary';  // used as value
 
 /**
  * `ServerHost` is a wrapper around `ts.sys` for the Node system. In Node, all
  * optional methods of `ts.System` are implemented.
- * See https://github.com/microsoft/TypeScript/blob/ec39d412876d0dcf704fc886d5036cb625220d2f/src/compiler/sys.ts#L716
+ * See
+ * https://github.com/microsoft/TypeScript/blob/ec39d412876d0dcf704fc886d5036cb625220d2f/src/compiler/sys.ts#L716
  */
 export class ServerHost implements ts.server.ServerHost {
   readonly args: string[];
@@ -48,15 +49,13 @@ export class ServerHost implements ts.server.ServerHost {
    * @pollingInterval - this parameter is used in polling-based watchers and
    * ignored in watchers that use native OS file watching
    */
-  watchFile(
-      path: string, callback: ts.FileWatcherCallback,
-      pollingInterval?: number): ts.FileWatcher {
+  watchFile(path: string, callback: ts.FileWatcherCallback, pollingInterval?: number):
+      ts.FileWatcher {
     return ts.sys.watchFile!(path, callback, pollingInterval);
   }
 
-  watchDirectory(
-      path: string, callback: ts.DirectoryWatcherCallback,
-      recursive?: boolean): ts.FileWatcher {
+  watchDirectory(path: string, callback: ts.DirectoryWatcherCallback, recursive?: boolean):
+      ts.FileWatcher {
     return ts.sys.watchDirectory!(path, callback, recursive);
   }
 
@@ -89,9 +88,8 @@ export class ServerHost implements ts.server.ServerHost {
   }
 
   readDirectory(
-      path: string, extensions?: ReadonlyArray<string>,
-      exclude?: ReadonlyArray<string>, include?: ReadonlyArray<string>,
-      depth?: number): string[] {
+      path: string, extensions?: ReadonlyArray<string>, exclude?: ReadonlyArray<string>,
+      include?: ReadonlyArray<string>, depth?: number): string[] {
     return ts.sys.readDirectory(path, extensions, exclude, include, depth);
   }
 
@@ -135,8 +133,7 @@ export class ServerHost implements ts.server.ServerHost {
     return ts.sys.realpath!(path);
   }
 
-  setTimeout(callback: (...args: any[]) => void, ms: number, ...args: any[]):
-      any {
+  setTimeout(callback: (...args: any[]) => void, ms: number, ...args: any[]): any {
     return ts.sys.setTimeout!(callback, ms, ...args);
   }
 

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import * as ts from 'typescript/lib/tsserverlibrary';  // used as types only
 import * as lsp from 'vscode-languageserver';
-import * as ts from 'typescript/lib/tsserverlibrary'; // used as types only
 import {URI} from 'vscode-uri';
 
 enum Scheme {
@@ -20,7 +20,8 @@ enum Scheme {
  */
 export function uriToFilePath(uri: string): string {
   // Note: uri.path is different from uri.fsPath
-  // See https://github.com/microsoft/vscode-uri/blob/413805221cc6ed167186ab3103d3248d6f7161f2/src/index.ts#L622-L645
+  // See
+  // https://github.com/microsoft/vscode-uri/blob/413805221cc6ed167186ab3103d3248d6f7161f2/src/index.ts#L622-L645
   const {scheme, fsPath} = URI.parse(uri);
   if (scheme !== Scheme.File) {
     return '';
@@ -47,13 +48,11 @@ export function filePathToUri(filePath: string): string {
  * @param scriptInfo Used to determine the offsets.
  * @param textSpan
  */
-export function tsTextSpanToLspRange(
-    scriptInfo: ts.server.ScriptInfo, textSpan: ts.TextSpan) {
+export function tsTextSpanToLspRange(scriptInfo: ts.server.ScriptInfo, textSpan: ts.TextSpan) {
   const start = scriptInfo.positionToLineOffset(textSpan.start);
   const end = scriptInfo.positionToLineOffset(textSpan.start + textSpan.length);
   // ScriptInfo (TS) is 1-based, LSP is 0-based.
-  return lsp.Range.create(
-      start.line - 1, start.offset - 1, end.line - 1, end.offset - 1);
+  return lsp.Range.create(start.line - 1, start.offset - 1, end.line - 1, end.offset - 1);
 }
 
 /**
@@ -62,8 +61,7 @@ export function tsTextSpanToLspRange(
  * @param scriptInfo Used to determine the offsets.
  * @param position
  */
-export function lspPositionToTsPosition(
-    scriptInfo: ts.server.ScriptInfo, position: lsp.Position) {
+export function lspPositionToTsPosition(scriptInfo: ts.server.ScriptInfo, position: lsp.Position) {
   const {line, character} = position;
   // ScriptInfo (TS) is 1-based, LSP is 0-based.
   return scriptInfo.lineOffsetToPosition(line + 1, character + 1);


### PR DESCRIPTION
Adds automated Travis CI test to ensure TypeScript files are formatted
with `clang-format`. If any files are unformatted, and error message
stating "Files not formatted; please run 'yarn format'" is given.

Also formats existing files to pass this new test.

PR Closes #373