### PR TITLE
fix: remove incremental compilation caches across builds

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -6,6 +6,7 @@ set -ex -o pipefail
 rm -rf client/out
 rm -rf server/out
 rm -rf dist
+rm -rf **/*.tsbuildinfo
 
 # Build the client and server
 yarn run compile


### PR DESCRIPTION
Currently, consecutive builds of the extension will fail because
[TypeScript always saves](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-4.html#composite-projects)
incremental compilation information in a composite project like this
one. In particular, this means that even when the output directory of
the TS compilation is removed, TypeScript doesn't realize that the
output files are no longer there because it has cached the build graph,
and thus not all the expected files are present for copying to the
extension output directory.

This commit fixes the above issue by removing TypeScript's incremental
compilation build files before rebuilding the project.