### PR TITLE
test: fail fast on travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ install:
   - ./scripts/install.sh
 
 script:
+  - set -euxo pipefail
   - ./scripts/lint.sh
   - ./scripts/build.sh
   - ./scripts/test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
   - ./scripts/install.sh
 
 script:
-  - set -euxo pipefail
+  - set -exo pipefail
   - ./scripts/lint.sh
   - ./scripts/build.sh
   - ./scripts/test.sh


### PR DESCRIPTION
As per https://github.com/travis-ci/travis-ci/issues/1066, Travis CI
only reports a failed test if the last command in the test script fails.
If anything but the last line in our script fails, the build won't
actually be detected as failing. The alternative is to set the script to
fail fast with `set -e`.