### PR TITLE
fix: use replacementSpan for completion if provided

### DIFF
--- a/server/src/session.ts
+++ b/server/src/session.ts
@@ -353,7 +353,8 @@ export class Session {
     if (!completions) {
       return;
     }
-    return completions.entries.map((e) => tsCompletionEntryToLspCompletionItem(e, position));
+    return completions.entries.map(
+        (e) => tsCompletionEntryToLspCompletionItem(e, position, scriptInfo));
   }
 
   /**


### PR DESCRIPTION
The language service returns an optional replacement span, but the
information is not propagated to the editor.