### PR TITLE
feat: add Session class and refactor server.js

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -17,7 +17,14 @@ export function activate(context: vscode.ExtensionContext) {
   // Log file does not yet exist on disk. It is up to the server to create the
   // file.
   const logFile = path.join(context.logPath, 'nglangsvc.log');
-  const pluginProbeLocation = context.asAbsolutePath('server');
+  const ngProbeLocations = [
+    process.cwd(),                     // workspace version
+    context.asAbsolutePath('server'),  // bundled version
+  ];
+  const tsProbeLocations = [
+    process.cwd(),          // workspace version
+    context.extensionPath,  // bundled version
+  ];
 
   // If the extension is launched in debug mode then the debug server options are used
   // Otherwise the run options are used
@@ -29,8 +36,10 @@ export function activate(context: vscode.ExtensionContext) {
         '--logFile',
         logFile,
         // TODO: Might want to turn off logging completely.
-        '--pluginProbeLocation',
-        pluginProbeLocation,
+        '--ngProbeLocations',
+        ngProbeLocations.join(','),
+        '--tsProbeLocations',
+        tsProbeLocations.join(','),
       ],
       options: {
         env: {
@@ -47,8 +56,10 @@ export function activate(context: vscode.ExtensionContext) {
         logFile,
         '--logVerbosity',
         'verbose',
-        '--pluginProbeLocation',
-        pluginProbeLocation,
+        '--ngProbeLocations',
+        ngProbeLocations.join(','),
+        '--tsProbeLocations',
+        tsProbeLocations.join(','),
       ],
       options: {
         env: {

--- a/integration/lsp/smoke_spec.ts
+++ b/integration/lsp/smoke_spec.ts
@@ -8,6 +8,7 @@ class ResponseEmitter extends EventEmitter {}
 
 describe('Angular Language Service', () => {
   jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000; /* 10 seconds */
+  const PACKAGE_ROOT = resolve(__dirname, '../../..');
   const PROJECT_PATH = resolve(__dirname, '../../project');
   const SERVER_PATH = resolve(__dirname, '../../../server/out/server.js');
   const responseEmitter = new ResponseEmitter();
@@ -31,12 +32,21 @@ describe('Angular Language Service', () => {
   }
 
   beforeEach(() => {
-    server = fork(SERVER_PATH, ['--node-ipc'], {
-      cwd: PROJECT_PATH,
-      env: {
-        TSC_NONPOLLING_WATCHER: 'true',
-      },
-    });
+    server = fork(
+        SERVER_PATH,
+        [
+          '--node-ipc',
+          '--tsProbeLocations',
+          PACKAGE_ROOT,
+          '--ngProbeLocations',
+          PROJECT_PATH,
+        ],
+        {
+          cwd: PROJECT_PATH,
+          env: {
+            TSC_NONPOLLING_WATCHER: 'true',
+          },
+        });
     server.on('error', fail);
     server.on('close', (code, signal) => {
       console.log(`Server 'close' event received`, code, signal);

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "jasmine": "^3.4.0",
     "rollup": "^1.23.1",
     "rollup-plugin-commonjs": "^10.1.0",
-    "rollup-plugin-node-resolve": "^5.2.0",
     "tslint": "^5.19.0",
     "tslint-eslint-rules": "^5.4.0",
     "vsce": "^1.66.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,5 @@
 import * as fs from 'fs';
 import commonjs from 'rollup-plugin-commonjs';
-import nodeResolve from 'rollup-plugin-node-resolve';
 
 module.exports = [
   {
@@ -16,7 +15,6 @@ module.exports = [
       'vscode-languageclient',
     ],
     plugins: [
-      nodeResolve(),
       commonjs(),
     ],
   },
@@ -35,8 +33,12 @@ module.exports = [
       'vscode-uri',
     ],
     plugins: [
-      nodeResolve(),
-      commonjs(),
+      commonjs({
+        ignore: [
+          // leave require statements unconverted.
+          'conditional-runtime-dependency',
+        ],
+      }),
     ],
   },
 ];

--- a/server/package.json
+++ b/server/package.json
@@ -9,7 +9,7 @@
     "node": "*"
   },
   "dependencies": {
-    "@angular/language-service": "^9.0.0-next.7",
+    "@angular/language-service": "^9.0.0-next.9",
     "vscode-languageserver": "~5.2.1",
     "vscode-uri": "^2.0.3"
   }

--- a/server/src/banner.js
+++ b/server/src/banner.js
@@ -7,20 +7,17 @@ function define(modules, cb) {
     const arg = process.argv[index + 1];
     return arg.split(',');
   }
-  const TSSERVER = 'typescript/lib/tsserverlibrary';
-  let tsserverPath;
-  try {
-    tsserverPath = require.resolve(TSSERVER, {
-      paths: parseStringArray('--typeScriptProbeLocations'),
-    });
-  }
-  catch {}
-  const resolvedModules = modules.map(m => {
-    if (m === 'typescript') {
-      throw new Error(`'typescript' should never be used. Use '${TSSERVER}' instead.`)
+  function resolve(packageName, paths) {
+    try {
+      return require.resolve(packageName, {paths});
     }
-    if (tsserverPath && m === TSSERVER) {
-      return require(tsserverPath);
+    catch {}
+  }
+  const TSSERVER = 'typescript/lib/tsserverlibrary';
+  const resolvedModules = modules.map(m => {
+    if (m === TSSERVER || m === 'typescript') {
+      const tsProbeLocations = parseStringArray('--tsProbeLocations');
+      m = resolve(TSSERVER, tsProbeLocations) || TSSERVER;
     }
     return require(m);
   });

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -6,269 +6,84 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import * as ts from 'typescript/lib/tsserverlibrary';
-import * as lsp from 'vscode-languageserver';
-
-import {tsCompletionEntryToLspCompletionItem} from './completion';
 import {createLogger} from './logger';
-import {ProjectService} from './project_service';
 import {ServerHost} from './server_host';
-import {filePathToUri, lspPositionToTsPosition, lspRangeToTsPositions, tsTextSpanToLspRange, uriToFilePath} from './utils';
+import {Session} from './session';
+import {resolveWithMinMajor} from './version_provider';
 
-enum LanguageId {
-  TS = 'typescript',
-  HTML = 'html',
+// Parse command line arguments
+const help = hasArgument('--help');
+const logFile = findArgument('--logFile');
+const logVerbosity = findArgument('--logVerbosity');
+const ngProbeLocations = parseStringArray('--ngProbeLocations');
+const tsProbeLocations = parseStringArray('--tsProbeLocations');
+
+if (help) {
+  const {argv} = process;
+  console.error(`Angular Language Service that implements the Language Server Protocol (LSP).
+
+Usage: ${argv[0]} ${argv[1]} [options]
+
+Options:
+  --help: Prints help message.
+  --logFile: Location to log messages. Logging is disabled if not provided.
+  --logVerbosity: terse|normal|verbose|requestTime. See ts.server.LogLevel.
+  --ngProbeLocations: Path of @angular/language-service. Required.
+  --tsProbeLocations: Path of typescript. Required.
+
+Additional options supported by vscode-languageserver:
+  --node-ipc: Communicate using Node's IPC. This is the default.
+  --stdio: Communicate over stdin/stdout.
+  --socket=<number>: Communicate using Unix socket.
+`);
+  process.exit(0);
 }
 
-// Parse startup options
-const options = new Map<string, string>();
-for (let i = 0; i < process.argv.length; ++i) {
-  const arg = process.argv[i];
-  if (arg === '--logFile') {
-    options.set('logFile', process.argv[i + 1]);
-  } else if (arg === '--logVerbosity') {
-    options.set('logVerbosity', process.argv[i + 1]);
-  } else if (arg === '--pluginProbeLocation') {
-    options.set('pluginProbeLocation', process.argv[i + 1]);
-  }
-}
+// Create a logger that logs to file. OK to emit verbose entries.
+const logger = createLogger({logFile, logVerbosity});
 
-// Create a connection for the server. The connection uses Node's IPC as a transport
-const connection: lsp.IConnection = lsp.createConnection();
+const ts = resolveWithMinMajor('typescript', 3, tsProbeLocations);
+const ng = resolveWithMinMajor('@angular/language-service', 9, ngProbeLocations);
 
-// logger logs to file. OK to emit verbose entries.
-const logger = createLogger(options);
 // ServerHost provides native OS functionality
-const serverHost = new ServerHost();
-// Our ProjectService is just a thin wrapper around TS's ProjectService
-const projSvc = new ProjectService(serverHost, logger, connection, options);
-const {tsProjSvc} = projSvc;
+const host = new ServerHost();
 
-// Empty definition range for files without `scriptInfo`
-const EMPTY_RANGE = lsp.Range.create(0, 0, 0, 0);
+// Establish a new server session that encapsulates lsp connection.
+const session = new Session({
+  host,
+  logger,
+  ngProbeLocation: ng.resolvedPath,
+});
 
 // Log initialization info
-connection.console.info(`TypeScript version: ${ts.version}`);
-connection.console.info(`Log file: ${logger.getLogFileName()}`);
+session.info(`Using typescript v${ts.version} from ${ts.resolvedPath}`);
+session.info(`Using @angular/language-service v${ng.version} from ${ng.resolvedPath}`);
+session.info(`Log file: ${logger.getLogFileName()}`);
 if (process.env.NG_DEBUG) {
-  logger.info('Angular Language Service is under DEBUG mode');
+  session.info('Angular Language Service is running under DEBUG mode');
 }
 if (process.env.TSC_NONPOLLING_WATCHER !== 'true') {
-  connection.console.warn(
-      `Using less efficient polling watcher. Set TSC_NONPOLLING_WATCHER to true.`);
+  session.warn(`Using less efficient polling watcher. Set TSC_NONPOLLING_WATCHER to true.`);
 }
 
-// After the server has started the client sends an initilize request.
-connection.onInitialize((params: lsp.InitializeParams): lsp.InitializeResult => {
-  return {
-    capabilities: {
-      textDocumentSync: lsp.TextDocumentSyncKind.Incremental,
-      completionProvider: {
-        /// The server does not provide support to resolve additional information
-        // for a completion item.
-        resolveProvider: false,
-        triggerCharacters: ['<', '.', '*', '[', '(']
-      },
-      definitionProvider: true,
-      hoverProvider: true,
-    },
-  };
-});
+session.listen();
 
-connection.onDidOpenTextDocument((params: lsp.DidOpenTextDocumentParams) => {
-  const {uri, text, languageId} = params.textDocument;
-  const filePath = uriToFilePath(uri);
-  if (!filePath) {
-    return;
-  }
+function hasArgument(argName: string): boolean {
+  return process.argv.includes(argName);
+}
 
-  const scriptKind = languageId === LanguageId.TS ? ts.ScriptKind.TS : ts.ScriptKind.External;
-  const result = tsProjSvc.openClientFile(filePath, text, scriptKind);
+function findArgument(argName: string): string|undefined {
+  const index = process.argv.indexOf(argName);
+  if (index < 0 || index === process.argv.length - 1) {
+    return;
+  }
+  return process.argv[index + 1];
+}
 
-  const {configFileName, configFileErrors} = result;
-  if (configFileErrors && configFileErrors.length) {
-    connection.console.error(configFileErrors.map(e => e.messageText).join('\n'));
+function parseStringArray(argName: string): string[] {
+  const arg = findArgument(argName);
+  if (!arg) {
+    return [];
   }
-  if (!configFileName) {
-    // TODO: This could happen if the first file opened is HTML. Fix this.
-    connection.console.error(`No config file for ${filePath}`);
-    return;
-  }
-  const project = tsProjSvc.findProject(configFileName);
-  if (!project) {
-    connection.console.error(`Failed to find project for ${filePath}`);
-    return;
-  }
-  project.markAsDirty();         // Must mark project as dirty to rebuild the program.
-  project.refreshDiagnostics();  // Show initial diagnostics
-});
-
-connection.onDidCloseTextDocument((params: lsp.DidCloseTextDocumentParams) => {
-  const {textDocument} = params;
-  const filePath = uriToFilePath(textDocument.uri);
-  if (!filePath) {
-    return;
-  }
-  tsProjSvc.closeClientFile(filePath);
-});
-
-connection.onDidChangeTextDocument((params: lsp.DidChangeTextDocumentParams) => {
-  const {contentChanges, textDocument} = params;
-  const filePath = uriToFilePath(textDocument.uri);
-  if (!filePath) {
-    return;
-  }
-  const scriptInfo = tsProjSvc.getScriptInfo(filePath);
-  if (!scriptInfo) {
-    connection.console.log(`Failed to get script info for ${filePath}`);
-    return;
-  }
-  for (const change of contentChanges) {
-    if (change.range) {
-      const [start, end] = lspRangeToTsPositions(scriptInfo, change.range);
-      scriptInfo.editContent(start, end, change.text);
-    }
-  }
-
-  const project = projSvc.getDefaultProjectForScriptInfo(scriptInfo);
-  if (!project) {
-    return;
-  }
-  project.refreshDiagnostics();
-});
-
-connection.onDidSaveTextDocument((params: lsp.DidSaveTextDocumentParams) => {
-  const {text, textDocument} = params;
-  const filePath = uriToFilePath(textDocument.uri);
-  const scriptInfo = tsProjSvc.getScriptInfo(filePath);
-  if (!scriptInfo) {
-    return;
-  }
-  if (text) {
-    scriptInfo.open(text);
-  } else {
-    scriptInfo.reloadFromFile();
-  }
-});
-
-connection.onDefinition((params: lsp.TextDocumentPositionParams) => {
-  const {position, textDocument} = params;
-  const filePath = uriToFilePath(textDocument.uri);
-  const scriptInfo = tsProjSvc.getScriptInfo(filePath);
-  if (!scriptInfo) {
-    connection.console.log(`Script info not found for ${filePath}`);
-    return;
-  }
-
-  const {fileName} = scriptInfo;
-  const project = projSvc.getDefaultProjectForScriptInfo(scriptInfo);
-  if (!project || !project.languageServiceEnabled) {
-    return;
-  }
-
-  const offset = lspPositionToTsPosition(scriptInfo, position);
-  const langSvc = project.getLanguageService();
-  const definition = langSvc.getDefinitionAndBoundSpan(fileName, offset);
-  if (!definition || !definition.definitions) {
-    return;
-  }
-  const originSelectionRange = tsTextSpanToLspRange(scriptInfo, definition.textSpan);
-  const results: lsp.LocationLink[] = [];
-  for (const d of definition.definitions) {
-    const scriptInfo = tsProjSvc.getScriptInfo(d.fileName);
-
-    // Some definitions, like definitions of CSS files, may not be recorded files with a
-    // `scriptInfo` but are still valid definitions because they are files that exist. In this case,
-    // check to make sure that the text span of the definition is zero so that the file doesn't have
-    // to be read; if the span is non-zero, we can't do anything with this definition.
-    if (!scriptInfo && d.textSpan.length > 0) {
-      continue;
-    }
-    const range = scriptInfo ? tsTextSpanToLspRange(scriptInfo, d.textSpan) : EMPTY_RANGE;
-
-    const targetUri = filePathToUri(d.fileName);
-    results.push({
-      originSelectionRange,
-      targetUri,
-      targetRange: range,
-      targetSelectionRange: range,
-    });
-  }
-  return results;
-});
-
-connection.onHover((params: lsp.TextDocumentPositionParams) => {
-  const {position, textDocument} = params;
-  const filePath = uriToFilePath(textDocument.uri);
-  if (!filePath) {
-    return;
-  }
-  const scriptInfo = tsProjSvc.getScriptInfo(filePath);
-  if (!scriptInfo) {
-    return;
-  }
-  const {fileName} = scriptInfo;
-  const project = tsProjSvc.getDefaultProjectForFile(fileName, true /* ensureProject */);
-  if (!project || !project.languageServiceEnabled) {
-    return;
-  }
-  const offset = lspPositionToTsPosition(scriptInfo, position);
-  const langSvc = project.getLanguageService();
-  const info = langSvc.getQuickInfoAtPosition(fileName, offset);
-  if (!info) {
-    return;
-  }
-  const {kind, kindModifiers, textSpan, displayParts, documentation} = info;
-  let desc = kindModifiers ? kindModifiers + ' ' : '';
-  if (displayParts) {
-    // displayParts does not contain info about kindModifiers
-    // but displayParts does contain info about kind
-    desc += displayParts.map(dp => dp.text).join('');
-  } else {
-    desc += kind;
-  }
-  const contents: lsp.MarkedString[] = [{
-    language: 'typescript',
-    value: desc,
-  }];
-  if (documentation) {
-    for (const d of documentation) {
-      contents.push(d.text);
-    }
-  }
-  return {
-    contents,
-    range: tsTextSpanToLspRange(scriptInfo, textSpan),
-  };
-});
-
-// This handler provides the initial list of the completion items.
-connection.onCompletion((params: lsp.CompletionParams) => {
-  const {position, textDocument} = params;
-  const filePath = uriToFilePath(textDocument.uri);
-  if (!filePath) {
-    return;
-  }
-  const scriptInfo = tsProjSvc.getScriptInfo(filePath);
-  if (!scriptInfo) {
-    return;
-  }
-  const {fileName} = scriptInfo;
-  const project = projSvc.getDefaultProjectForScriptInfo(scriptInfo);
-  if (!project || !project.languageServiceEnabled) {
-    return;
-  }
-  const offset = lspPositionToTsPosition(scriptInfo, position);
-  const langSvc = project.getLanguageService();
-  const completions = langSvc.getCompletionsAtPosition(
-      fileName, offset,
-      {
-          // options
-      });
-  if (!completions) {
-    return;
-  }
-  return completions.entries.map((e) => tsCompletionEntryToLspCompletionItem(e, position));
-});
-
-connection.listen();
+  return arg.split(',');
+}

--- a/server/src/session.ts
+++ b/server/src/session.ts
@@ -1,0 +1,374 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as ts from 'typescript/lib/tsserverlibrary';
+import * as lsp from 'vscode-languageserver';
+
+import {tsCompletionEntryToLspCompletionItem} from './completion';
+import {tsDiagnosticToLspDiagnostic} from './diagnostic';
+import {Logger} from './logger';
+import {ProjectService} from './project_service';
+import {projectLoadingNotification} from './protocol';
+import {ServerHost} from './server_host';
+import {filePathToUri, lspPositionToTsPosition, lspRangeToTsPositions, tsTextSpanToLspRange, uriToFilePath} from './utils';
+
+export interface SessionOptions {
+  host: ServerHost;
+  logger: Logger;
+  ngProbeLocation: string;
+}
+
+enum LanguageId {
+  TS = 'typescript',
+  HTML = 'html',
+}
+
+// Empty definition range for files without `scriptInfo`
+const EMPTY_RANGE = lsp.Range.create(0, 0, 0, 0);
+
+/**
+ * Session is a wrapper around lsp.IConnection, with all the necessary protocol
+ * handlers installed for Angular language service.
+ */
+export class Session {
+  private readonly connection: lsp.IConnection;
+  private readonly projectService: ProjectService;
+
+  constructor(options: SessionOptions) {
+    // Create a connection for the server. The connection uses Node's IPC as a transport.
+    this.connection = lsp.createConnection();
+    this.addProtocolHandlers(this.connection);
+    this.projectService = new ProjectService({
+      host: options.host,
+      logger: options.logger,
+      cancellationToken: ts.server.nullCancellationToken,
+      useSingleInferredProject: true,
+      useInferredProjectPerProjectRoot: true,
+      typingsInstaller: ts.server.nullTypingsInstaller,
+      suppressDiagnosticEvents: false,
+      eventHandler: (e) => this.handleProjectServiceEvent(e),
+      globalPlugins: ['@angular/language-service'],
+      pluginProbeLocations: [options.ngProbeLocation],
+      allowLocalPluginLoads: false,  // do not load plugins from tsconfig.json
+    });
+  }
+
+  private addProtocolHandlers(conn: lsp.IConnection) {
+    conn.onInitialize(p => this.onInitialize(p));
+    conn.onDidOpenTextDocument(p => this.onDidOpenTextDocument(p));
+    conn.onDidCloseTextDocument(p => this.onDidCloseTextDocument(p));
+    conn.onDidChangeTextDocument(p => this.onDidChangeTextDocument(p));
+    conn.onDidSaveTextDocument(p => this.onDidSaveTextDocument(p));
+    conn.onDefinition(p => this.onDefinition(p));
+    conn.onHover(p => this.onHover(p));
+    conn.onCompletion(p => this.onCompletion(p));
+  }
+
+  /**
+   * An event handler that gets invoked whenever the program changes and
+   * TS ProjectService sends `ProjectUpdatedInBackgroundEvent`. This particular
+   * event is used to trigger diagnostic checks.
+   * @param event
+   */
+  private handleProjectServiceEvent(event: ts.server.ProjectServiceEvent) {
+    switch (event.eventName) {
+      case ts.server.ProjectLoadingStartEvent:
+        this.connection.sendNotification(
+            projectLoadingNotification.start, event.data.project.projectName);
+        break;
+      case ts.server.ProjectLoadingFinishEvent:
+        this.connection.sendNotification(
+            projectLoadingNotification.finish, event.data.project.projectName);
+        break;
+      case ts.server.ProjectsUpdatedInBackgroundEvent:
+        // ProjectsUpdatedInBackgroundEvent is sent whenever diagnostics are
+        // requested via project.refreshDiagnostics()
+        this.refreshDiagnostics(event.data.openFiles);
+        break;
+    }
+  }
+
+  /**
+   * Retrieve Angular diagnostics for the specified `openFiles`.
+   * @param openFiles
+   */
+  private refreshDiagnostics(openFiles: string[]) {
+    for (const fileName of openFiles) {
+      const scriptInfo = this.projectService.getScriptInfo(fileName);
+      if (!scriptInfo) {
+        continue;
+      }
+      const project = this.projectService.getDefaultProjectForScriptInfo(scriptInfo);
+      if (!project || !project.languageServiceEnabled) {
+        continue;
+      }
+      const ngLS = project.getLanguageService();
+      const diagnostics = ngLS.getSemanticDiagnostics(fileName);
+      // Need to send diagnostics even if it's empty otherwise editor state will
+      // not be updated.
+      this.connection.sendDiagnostics({
+        uri: filePathToUri(fileName),
+        diagnostics: diagnostics.map(d => tsDiagnosticToLspDiagnostic(d, scriptInfo)),
+      });
+    }
+  }
+
+  private onInitialize(params: lsp.InitializeParams): lsp.InitializeResult {
+    return {
+      capabilities: {
+        textDocumentSync: lsp.TextDocumentSyncKind.Incremental,
+        completionProvider: {
+          /// The server does not provide support to resolve additional information
+          // for a completion item.
+          resolveProvider: false,
+          triggerCharacters: ['<', '.', '*', '[', '(']
+        },
+        definitionProvider: true,
+        hoverProvider: true,
+      },
+    };
+  }
+
+  private onDidOpenTextDocument(params: lsp.DidOpenTextDocumentParams) {
+    const {uri, text, languageId} = params.textDocument;
+    const filePath = uriToFilePath(uri);
+    if (!filePath) {
+      return;
+    }
+
+    const scriptKind = languageId === LanguageId.TS ? ts.ScriptKind.TS : ts.ScriptKind.External;
+    const result = this.projectService.openClientFile(filePath, text, scriptKind);
+
+    const {configFileName, configFileErrors} = result;
+    if (configFileErrors) {
+      this.connection.console.error(configFileErrors.map(e => e.messageText).join('\n'));
+    }
+    if (!configFileName) {
+      // TODO: This could happen if the first file opened is HTML. Fix this.
+      this.connection.console.error(`No config file for ${filePath}`);
+      return;
+    }
+    const project = this.projectService.findProject(configFileName);
+    if (!project) {
+      this.connection.console.error(`Failed to find project for ${filePath}`);
+      return;
+    }
+    project.markAsDirty();         // Must mark project as dirty to rebuild the program.
+    project.refreshDiagnostics();  // Show initial diagnostics
+  }
+
+  private onDidCloseTextDocument(params: lsp.DidCloseTextDocumentParams) {
+    const {textDocument} = params;
+    const filePath = uriToFilePath(textDocument.uri);
+    if (!filePath) {
+      return;
+    }
+    this.projectService.closeClientFile(filePath);
+  }
+
+  private onDidChangeTextDocument(params: lsp.DidChangeTextDocumentParams) {
+    const {contentChanges, textDocument} = params;
+    const filePath = uriToFilePath(textDocument.uri);
+    if (!filePath) {
+      return;
+    }
+    const scriptInfo = this.projectService.getScriptInfo(filePath);
+    if (!scriptInfo) {
+      this.connection.console.log(`Failed to get script info for ${filePath}`);
+      return;
+    }
+    for (const change of contentChanges) {
+      if (change.range) {
+        const [start, end] = lspRangeToTsPositions(scriptInfo, change.range);
+        scriptInfo.editContent(start, end, change.text);
+      }
+    }
+
+    const project = this.projectService.getDefaultProjectForScriptInfo(scriptInfo);
+    if (!project) {
+      return;
+    }
+    project.refreshDiagnostics();
+  }
+
+  private onDidSaveTextDocument(params: lsp.DidSaveTextDocumentParams) {
+    const {text, textDocument} = params;
+    const filePath = uriToFilePath(textDocument.uri);
+    const scriptInfo = this.projectService.getScriptInfo(filePath);
+    if (!scriptInfo) {
+      return;
+    }
+    if (text) {
+      scriptInfo.open(text);
+    } else {
+      scriptInfo.reloadFromFile();
+    }
+  }
+
+  private onDefinition(params: lsp.TextDocumentPositionParams) {
+    const {position, textDocument} = params;
+    const filePath = uriToFilePath(textDocument.uri);
+    const scriptInfo = this.projectService.getScriptInfo(filePath);
+    if (!scriptInfo) {
+      this.connection.console.log(`Script info not found for ${filePath}`);
+      return;
+    }
+
+    const {fileName} = scriptInfo;
+    const project = this.projectService.getDefaultProjectForScriptInfo(scriptInfo);
+    if (!project || !project.languageServiceEnabled) {
+      return;
+    }
+
+    const offset = lspPositionToTsPosition(scriptInfo, position);
+    const langSvc = project.getLanguageService();
+    const definition = langSvc.getDefinitionAndBoundSpan(fileName, offset);
+    if (!definition || !definition.definitions) {
+      return;
+    }
+    const originSelectionRange = tsTextSpanToLspRange(scriptInfo, definition.textSpan);
+    const results: lsp.LocationLink[] = [];
+    for (const d of definition.definitions) {
+      const scriptInfo = this.projectService.getScriptInfo(d.fileName);
+
+      // Some definitions, like definitions of CSS files, may not be recorded files with a
+      // `scriptInfo` but are still valid definitions because they are files that exist. In this
+      // case, check to make sure that the text span of the definition is zero so that the file
+      // doesn't have to be read; if the span is non-zero, we can't do anything with this
+      // definition.
+      if (!scriptInfo && d.textSpan.length > 0) {
+        continue;
+      }
+      const range = scriptInfo ? tsTextSpanToLspRange(scriptInfo, d.textSpan) : EMPTY_RANGE;
+
+      const targetUri = filePathToUri(d.fileName);
+      results.push({
+        originSelectionRange,
+        targetUri,
+        targetRange: range,
+        targetSelectionRange: range,
+      });
+    }
+    return results;
+  }
+
+  private onHover(params: lsp.TextDocumentPositionParams) {
+    const {position, textDocument} = params;
+    const filePath = uriToFilePath(textDocument.uri);
+    if (!filePath) {
+      return;
+    }
+    const scriptInfo = this.projectService.getScriptInfo(filePath);
+    if (!scriptInfo) {
+      return;
+    }
+    const project = this.projectService.getDefaultProjectForScriptInfo(scriptInfo);
+    if (!project || !project.languageServiceEnabled) {
+      return;
+    }
+    const offset = lspPositionToTsPosition(scriptInfo, position);
+    const langSvc = project.getLanguageService();
+    const info = langSvc.getQuickInfoAtPosition(scriptInfo.fileName, offset);
+    if (!info) {
+      return;
+    }
+    const {kind, kindModifiers, textSpan, displayParts, documentation} = info;
+    let desc = kindModifiers ? kindModifiers + ' ' : '';
+    if (displayParts) {
+      // displayParts does not contain info about kindModifiers
+      // but displayParts does contain info about kind
+      desc += displayParts.map(dp => dp.text).join('');
+    } else {
+      desc += kind;
+    }
+    const contents: lsp.MarkedString[] = [{
+      language: 'typescript',
+      value: desc,
+    }];
+    if (documentation) {
+      for (const d of documentation) {
+        contents.push(d.text);
+      }
+    }
+    return {
+      contents,
+      range: tsTextSpanToLspRange(scriptInfo, textSpan),
+    };
+  }
+
+  private onCompletion(params: lsp.CompletionParams) {
+    const {position, textDocument} = params;
+    const filePath = uriToFilePath(textDocument.uri);
+    if (!filePath) {
+      return;
+    }
+    const scriptInfo = this.projectService.getScriptInfo(filePath);
+    if (!scriptInfo) {
+      return;
+    }
+    const {fileName} = scriptInfo;
+    const project = this.projectService.getDefaultProjectForScriptInfo(scriptInfo);
+    if (!project || !project.languageServiceEnabled) {
+      return;
+    }
+    const offset = lspPositionToTsPosition(scriptInfo, position);
+    const langSvc = project.getLanguageService();
+    const completions = langSvc.getCompletionsAtPosition(
+        fileName, offset,
+        {
+            // options
+        });
+    if (!completions) {
+      return;
+    }
+    return completions.entries.map((e) => tsCompletionEntryToLspCompletionItem(e, position));
+  }
+
+  /**
+   * Show an error message.
+   *
+   * @param message The message to show.
+   */
+  error(message: string): void {
+    this.connection.console.error(message);
+  }
+
+  /**
+   * Show a warning message.
+   *
+   * @param message The message to show.
+   */
+  warn(message: string): void {
+    this.connection.console.warn(message);
+  }
+
+  /**
+   * Show an information message.
+   *
+   * @param message The message to show.
+   */
+  info(message: string): void {
+    this.connection.console.info(message);
+  }
+
+  /**
+   * Log a message.
+   *
+   * @param message The message to log.
+   */
+  log(message: string): void {
+    this.connection.console.log(message);
+  }
+
+  /**
+   * Start listening on the input stream for messages to process.
+   */
+  listen() {
+    this.connection.listen();
+  }
+}

--- a/server/src/tests/version_provider_spec.ts
+++ b/server/src/tests/version_provider_spec.ts
@@ -6,24 +6,23 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {NgVersionProvider} from '../version_provider';
+import {resolveWithMinMajor} from '../version_provider';
 
-describe('NgVersionProvider', () => {
-  const probeLocation = __dirname;
+describe('resolveWithMinMajor', () => {
+  const probeLocations = [__dirname];
 
-  it('should find bundled version', () => {
-    const provider = new NgVersionProvider(probeLocation);
-    const bundledVersion = provider.bundledVersion;
-    expect(bundledVersion).toBeDefined();
-    const {dirName, version} = bundledVersion!;
-    expect(dirName).toMatch(/@angular\/language-service$/);
-    expect(version).toBeTruthy();
+  it('should find typescript >= v2', () => {
+    const result = resolveWithMinMajor('typescript', 2, probeLocations);
+    expect(result.version).toBe('3.5.3');
   });
 
-  it('should not find local version', () => {
-    const provider = new NgVersionProvider(probeLocation);
-    const localVersion = provider.localVersion;
-    // Don't expect to find `@angular/language-service` in current directory.
-    expect(localVersion).toBeUndefined();
+  it('should find typescript v3', () => {
+    const result = resolveWithMinMajor('typescript', 3, probeLocations);
+    expect(result.version).toBe('3.5.3');
+  });
+
+  it('should fail to find typescript v4', () => {
+    expect(() => resolveWithMinMajor('typescript', 4, probeLocations))
+        .toThrowError(/^Failed to resolve 'typescript'/);
   });
 });

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@angular/language-service@^9.0.0-next.7":
-  version "9.0.0-next.7"
-  resolved "https://registry.yarnpkg.com/@angular/language-service/-/language-service-9.0.0-next.7.tgz#101820e30d7f16f9ca68004aa5c9fed5b8d66a1c"
-  integrity sha512-tw/zJBxJJjKWoDoF/Bm7HZGP9IQppf7Ettajhn+JSbbVh+IN1vh3eA9HPkSt4mQotdHUxdMHZ1ZV1E7W5XqgTA==
+"@angular/language-service@^9.0.0-next.9":
+  version "9.0.0-next.9"
+  resolved "https://registry.yarnpkg.com/@angular/language-service/-/language-service-9.0.0-next.9.tgz#ce83b96f4459f9767feae63f2ad26a2ecc10c911"
+  integrity sha512-l8+oh0/Gvnr4lhOseIVixNdZrOKezlUfCvA4H+9xzGnXJM5+SvagPt1aC3NVeA5x2H044WrOmIg6Up1/DXbNIg==
 
 vscode-jsonrpc@^4.0.0:
   version "4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -38,13 +38,6 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.14.15.tgz#e8f7729b631be1b02ae130ff0b61f3e018000640"
   integrity sha512-CBR5avlLcu0YCILJiDIXeU2pTw7UK/NIxfC63m7d7CVamho1qDEzXKkOtEauQRPMy6MI8mLozth+JJkas7HY6g==
 
-"@types/resolve@0.0.8":
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-0.0.8.tgz#f26074d238e02659e323ce1a13d041eee280e194"
-  integrity sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==
-  dependencies:
-    "@types/node" "*"
-
 acorn@^7.1.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.1.0.tgz#949d36f2c292535da602283586c2477c57eb2d6c"
@@ -167,11 +160,6 @@ builtin-modules@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
   integrity sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=
-
-builtin-modules@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-3.1.0.tgz#aad97c15131eb76b65b50ef208e7584cd76a7484"
-  integrity sha512-k0KL0aWZuBt2lrxrcASWDfwOLMnodeQjodT/1SxEQAXsHANgo6ZC/VEaSEHCXt7aSTZ4/4H5LKa+tBXmW7Vtvw==
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -575,11 +563,6 @@ inherits@2, inherits@^2.0.1, inherits@^2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
-is-module@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-module/-/is-module-1.0.0.tgz#3258fb69f78c14d5b815d664336b4cffb6441591"
-  integrity sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=
-
 is-reference@^1.1.2:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/is-reference/-/is-reference-1.1.4.tgz#3f95849886ddb70256a3e6d062b1a68c13c51427"
@@ -909,7 +892,7 @@ requires-port@^1.0.0:
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
 
-resolve@^1.1.6, resolve@^1.11.0, resolve@^1.11.1, resolve@^1.3.2:
+resolve@^1.1.6, resolve@^1.11.0, resolve@^1.3.2:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.12.0.tgz#3fc644a35c84a48554609ff26ec52b66fa577df6"
   integrity sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==
@@ -925,17 +908,6 @@ rollup-plugin-commonjs@^10.1.0:
     is-reference "^1.1.2"
     magic-string "^0.25.2"
     resolve "^1.11.0"
-    rollup-pluginutils "^2.8.1"
-
-rollup-plugin-node-resolve@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-5.2.0.tgz#730f93d10ed202473b1fb54a5997a7db8c6d8523"
-  integrity sha512-jUlyaDXts7TW2CqQ4GaO5VJ4PwwaV8VUGA7+km3n6k6xtOEacf61u0VXwN80phY/evMcaS+9eIeJ9MOyDxt5Zw==
-  dependencies:
-    "@types/resolve" "0.0.8"
-    builtin-modules "^3.1.0"
-    is-module "^1.0.0"
-    resolve "^1.11.1"
     rollup-pluginutils "^2.8.1"
 
 rollup-pluginutils@^2.8.1:


### PR DESCRIPTION
This PR moves most of the code in server.js to a standalone module named
Session, which provides an encapsulation of LSP connection. Since
server.js is a script and not a module, it should not contain too much
code.

Improved command line parsing and added help menu.

