### PR TITLE
fix(syntaxes): do not syntax highlight commented template properties

### DIFF
--- a/scripts/syntax.sh
+++ b/scripts/syntax.sh
@@ -15,8 +15,5 @@ ARGS=$(cat<<ARGS
 ARGS
 )
 
-# Unit tests
-yarn vscode-tmgrammar-test $ARGS
-
 # Snapshot tests
 yarn vscode-tmgrammar-snap $ARGS "$@"

--- a/scripts/syntax.sh
+++ b/scripts/syntax.sh
@@ -2,7 +2,7 @@
 # Usage:
 #   scripts/syntax.sh [-u]
 #
-# Parameters
+# Arguments:
 #   -u update snapshot files
 
 set -ex -o pipefail

--- a/scripts/syntax.sh
+++ b/scripts/syntax.sh
@@ -3,9 +3,15 @@
 set -ex -o pipefail
 
 DUMMY_GRAMMARS=$(find syntaxes/test -name '*-dummy.json' -exec echo "-g {}" \; | tr '\n' ' ')
+ARGS=$(cat<<ARGS
+  -s template.ng 
+  -g syntaxes/template.ng.json $DUMMY_GRAMMARS 
+  -t syntaxes/test/**/*.ts
+ARGS
+)
 
-# Template syntax tests
-yarn vscode-tmgrammar-test \
-  -s template.ng \
-  -g syntaxes/template.ng.json $DUMMY_GRAMMARS \
-  -t "syntaxes/test/**/*.ts"
+# Unit tests
+yarn vscode-tmgrammar-test $ARGS
+
+# Snapshot tests
+yarn vscode-tmgrammar-snap $ARGS

--- a/scripts/syntax.sh
+++ b/scripts/syntax.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# Usage:
+#   scripts/syntax.sh [-u]
+#
+# Parameters
+#   -u update snapshot files
 
 set -ex -o pipefail
 
@@ -14,4 +19,4 @@ ARGS
 yarn vscode-tmgrammar-test $ARGS
 
 # Snapshot tests
-yarn vscode-tmgrammar-snap $ARGS
+yarn vscode-tmgrammar-snap $ARGS "$@"

