### PR TITLE
build: upgrade to TypeScript 3.6.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ and external templates including:
 * Quick info
 * Go to definition
 
-This extension uses `typescript@3.5.x`.
+This extension uses `typescript@3.6.x`.
 
 **NOTE**: Please make sure `@angular/language-service` >= v9.0.0 is installed
 in your project otherwise the extension would not work.

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "test:e2e": "yarn compile:integration && ./scripts/e2e.sh"
   },
   "dependencies": {
-    "typescript": "~3.5.3"
+    "typescript": "~3.6.4"
   },
   "devDependencies": {
     "@types/jasmine": "^3.4.0",

--- a/server/src/tests/version_provider_spec.ts
+++ b/server/src/tests/version_provider_spec.ts
@@ -13,12 +13,12 @@ describe('resolveWithMinMajor', () => {
 
   it('should find typescript >= v2', () => {
     const result = resolveWithMinMajor('typescript', 2, probeLocations);
-    expect(result.version).toBe('3.5.3');
+    expect(result.version).toBe('3.6.4');
   });
 
   it('should find typescript v3', () => {
     const result = resolveWithMinMajor('typescript', 3, probeLocations);
-    expect(result.version).toBe('3.5.3');
+    expect(result.version).toBe('3.6.4');
   });
 
   it('should fail to find typescript v4', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1092,10 +1092,10 @@ typed-rest-client@1.2.0:
     tunnel "0.0.4"
     underscore "1.8.3"
 
-typescript@~3.5.3:
-  version "3.5.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
-  integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
+typescript@~3.6.4:
+  version "3.6.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.4.tgz#b18752bb3792bc1a0281335f7f6ebf1bbfc5b91d"
+  integrity sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==
 
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"


### PR DESCRIPTION
Now that https://github.com/angular/angular/pull/32946 has landed,
upgrade to ts 3.6.4.