### PR TITLE
feat: Allow users to set @angular/language-service from vscode

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,17 @@
         "title": "Restart Angular Language server",
         "category": "Angular"
       }
-    ]
+    ],
+    "configuration": {
+      "title": "Angular Language Service",
+      "properties": {
+        "angular.ngdk": {
+          "type": ["string", "null"],
+          "default": null,
+          "description": "Specifies the folder path to @angular/language-service."
+        }
+      }
+    }
   },
   "activationEvents": [
     "onLanguage:html",


### PR DESCRIPTION
This PR allows users to change the version of typescript and
@angular/language-service used by the server from vscode.

Instead of using process.cwd() (which is a very bad idea), the extension
client should instead look for typescript and @angular/language-service
in the workspace folders.
If there's no workspace folder, fallback to the bundled version.

![Screenshot from 2019-10-10 17-06-23](https://user-images.githubusercontent.com/2941178/66615396-5d4ac300-eb81-11e9-9af3-6a49eda86397.png)
