### PR TITLE
feat: Make @angular/language-server public

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -1,12 +1,11 @@
 {
-  "name": "ng-template-server",
-  "description": "Angular Language Service server",
+  "name": "@angular/language-server",
+  "description": "LSP server for Angular Language Service",
   "version": "0.900.0-next.0",
-  "private": true,
   "author": "Angular",
   "license": "MIT",
   "engines": {
-    "node": "*"
+    "node": ">=10.9.0 <13.0.0"
   },
   "dependencies": {
     "@angular/language-service": "^9.0.0-next.10",


### PR DESCRIPTION
Make @angular/language-server the official public npm package for LSP.

PR closes https://github.com/angular/vscode-ng-language-service/issues/377