### PR TITLE
refactor(server): remove unused ProjectService class properties

### DIFF
--- a/server/src/project_service.ts
+++ b/server/src/project_service.ts
@@ -38,8 +38,8 @@ export class ProjectService {
   public readonly tsProjSvc: ts.server.ProjectService;
 
   constructor(
-      private readonly serverHost: ts.server.ServerHost,
-      private readonly logger: ts.server.Logger,
+      serverHost: ts.server.ServerHost,
+      logger: ts.server.Logger,
       private readonly connection: lsp.IConnection,
       options: Map<string, string>,
   ) {


### PR DESCRIPTION
`ProjectService.serverHost` and `ProjectService.logger` are never
actually used by `ProjectService` except in the constructor. Remove them
as properties.