### PR TITLE
test: use rollup bundle for e2e test

### DIFF
--- a/integration/lsp/smoke_spec.ts
+++ b/integration/lsp/smoke_spec.ts
@@ -10,7 +10,7 @@ describe('Angular Language Service', () => {
   jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000; /* 10 seconds */
   const PACKAGE_ROOT = resolve(__dirname, '../../..');
   const PROJECT_PATH = resolve(__dirname, '../../project');
-  const SERVER_PATH = resolve(__dirname, '../../../server/out/server.js');
+  const SERVER_PATH = resolve(__dirname, '../../../dist/server/index.js');
   const responseEmitter = new ResponseEmitter();
   let server: ChildProcess;
 


### PR DESCRIPTION
In dev mode, rollup is not used to bundle the code so that test execution is fast.
However, this means the actual bundle that is published to the marketplace is not
tested in any way. This commit changes the end-to-end test to exercise the
production bundle instead.