### PR TITLE
fix: Always open HTML files as External Script

### DIFF
--- a/server/src/project_service.ts
+++ b/server/src/project_service.ts
@@ -61,6 +61,17 @@ export class ProjectService {
       allowLocalPluginLoads: false,  // do not load plugins from tsconfig.json
     });
 
+    this.tsProjSvc.setHostConfiguration({
+      formatOptions: this.tsProjSvc.getHostFormatCodeOptions(),
+      extraFileExtensions: [
+        {
+          extension: '.html',
+          isMixedContent: false,
+          scriptKind: ts.ScriptKind.External,
+        },
+      ],
+    });
+
     this.tsProjSvc.configurePlugin({
       pluginName: '@angular/language-service',
       configuration: {


### PR DESCRIPTION
When `ScriptInfo` is created for non-JS/TS files other than through
`openClientFile()`, explicitly set HTML files as `ts.ScriptKind.External`.
This is used, for example, for files returned by `getExternalFiles()`.