### PR TITLE
fix: always use projSvc.getDefaultProjectForScriptInfo

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -128,7 +128,10 @@ connection.onDidChangeTextDocument((params: lsp.DidChangeTextDocumentParams) => 
     }
   }
 
-  const project = scriptInfo.getDefaultProject();
+  const project = projSvc.getDefaultProjectForScriptInfo(scriptInfo);
+  if (!project) {
+    return;
+  }
   project.refreshDiagnostics();
 });
 


### PR DESCRIPTION
`scriptInfo.getDefaultProject()` will throw if it does not have any containing project, thus it should not be used.
This could occur if only HTML file is opened in the editor, and `openClientFile()` does not return the
config file name.