### PR TITLE
fix: reset loading status when the language service fails to load the project.

### DIFF
--- a/client/src/protocol.ts
+++ b/client/src/protocol.ts
@@ -6,9 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {NotificationType} from 'vscode-languageclient';
+import {NotificationType0} from 'vscode-languageclient';
 
 export const projectLoadingNotification = {
-  start: new NotificationType<string, string>('angular-language-service/projectLoadingStart'),
-  finish: new NotificationType<string, string>('angular-language-service/projectLoadingFinish')
+  start: new NotificationType0<string>('angular-language-service/projectLoadingStart'),
+  finish: new NotificationType0<string>('angular-language-service/projectLoadingFinish')
 };

--- a/integration/lsp/smoke_spec.ts
+++ b/integration/lsp/smoke_spec.ts
@@ -54,7 +54,9 @@ describe('Angular Language Service', () => {
     });
     server.on('message', (data: Message) => {
       if (isNotificationMessage(data)) {
-        console.log('[server]', data.params.message);
+        const toLog = ['[server]', data.method];
+        if (data.params && data.params.message) toLog.push(data.params.message);
+        console.log(...toLog);
       } else {
         responseEmitter.emit('response', data);
       }

--- a/server/src/protocol.ts
+++ b/server/src/protocol.ts
@@ -6,9 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {NotificationType} from 'vscode-languageserver';
+import {NotificationType0} from 'vscode-languageserver';
 
 export const projectLoadingNotification = {
-  start: new NotificationType<string, string>('angular-language-service/projectLoadingStart'),
-  finish: new NotificationType<string, string>('angular-language-service/projectLoadingFinish')
+  start: new NotificationType0<string>('angular-language-service/projectLoadingStart'),
+  finish: new NotificationType0<string>('angular-language-service/projectLoadingFinish')
 };


### PR DESCRIPTION
Currently, the loading indicator remains in pending state when the language service fails to load the project. Typescript project server doesn't send any event when the error occurs.
This commit refactors the loading indicator to reset state when any error occurs while opening the document.

PR closes #464