### PR TITLE
fix: do not include fileContent when opening file

### DIFF
--- a/server/src/session.ts
+++ b/server/src/session.ts
@@ -161,14 +161,18 @@ export class Session {
   }
 
   private onDidOpenTextDocument(params: lsp.DidOpenTextDocumentParams) {
-    const {uri, text, languageId} = params.textDocument;
+    const {uri, languageId} = params.textDocument;
     const filePath = uriToFilePath(uri);
     if (!filePath) {
       return;
     }
-
     const scriptKind = languageId === LanguageId.TS ? ts.ScriptKind.TS : ts.ScriptKind.External;
-    const result = this.projectService.openClientFile(filePath, text, scriptKind);
+    // Since we are only keeping track of changes of files that are already on
+    // disk (see documentSelector.scheme in extension.ts), the content on disk
+    // is up-to-date when a file is first opened in the editor.
+    // In this case, we should not pass fileContent to projectService.
+    const fileContent = undefined;
+    const result = this.projectService.openClientFile(filePath, fileContent, scriptKind);
 
     const {configFileName, configFileErrors} = result;
     if (configFileErrors && configFileErrors.length) {


### PR DESCRIPTION
When a file is first opened in the editor, we should not pass
`fileContent` to the project service, because doing so assumes that the
content in the editor is more up-to-date than the content on disk, which
is not true. We only keep track of changes of files that are already on
disk, so the content on disk is already the latest snapshot.

This is a prerequisite to remove `getExternalFiles()`.

See discussion at https://github.com/angular/vscode-ng-language-service/issues/473