### PR TITLE
fix: use non-rollup bundle in development

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -49,7 +49,7 @@ export function activate(context: vscode.ExtensionContext) {
       },
     },
     debug: {
-      module: context.asAbsolutePath(path.join('dist', 'server')),
+      module: context.asAbsolutePath(path.join('server', 'out', 'server.js')),
       transport: lsp.TransportKind.ipc,
       args: [
         '--logFile',

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "compile:test": "tsc -b server/src/tests",
     "compile:integration": "tsc -b integration",
     "format": "scripts/format.sh",
-    "watch": "tsc -b -w & rollup -c -w",
+    "watch": "tsc -b -w",
     "postinstall": "vscode-install && cd client && yarn && cd ../server && yarn && cd ..",
     "package": "rm -rf dist && node scripts/package.js",
     "test": "yarn compile:test && jasmine server/out/tests/*_spec.js",


### PR DESCRIPTION
Rollup bundle does not work in development for a few reasons:

1. Watch mode in vscode has to wait for tsc then rollup to finish.
   This might be possible by setting up one task to "dependsOn" another
   task, but don't bother with this for now.
   See https://code.visualstudio.com/docs/editor/tasks#_compound-tasks
2. Sourcemaps have to be enabled in rollup, otherwise breakpoints in TS
   code would not work.

Besides, running rollup is relatively slow, and thus hinders development
velocity.

Removing rollup from the development workflow has no impact on
correctness, so it's safe to omit this step.

Revisit this some other time if necessary.