### PR TITLE
docs: add prereleae installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,15 @@ This extension uses `typescript@3.6.x`.
 ## Download
 
 Download the extension from [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=Angular.ng-template).
+
+
+## Installing a particular release build
+
+Download the `.vsix` file for the release that you want to install from the [releases](https://github.com/angular/vscode-ng-language-service/releases) tab.
+
+*Do not open the .vsix file directly*. Instead, in Visual Studio code, go to the extensions tab. Click on the "..." menu in the upper right corner of the extensions tab, select "Install from vsix..." and then select the .vsix file for the release you just downloaded.
+
+The extension can also be installed with the following command:
+```
+code --install-extension /path/to/ngls.vsix
+```


### PR DESCRIPTION
Just opening the .vsix file directly does not work. This commit
adds instructions on how to install a prerelease ,so that other users
don't run into the same issue as I did.

Fixes #450.