### PR TITLE
refactor: rename template syntax to inline_template

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,8 +50,8 @@
     },
     "grammars": [
       {
-        "path": "./syntaxes/template.ng.json",
-        "scopeName": "template.ng",
+        "path": "./syntaxes/inline-template.json",
+        "scopeName": "inline-template.ng",
         "injectTo": [
           "source.ts"
         ],

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -19,7 +19,7 @@ cp client/package.json client/yarn.lock dist/client
 cp server/package.json server/yarn.lock server/README.md dist/server
 # Copy files to syntaxes directory
 mkdir dist/syntaxes
-cp syntaxes/template.ng.json dist/syntaxes
+cp syntaxes/*.json dist/syntaxes
 
 pushd dist
 yarn install --production --ignore-scripts

--- a/scripts/syntax.sh
+++ b/scripts/syntax.sh
@@ -10,7 +10,7 @@ set -ex -o pipefail
 DUMMY_GRAMMARS=$(find syntaxes/test -name '*-dummy.json' -exec echo "-g {}" \; | tr '\n' ' ')
 ARGS=$(cat<<ARGS
   -s inline-template.ng 
-  -g syntaxes/template.ng.json $DUMMY_GRAMMARS 
+  -g syntaxes/inline-template.json $DUMMY_GRAMMARS
   -t syntaxes/test/**/*.ts
 ARGS
 )

--- a/scripts/syntax.sh
+++ b/scripts/syntax.sh
@@ -9,7 +9,7 @@ set -ex -o pipefail
 
 DUMMY_GRAMMARS=$(find syntaxes/test -name '*-dummy.json' -exec echo "-g {}" \; | tr '\n' ' ')
 ARGS=$(cat<<ARGS
-  -s template.ng 
+  -s inline-template.ng 
   -g syntaxes/template.ng.json $DUMMY_GRAMMARS 
   -t syntaxes/test/**/*.ts
 ARGS

--- a/syntaxes/inline-template.json
+++ b/syntaxes/inline-template.json
@@ -1,13 +1,13 @@
 {
-  "scopeName": "template.ng",
+  "scopeName": "inline-template.ng",
   "injectionSelector": "L:meta.decorator.ts -comment",
   "patterns": [
     {
-      "include": "#ts-decorator"
+      "include": "#inline-template"
     }
   ],
   "repository": {
-    "ts-decorator": {
+    "inline-template": {
       "begin": "(template)\\s*(:)",
       "beginCaptures": {
         "1": {

--- a/syntaxes/test/inline_template.ts.snap
+++ b/syntaxes/test/inline_template.ts.snap
@@ -1,98 +1,98 @@
 >// SYNTAX TEST "template.ng"
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.ng
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ inline-template.ng
 >/* clang-format off */
-#^^^^^^^^^^^^^^^^^^^^^^^ template.ng
+#^^^^^^^^^^^^^^^^^^^^^^^ inline-template.ng
 >
 >@Component({
-#^^^^^^^^^^^^^ template.ng
+#^^^^^^^^^^^^^ inline-template.ng
 >//// Property key/value test
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.ng
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ inline-template.ng
 >  template: '<div></div>',
-#^^ template.ng
-#  ^^^^^^^^ template.ng meta.object-literal.key.ts
-#          ^ template.ng meta.object-literal.key.ts punctuation.separator.key-value.ts
-#           ^ template.ng
-#            ^ template.ng string
-#             ^^^^^^^^^^^ template.ng
-#                        ^ template.ng string
-#                         ^^ template.ng
+#^^ inline-template.ng
+#  ^^^^^^^^ inline-template.ng meta.object-literal.key.ts
+#          ^ inline-template.ng meta.object-literal.key.ts punctuation.separator.key-value.ts
+#           ^ inline-template.ng
+#            ^ inline-template.ng string
+#             ^^^^^^^^^^^ inline-template.ng
+#                        ^ inline-template.ng string
+#                         ^^ inline-template.ng
 >
 >//// String delimiter tests
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.ng
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^ inline-template.ng
 >  template: `<div></div>`,
-#^^ template.ng
-#  ^^^^^^^^ template.ng meta.object-literal.key.ts
-#          ^ template.ng meta.object-literal.key.ts punctuation.separator.key-value.ts
-#           ^ template.ng
-#            ^ template.ng string
-#             ^^^^^^^^^^^ template.ng
-#                        ^ template.ng string
-#                         ^^ template.ng
+#^^ inline-template.ng
+#  ^^^^^^^^ inline-template.ng meta.object-literal.key.ts
+#          ^ inline-template.ng meta.object-literal.key.ts punctuation.separator.key-value.ts
+#           ^ inline-template.ng
+#            ^ inline-template.ng string
+#             ^^^^^^^^^^^ inline-template.ng
+#                        ^ inline-template.ng string
+#                         ^^ inline-template.ng
 >  template: "<div></div>",
-#^^ template.ng
-#  ^^^^^^^^ template.ng meta.object-literal.key.ts
-#          ^ template.ng meta.object-literal.key.ts punctuation.separator.key-value.ts
-#           ^ template.ng
-#            ^ template.ng string
-#             ^^^^^^^^^^^ template.ng
-#                        ^ template.ng string
-#                         ^^ template.ng
+#^^ inline-template.ng
+#  ^^^^^^^^ inline-template.ng meta.object-literal.key.ts
+#          ^ inline-template.ng meta.object-literal.key.ts punctuation.separator.key-value.ts
+#           ^ inline-template.ng
+#            ^ inline-template.ng string
+#             ^^^^^^^^^^^ inline-template.ng
+#                        ^ inline-template.ng string
+#                         ^^ inline-template.ng
 >  template: '<div></div>',
-#^^ template.ng
-#  ^^^^^^^^ template.ng meta.object-literal.key.ts
-#          ^ template.ng meta.object-literal.key.ts punctuation.separator.key-value.ts
-#           ^ template.ng
-#            ^ template.ng string
-#             ^^^^^^^^^^^ template.ng
-#                        ^ template.ng string
-#                         ^^ template.ng
+#^^ inline-template.ng
+#  ^^^^^^^^ inline-template.ng meta.object-literal.key.ts
+#          ^ inline-template.ng meta.object-literal.key.ts punctuation.separator.key-value.ts
+#           ^ inline-template.ng
+#            ^ inline-template.ng string
+#             ^^^^^^^^^^^ inline-template.ng
+#                        ^ inline-template.ng string
+#                         ^^ inline-template.ng
 >
 >//// Parenthesization tests
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.ng
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^ inline-template.ng
 >  template: ( (( '<div></div>' )) ),
-#^^ template.ng
-#  ^^^^^^^^ template.ng meta.object-literal.key.ts
-#          ^ template.ng meta.object-literal.key.ts punctuation.separator.key-value.ts
-#           ^ template.ng
-#            ^ template.ng meta.brace.round.ts
-#             ^ template.ng
-#              ^ template.ng meta.brace.round.ts
-#               ^ template.ng meta.brace.round.ts
-#                ^ template.ng
-#                 ^ template.ng string
-#                  ^^^^^^^^^^^ template.ng
-#                             ^ template.ng string
-#                              ^ template.ng
-#                               ^ template.ng meta.brace.round.ts
-#                                ^ template.ng meta.brace.round.ts
-#                                 ^ template.ng
-#                                  ^ template.ng meta.brace.round.ts
-#                                   ^^ template.ng
+#^^ inline-template.ng
+#  ^^^^^^^^ inline-template.ng meta.object-literal.key.ts
+#          ^ inline-template.ng meta.object-literal.key.ts punctuation.separator.key-value.ts
+#           ^ inline-template.ng
+#            ^ inline-template.ng meta.brace.round.ts
+#             ^ inline-template.ng
+#              ^ inline-template.ng meta.brace.round.ts
+#               ^ inline-template.ng meta.brace.round.ts
+#                ^ inline-template.ng
+#                 ^ inline-template.ng string
+#                  ^^^^^^^^^^^ inline-template.ng
+#                             ^ inline-template.ng string
+#                              ^ inline-template.ng
+#                               ^ inline-template.ng meta.brace.round.ts
+#                                ^ inline-template.ng meta.brace.round.ts
+#                                 ^ inline-template.ng
+#                                  ^ inline-template.ng meta.brace.round.ts
+#                                   ^^ inline-template.ng
 >
 >//// Comments tests
-#^^^^^^^^^^^^^^^^^^^^ template.ng
+#^^^^^^^^^^^^^^^^^^^^ inline-template.ng
 >  // template: '<div></div>'
-#^^^^^ template.ng
-#     ^^^^^^^^ template.ng meta.object-literal.key.ts
-#             ^ template.ng meta.object-literal.key.ts punctuation.separator.key-value.ts
-#              ^ template.ng
-#               ^ template.ng string
-#                ^^^^^^^^^^^ template.ng
-#                           ^ template.ng string
+#^^^^^ inline-template.ng
+#     ^^^^^^^^ inline-template.ng meta.object-literal.key.ts
+#             ^ inline-template.ng meta.object-literal.key.ts punctuation.separator.key-value.ts
+#              ^ inline-template.ng
+#               ^ inline-template.ng string
+#                ^^^^^^^^^^^ inline-template.ng
+#                           ^ inline-template.ng string
 >  /*
-#^^^^^ template.ng
+#^^^^^ inline-template.ng
 >   * template: '<div></div>'
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.ng
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ inline-template.ng
 >   */
-#^^^^^^ template.ng
+#^^^^^^ inline-template.ng
 >  /**
-#^^^^^^ template.ng
+#^^^^^^ inline-template.ng
 >   * template: '<div></div>'
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.ng
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ inline-template.ng
 >   */
-#^^^^^^ template.ng
+#^^^^^^ inline-template.ng
 >})
-#^^^ template.ng
+#^^^ inline-template.ng
 >export class TMComponent{}
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.ng
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^ inline-template.ng
 >


### PR DESCRIPTION
This commit performs a minor refactor, changing the TextMate inline
template syntax file name and scopes to explicitly be `inline_template`.
This is in preparation for adding a TextMate grammar for CSS styles in
`@Component` `styles` properties.