### PR TITLE
feat: Allow users to set log verbosity in editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,17 @@
           "type": ["string", "null"],
           "default": null,
           "description": "Specifies the folder path to @angular/language-service."
+        },
+        "angular.log": {
+          "type": "string",
+          "enum": [
+            "off",
+            "terse",
+            "normal",
+            "verbose"
+          ],
+          "default": "terse",
+          "description": "Enables logging of the Angular server to a file. This log can be used to diagnose Angular Server issues. The log may contain file paths, source code, and other potentially sensitive information from your project."
         }
       }
     }


### PR DESCRIPTION
This commit adds a vscode config `angular.log` that mirrors
`typescript.tsserver.log` for setting log verbosity. This allows users
to turn on verbose logging for debugging / diagnostic purpose.

It would also help us gather much more info when users report errors.

The default value is set to `terse`, which is minimal logging.