### PR TITLE
feat: Bundle @angular/language-service with server

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -17,6 +17,7 @@ export function activate(context: vscode.ExtensionContext) {
   // Log file does not yet exist on disk. It is up to the server to create the
   // file.
   const logFile = path.join(context.logPath, 'nglangsvc.log');
+  const pluginProbeLocation = context.asAbsolutePath('server');
 
   // If the extension is launched in debug mode then the debug server options are used
   // Otherwise the run options are used
@@ -25,8 +26,11 @@ export function activate(context: vscode.ExtensionContext) {
       module: context.asAbsolutePath(path.join('server', 'server.js')),
       transport: lsp.TransportKind.ipc,
       args: [
-        '--logFile', logFile,
+        '--logFile',
+        logFile,
         // TODO: Might want to turn off logging completely.
+        '--pluginProbeLocation',
+        pluginProbeLocation,
       ],
       options: {
         env: {
@@ -43,6 +47,8 @@ export function activate(context: vscode.ExtensionContext) {
         logFile,
         '--logVerbosity',
         'verbose',
+        '--pluginProbeLocation',
+        pluginProbeLocation,
       ],
       options: {
         env: {

--- a/server/package.json
+++ b/server/package.json
@@ -9,6 +9,7 @@
     "node": "*"
   },
   "dependencies": {
+    "@angular/language-service": "^9.0.0-next.7",
     "vscode-languageserver": "~5.2.1",
     "vscode-uri": "^2.0.3"
   }

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -23,12 +23,13 @@ enum LanguageId {
 // Parse startup options
 const options = new Map<string, string>();
 for (let i = 0; i < process.argv.length; ++i) {
-  const argv = process.argv[i];
-  if (argv === '--logFile') {
+  const arg = process.argv[i];
+  if (arg === '--logFile') {
     options.set('logFile', process.argv[i + 1]);
-  }
-  if (argv === '--logVerbosity') {
+  } else if (arg === '--logVerbosity') {
     options.set('logVerbosity', process.argv[i + 1]);
+  } else if (arg === '--pluginProbeLocation') {
+    options.set('pluginProbeLocation', process.argv[i + 1]);
   }
 }
 

--- a/server/src/tests/version_provider_spec.ts
+++ b/server/src/tests/version_provider_spec.ts
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {NgVersionProvider} from '../version_provider';
+
+describe('NgVersionProvider', () => {
+  const probeLocation = __dirname;
+
+  it('should find bundled version', () => {
+    const provider = new NgVersionProvider(probeLocation);
+    const bundledVersion = provider.bundledVersion;
+    expect(bundledVersion).toBeDefined();
+    const {dirName, version} = bundledVersion!;
+    expect(dirName).toMatch(/@angular\/language-service$/);
+    expect(version).toBeTruthy();
+  });
+
+  it('should not find local version', () => {
+    const provider = new NgVersionProvider(probeLocation);
+    const localVersion = provider.localVersion;
+    // Don't expect to find `@angular/language-service` in current directory.
+    expect(localVersion).toBeUndefined();
+  });
+});

--- a/server/src/version_provider.ts
+++ b/server/src/version_provider.ts
@@ -1,0 +1,68 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as path from 'path';
+
+/**
+ * Represents a valid directory where `@angular/language-service` could be
+ * found, as well as its version.
+ */
+interface NgVersion {
+  dirName: string;
+  version?: string;
+}
+
+const NGLANGSVC = `@angular/language-service/package.json`;
+
+export class NgVersionProvider {
+  constructor(private readonly probeLocation?: string) {}
+
+  /**
+   * Return the version that is found via the probe location, if provided.
+   */
+  get bundledVersion(): NgVersion|undefined {
+    if (!this.probeLocation) {
+      return;
+    }
+    return this.resolve(this.probeLocation);
+  }
+
+  /**
+   * Return the version that is found via current directory, if any.
+   */
+  get localVersion(): NgVersion|undefined {
+    return this.resolve(process.cwd());
+  }
+
+  private resolve(dirName: string): NgVersion|undefined {
+    // Here, use native NodeJS require instead of ServerHost.require because
+    // we want the full path of the resolution provided by native
+    // `require.resolve()`, which ServerHost does not provide.
+    let result: NgVersion|undefined;
+    try {
+      // require.resolve() throws if module resolution fails.
+      const resolutionPath = require.resolve(NGLANGSVC, {
+        paths: [dirName],
+      });
+      if (!resolutionPath) {
+        return;
+      }
+      result = {
+        dirName: path.dirname(resolutionPath),
+        version: undefined,
+      };
+      // require would throw if package.json is not strict JSON
+      const packageJson = require(resolutionPath);
+      if (packageJson && packageJson.version) {
+        result.version = packageJson.version;
+      }
+    } finally {
+      return result;
+    }
+  }
+}

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@angular/language-service@^9.0.0-next.7":
+  version "9.0.0-next.7"
+  resolved "https://registry.yarnpkg.com/@angular/language-service/-/language-service-9.0.0-next.7.tgz#101820e30d7f16f9ca68004aa5c9fed5b8d66a1c"
+  integrity sha512-tw/zJBxJJjKWoDoF/Bm7HZGP9IQppf7Ettajhn+JSbbVh+IN1vh3eA9HPkSt4mQotdHUxdMHZ1ZV1E7W5XqgTA==
+
 vscode-jsonrpc@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-4.0.0.tgz#a7bf74ef3254d0a0c272fab15c82128e378b3be9"


### PR DESCRIPTION
The initial idea of the new extension is to always load
`@angular/language-service` from an Angular project that has the package
installed. That is why it does not bundle the package with the server.

However, `@angular/language-service` is not always available, due to a
few reasons:
1. The initial directory opened is not the root of an Angular project.
2. When spawned as pure LSP server, the process CWD is not where
@angular/langauge-service is installed.

Besides that, users have no control over which @angular/language-service
version they want the extension to use. (TypeScript extension provides
this feature).

It is also surprising to users that the extension does nothing if
@angular/language-service is not found.

For the reasons above, it is better that the server bundles a fallback
version of @angular/language-service, but still provides users with an
option to specify the location via `--pluginProbeLocation` cmd line
flag.

PR closes https://github.com/angular/vscode-ng-language-service/issues/369