### PR TITLE
fix: Retrieve diagnostics for changed document only

### DIFF
--- a/server/src/session.ts
+++ b/server/src/session.ts
@@ -220,7 +220,7 @@ export class Session {
     if (!project || !project.languageServiceEnabled) {
       return;
     }
-    project.refreshDiagnostics();
+    this.triggerDiagnostics([scriptInfo.fileName]);
   }
 
   private onDidSaveTextDocument(params: lsp.DidSaveTextDocumentParams) {


### PR DESCRIPTION
Currently, when a document is changed, we retrieve diagnostics for
**all** open files. This could be very slow when there are many open
files. Instead, retrieve diagnostics for that one file only.