### PR TITLE
test: add tests for inline template textmate grammar

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ script:
   - ./scripts/build.sh
   - ./scripts/test.sh
   - ./scripts/format.sh
+  - ./scripts/syntax.sh
 
 after_script:
   - ./scripts/cleanup.sh

--- a/package.json
+++ b/package.json
@@ -77,7 +77,8 @@
     "package": "rm -rf dist && node scripts/package.js",
     "test": "yarn compile:test && jasmine server/out/tests/*_spec.js",
     "test:lsp": "yarn compile:integration && jasmine integration/out/lsp/*_spec.js",
-    "test:e2e": "yarn compile:integration && ./scripts/e2e.sh"
+    "test:e2e": "yarn compile:integration && ./scripts/e2e.sh",
+    "test:syntax": "./scripts/syntax.sh"
   },
   "dependencies": {
     "typescript": "~3.6.4"
@@ -93,7 +94,8 @@
     "tslint-eslint-rules": "^5.4.0",
     "vsce": "^1.69.0",
     "vscode": "^1.1.36",
-    "vscode-jsonrpc": "^4.0.0"
+    "vscode-jsonrpc": "^4.0.0",
+    "vscode-tmgrammar-test": "^0.0.8"
   },
   "repository": {
     "type": "git",

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -7,7 +7,6 @@ find . -name "*.ts" \
   -not -path "*/project/*" \
   -not -path "*/node_modules/*" \
   -not -path "*/out/*" \
-  -not -path "*/syntaxes/test/*" \
   -exec yarn clang-format -i {} +
 
 if [[ ! -z "${CI_MODE}" ]]; then

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -7,6 +7,7 @@ find . -name "*.ts" \
   -not -path "*/project/*" \
   -not -path "*/node_modules/*" \
   -not -path "*/out/*" \
+  -not -path "*/syntaxes/test/*" \
   -exec yarn clang-format -i {} +
 
 if [[ ! -z "${CI_MODE}" ]]; then

--- a/scripts/syntax.sh
+++ b/scripts/syntax.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -ex -o pipefail
+
+DUMMY_GRAMMARS=$(find syntaxes/test -name '*-dummy.json' -exec echo "-g {}" \; | tr '\n' ' ')
+
+# Template syntax tests
+yarn vscode-tmgrammar-test \
+  -s template.ng \
+  -g syntaxes/template.ng.json $DUMMY_GRAMMARS \
+  -t "syntaxes/test/**/*.ts"

--- a/syntaxes/test/html.tmLanguage-dummy.json
+++ b/syntaxes/test/html.tmLanguage-dummy.json
@@ -1,0 +1,4 @@
+{
+  "comment": "Dummy HTML TextMate grammar for use in testing",
+  "scopeName": "text.html.basic"
+}

--- a/syntaxes/test/inline_template.ts
+++ b/syntaxes/test/inline_template.ts
@@ -1,4 +1,5 @@
 // SYNTAX TEST "template.ng"
+/* clang-format off */
 
 @Component({
 //// Property key/value test

--- a/syntaxes/test/inline_template.ts
+++ b/syntaxes/test/inline_template.ts
@@ -1,0 +1,29 @@
+// SYNTAX TEST "template.ng"
+
+@Component({
+//// Property key/value test
+  template: '<div></div>',
+//^^^^^^^^^                 meta.object-literal.key.ts
+//           ^^^^^^^^^^^    template.ng (fake grammar token)
+
+//// String delimiter tests
+  template: `<div></div>`,
+//          ^               string
+//                      ^   string
+  template: "<div></div>",
+//          ^               string
+//                      ^   string
+  template: '<div></div>',
+//          ^               string
+//                      ^   string
+
+//// Parenthesization tests
+  template: ( (( '<div></div>' )) ),
+//          ^                         meta.brace.round.ts
+//            ^^                      meta.brace.round.ts
+//               ^                    string
+//                           ^        string
+//                             ^^     meta.brace.round.ts
+//                                ^   meta.brace.round.ts
+})
+export class TMComponent{}

--- a/yarn.lock
+++ b/yarn.lock
@@ -225,6 +225,11 @@ commander@^2.12.1, commander@^2.8.1:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
   integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
 
+commander@^2.20.0:
+  version "2.20.3"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
+  integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -290,6 +295,11 @@ diff@3.5.0, diff@^3.2.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
   integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
+
+diff@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.1.tgz#0c667cb467ebbb5cea7f14f135cc2dba7780a8ff"
+  integrity sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==
 
 doctrine@0.7.2:
   version "0.7.2"
@@ -477,6 +487,18 @@ glob@^7.0.0, glob@^7.0.6, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3:
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.4.tgz#aa608a2f6c577ad357e1ae5a5c26d9a8d1969255"
   integrity sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^7.1.4:
+  version "7.1.6"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
+  integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -744,6 +766,11 @@ mute-stream@~0.0.4:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
+nan@^2.14.0:
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
+  integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
+
 nth-check@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-1.0.2.tgz#b2bd295c37e3dd58a3bf0700376663ba4d9cf05c"
@@ -762,6 +789,13 @@ once@^1.3.0:
   integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
   dependencies:
     wrappy "1"
+
+oniguruma@^7.2.0:
+  version "7.2.1"
+  resolved "https://registry.yarnpkg.com/oniguruma/-/oniguruma-7.2.1.tgz#51775834f7819b6e31aa878706aa7f65ad16b07f"
+  integrity sha512-WPS/e1uzhswPtJSe+Zls/kAj27+lEqZjCmRSjnYk/Z4L2Mu+lJC2JWtkZhPJe4kZeTQfz7ClcLyXlI4J68MG2w==
+  dependencies:
+    nan "^2.14.0"
 
 os-homedir@^1.0.0:
   version "1.0.2"
@@ -1184,6 +1218,24 @@ vscode-test@^0.4.1:
   dependencies:
     http-proxy-agent "^2.1.0"
     https-proxy-agent "^2.2.1"
+
+vscode-textmate@^4.1.1:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/vscode-textmate/-/vscode-textmate-4.4.0.tgz#14032afeb50152e8f53258c95643e555f2948305"
+  integrity sha512-dFpm2eK0HwEjeFSD1DDh3j0q47bDSVuZt20RiJWxGqjtm73Wu2jip3C2KaZI3dQx/fSeeXCr/uEN4LNaNj7Ytw==
+  dependencies:
+    oniguruma "^7.2.0"
+
+vscode-tmgrammar-test@^0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/vscode-tmgrammar-test/-/vscode-tmgrammar-test-0.0.8.tgz#e21e3c6d5f98b25cef64d6b313350ae93617c6d6"
+  integrity sha512-Ipa76MQrvU6yz699LiueHa4uHkXu4nxI5yueo9cHc+kggZXsKsOmAyVc8m4V8lyIz9KesZ7Nq9NPgh78AYXPrw==
+  dependencies:
+    chalk "^2.4.2"
+    commander "^2.20.0"
+    diff "^4.0.1"
+    glob "^7.1.4"
+    vscode-textmate "^4.1.1"
 
 vscode@^1.1.36:
   version "1.1.36"


### PR DESCRIPTION
Adds tests for the TypeScript inline Angular template grammar via the
[vscode-tmgrammar-test](https://github.com/PanAeon/vscode-tmgrammar-test) framework, which [now supports loading multiple grammars](https://github.com/PanAeon/vscode-tmgrammar-test/commit/e2c4e86cd0f365a106125f3df03208d90b11a72e)
as needed by this project.

A dummy HTML grammar is used for inline templates, as currently we are
only concerned with recognization of the inline template.