### PR TITLE
feat: Add restart command

### DIFF
--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as vscode from 'vscode';
+import * as lsp from 'vscode-languageclient';
+
+/**
+ * Represent a vscode command with an ID and an impl function `execute`.
+ */
+interface Command {
+  id: string;
+  execute(): Promise<vscode.Disposable>;
+}
+
+/**
+ * Restart the language server by killing the process then spanwing a new one.
+ * @param client language client
+ */
+function restartNgServer(client: lsp.LanguageClient): Command {
+  return {
+    id: 'angular.restartNgServer',
+    async execute() {
+      await client.stop();
+      return client.start();
+    },
+  };
+}
+
+/**
+ * Register all supported vscode commands for the Angular extension.
+ * @param client language client
+ */
+export function registerCommands(client: lsp.LanguageClient): vscode.Disposable[] {
+  const commands: Command[] = [
+    restartNgServer(client),
+  ];
+
+  const disposables = commands.map((command) => {
+    return vscode.commands.registerCommand(command.id, command.execute);
+  });
+
+  return disposables;
+}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "commands": [
       {
         "command": "angular.restartNgServer",
-        "title": "Restart Angular server",
+        "title": "Restart Angular Language server",
         "category": "Angular"
       }
     ]

--- a/package.json
+++ b/package.json
@@ -16,6 +16,15 @@
   "categories": [
     "Programming Languages"
   ],
+  "contributes": {
+    "commands": [
+      {
+        "command": "angular.restartNgServer",
+        "title": "Restart Angular server",
+        "category": "Angular"
+      }
+    ]
+  },
   "activationEvents": [
     "onLanguage:html",
     "onLanguage:typescript"


### PR DESCRIPTION
This PR adds `Angular: Restart Angular server' command to the extension.
This will kill the existing language server then spawns a new process.

PR closes https://github.com/angular/vscode-ng-language-service/issues/267

![Screen Shot 2019-09-13 at 10 07 27 AM](https://user-images.githubusercontent.com/2941178/64881131-d6044100-d60e-11e9-8785-055ad46a7629.png)
