### PR TITLE
fix: do not retrieve language service if it's disabled

### DIFF
--- a/server/src/project_service.ts
+++ b/server/src/project_service.ts
@@ -159,7 +159,7 @@ export class ProjectService {
         continue;
       }
       const project = this.getDefaultProjectForScriptInfo(scriptInfo);
-      if (!project) {
+      if (!project || !project.languageServiceEnabled) {
         continue;
       }
       const ngLS = project.getLanguageService();

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -160,7 +160,7 @@ connection.onDefinition((params: lsp.TextDocumentPositionParams) => {
 
   const {fileName} = scriptInfo;
   const project = projSvc.getDefaultProjectForScriptInfo(scriptInfo);
-  if (!project) {
+  if (!project || !project.languageServiceEnabled) {
     return;
   }
 
@@ -207,7 +207,7 @@ connection.onHover((params: lsp.TextDocumentPositionParams) => {
   }
   const {fileName} = scriptInfo;
   const project = tsProjSvc.getDefaultProjectForFile(fileName, true /* ensureProject */);
-  if (!project) {
+  if (!project || !project.languageServiceEnabled) {
     return;
   }
   const offset = lspPositionToTsPosition(scriptInfo, position);
@@ -253,7 +253,7 @@ connection.onCompletion((params: lsp.CompletionParams) => {
   }
   const {fileName} = scriptInfo;
   const project = projSvc.getDefaultProjectForScriptInfo(scriptInfo);
-  if (!project) {
+  if (!project || !project.languageServiceEnabled) {
     return;
   }
   const offset = lspPositionToTsPosition(scriptInfo, position);


### PR DESCRIPTION
This is the first part to partially address https://github.com/angular/vscode-ng-language-service/issues/391

When non-Angular TypeScript projects are opened, the Angular language service should be disabled.
Once it's disabled, the server should not call `getLanguageService()`.