--- a/syntaxes/template.ng.json
+++ b/syntaxes/template.ng.json
@@ -1,6 +1,6 @@
 {
   "scopeName": "template.ng",
-  "injectionSelector": "L:meta.decorator.ts",
+  "injectionSelector": "L:meta.decorator.ts -comment",
   "patterns": [
     {
       "include": "#ts-decorator"

--- a/syntaxes/test/inline_template.ts
+++ b/syntaxes/test/inline_template.ts
@@ -4,27 +4,22 @@
 @Component({
 //// Property key/value test
   template: '<div></div>',
-//^^^^^^^^^                 meta.object-literal.key.ts
-//           ^^^^^^^^^^^    template.ng (fake grammar token)
 
 //// String delimiter tests
   template: `<div></div>`,
-//          ^               string
-//                      ^   string
   template: "<div></div>",
-//          ^               string
-//                      ^   string
   template: '<div></div>',
-//          ^               string
-//                      ^   string
 
 //// Parenthesization tests
   template: ( (( '<div></div>' )) ),
-//          ^                         meta.brace.round.ts
-//            ^^                      meta.brace.round.ts
-//               ^                    string
-//                           ^        string
-//                             ^^     meta.brace.round.ts
-//                                ^   meta.brace.round.ts
+
+//// Comments tests
+  // template: '<div></div>'
+  /*
+   * template: '<div></div>'
+   */
+  /**
+   * template: '<div></div>'
+   */
 })
 export class TMComponent{}

--- a/syntaxes/test/inline_template.ts.snap
+++ b/syntaxes/test/inline_template.ts.snap
@@ -1,0 +1,98 @@
+>// SYNTAX TEST "template.ng"
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.ng
+>/* clang-format off */
+#^^^^^^^^^^^^^^^^^^^^^^^ template.ng
+>
+>@Component({
+#^^^^^^^^^^^^^ template.ng
+>//// Property key/value test
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.ng
+>  template: '<div></div>',
+#^^ template.ng
+#  ^^^^^^^^ template.ng meta.object-literal.key.ts
+#          ^ template.ng meta.object-literal.key.ts punctuation.separator.key-value.ts
+#           ^ template.ng
+#            ^ template.ng string
+#             ^^^^^^^^^^^ template.ng
+#                        ^ template.ng string
+#                         ^^ template.ng
+>
+>//// String delimiter tests
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.ng
+>  template: `<div></div>`,
+#^^ template.ng
+#  ^^^^^^^^ template.ng meta.object-literal.key.ts
+#          ^ template.ng meta.object-literal.key.ts punctuation.separator.key-value.ts
+#           ^ template.ng
+#            ^ template.ng string
+#             ^^^^^^^^^^^ template.ng
+#                        ^ template.ng string
+#                         ^^ template.ng
+>  template: "<div></div>",
+#^^ template.ng
+#  ^^^^^^^^ template.ng meta.object-literal.key.ts
+#          ^ template.ng meta.object-literal.key.ts punctuation.separator.key-value.ts
+#           ^ template.ng
+#            ^ template.ng string
+#             ^^^^^^^^^^^ template.ng
+#                        ^ template.ng string
+#                         ^^ template.ng
+>  template: '<div></div>',
+#^^ template.ng
+#  ^^^^^^^^ template.ng meta.object-literal.key.ts
+#          ^ template.ng meta.object-literal.key.ts punctuation.separator.key-value.ts
+#           ^ template.ng
+#            ^ template.ng string
+#             ^^^^^^^^^^^ template.ng
+#                        ^ template.ng string
+#                         ^^ template.ng
+>
+>//// Parenthesization tests
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.ng
+>  template: ( (( '<div></div>' )) ),
+#^^ template.ng
+#  ^^^^^^^^ template.ng meta.object-literal.key.ts
+#          ^ template.ng meta.object-literal.key.ts punctuation.separator.key-value.ts
+#           ^ template.ng
+#            ^ template.ng meta.brace.round.ts
+#             ^ template.ng
+#              ^ template.ng meta.brace.round.ts
+#               ^ template.ng meta.brace.round.ts
+#                ^ template.ng
+#                 ^ template.ng string
+#                  ^^^^^^^^^^^ template.ng
+#                             ^ template.ng string
+#                              ^ template.ng
+#                               ^ template.ng meta.brace.round.ts
+#                                ^ template.ng meta.brace.round.ts
+#                                 ^ template.ng
+#                                  ^ template.ng meta.brace.round.ts
+#                                   ^^ template.ng
+>
+>//// Comments tests
+#^^^^^^^^^^^^^^^^^^^^ template.ng
+>  // template: '<div></div>'
+#^^^^^ template.ng
+#     ^^^^^^^^ template.ng meta.object-literal.key.ts
+#             ^ template.ng meta.object-literal.key.ts punctuation.separator.key-value.ts
+#              ^ template.ng
+#               ^ template.ng string
+#                ^^^^^^^^^^^ template.ng
+#                           ^ template.ng string
+>  /*
+#^^^^^ template.ng
+>   * template: '<div></div>'
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.ng
+>   */
+#^^^^^^ template.ng
+>  /**
+#^^^^^^ template.ng
+>   * template: '<div></div>'
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.ng
+>   */
+#^^^^^^ template.ng
+>})
+#^^^ template.ng
+>export class TMComponent{}
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.ng
+>


### PR DESCRIPTION
Prevents syntax highlighting inline templates by excluding the grammar
injection on decorators with comments.

The grammar test framework does not currently support specifying grammar
rule exclusions (https://github.com/PanAeon/vscode-tmgrammar-test/issues/6),
so instead the test cases are moved to snapshot tests
that demonstrate that no other grammars are added on excluded cases.