### PR TITLE
fix: newline missing in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,9 +7,11 @@ assignees: ''
 ---
 
 **Describe the bug**
+
 A clear and concise description of what the bug is.
 
 **To Reproduce**
+
 Steps to reproduce the behavior:
 1. Go to '...'
 2. Click on '....'
@@ -17,17 +19,22 @@ Steps to reproduce the behavior:
 4. See error
 
 **Expected behavior**
+
 A clear and concise description of what you expected to happen.
 
 **Logs**
+
 Please attach two logs:
+
 1. Console output (Go to toolbar --> View --> Output, and copy the contents)
 2. Log file (Path is printed to the console output at startup)
 
 **Screenshots**
+
 If applicable, add screenshots to help explain your problem.
 
 ![Example Screenshot](./output.png)
 
 **Additional context**
+
 Add any other context about the problem here.


### PR DESCRIPTION
Markdown file requires either two trailing spaces or a newline in order
for the sentence to appear in a newline. vscode automatically removed
trailing whitespace in the previous commit, which leads to bad formatting.