### PR TITLE
feat: add textmate grammar for inline CSS styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,10 +54,14 @@
         "scopeName": "inline-template.ng",
         "injectTo": [
           "source.ts"
-        ],
-        "embeddedLanguages": {
-          "source.html": "html"
-        }
+        ]
+      },
+      {
+        "path": "./syntaxes/inline-styles.json",
+        "scopeName": "inline-styles.ng",
+        "injectTo": [
+          "source.ts"
+        ]
       }
     ]
   },

--- a/package.json
+++ b/package.json
@@ -54,14 +54,20 @@
         "scopeName": "inline-template.ng",
         "injectTo": [
           "source.ts"
-        ]
+        ],
+        "embeddedLanguages": {
+          "source.html": "html"
+        }
       },
       {
         "path": "./syntaxes/inline-styles.json",
         "scopeName": "inline-styles.ng",
         "injectTo": [
           "source.ts"
-        ]
+        ],
+        "embeddedLanguages": {
+          "source.css": "css"
+        }
       }
     ]
   },

--- a/syntaxes/inline-styles.json
+++ b/syntaxes/inline-styles.json
@@ -1,0 +1,94 @@
+{
+  "scopeName": "inline-styles.ng",
+  "injectionSelector": "L:source.ts#meta.decorator.ts -comment",
+  "patterns": [
+    {
+      "include": "#inline-styles"
+    }
+  ],
+  "repository": {
+    "inline-styles": {
+      "begin": "(styles)\\s*(:)",
+      "beginCaptures": {
+        "1": {
+          "name": "meta.object-literal.key.ts"
+        },
+        "2": {
+          "name": "meta.object-literal.key.ts punctuation.separator.key-value.ts"
+        }
+      },
+      "end": "(?=,|})",
+      "patterns": [
+        {
+          "include": "#ts-paren-expression"
+        },
+        {
+          "include": "#ts-bracket-expression"
+        }
+      ]
+    },
+
+    "ts-paren-expression": {
+      "begin": "\\G\\s*(\\()",
+      "beginCaptures": {
+        "1": {
+          "name": "meta.brace.round.ts"
+        }
+      },
+      "end": "\\)",
+      "endCaptures": {
+        "0": {
+          "name": "meta.brace.round.ts"
+        }
+      },
+      "patterns": [
+        {
+          "include": "$self"
+        },
+        {
+          "include": "#ts-bracket-expression"
+        }
+      ]
+    },
+
+    "ts-bracket-expression": {
+      "begin": "\\G\\s*(\\[)",
+      "beginCaptures": {
+        "1": {
+          "name": "meta.array.literal.ts meta.brace.square.ts"
+        }
+      },
+      "end": "\\]",
+      "endCaptures": {
+        "0": {
+          "name": "meta.array.literal.ts meta.brace.square.ts"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#style"
+        }
+      ]
+    },
+
+    "style": {
+      "begin": "\\s*([`|'|\"])",
+      "beginCaptures": {
+        "1": {
+          "name": "string"
+        }
+      },
+      "end": "\\1",
+      "endCaptures": {
+        "0": {
+          "name": "string"
+        }
+      },
+      "patterns": [
+        {
+          "include": "source.css"
+        }
+      ]
+    }
+  }
+}

--- a/syntaxes/inline-styles.json
+++ b/syntaxes/inline-styles.json
@@ -84,6 +84,7 @@
           "name": "string"
         }
       },
+      "contentName": "source.css",
       "patterns": [
         {
           "include": "source.css"

--- a/syntaxes/test/cases.json
+++ b/syntaxes/test/cases.json
@@ -3,5 +3,10 @@
     "scopeName": "inline-template.ng",
     "grammarFiles": ["syntaxes/inline-template.json"],
     "testFile": "syntaxes/test/data/inline-template.ts"
+  },
+  {
+    "scopeName": "inline-styles.ng",
+    "grammarFiles": ["syntaxes/inline-styles.json"],
+    "testFile": "syntaxes/test/data/inline-styles.ts"
   }
 ]

--- a/syntaxes/test/data/inline-styles.ts
+++ b/syntaxes/test/data/inline-styles.ts
@@ -1,0 +1,21 @@
+/* clang-format off */
+
+@Component({
+//// Property key/value test
+  styles: [ '.example { width: 100px; }' ],
+
+//// Multiple styles test
+  styles: [
+    '.example { width: 100px; }',
+    '.example { height: 100px; }',
+  ],
+
+//// String delimiter tests
+  styles: [ `.example { width: 100px; }` ],
+  styles: [ ".example { width: 100px; }" ],
+  styles: [ '.example { width: 100px; }' ],
+
+//// Parenthesization tests
+  styles: ( (( [ ( '.example { width: 100px; }' ) ] )) ),
+})
+export class TMComponent{}

--- a/syntaxes/test/data/inline-styles.ts.snap
+++ b/syntaxes/test/data/inline-styles.ts.snap
@@ -1,0 +1,105 @@
+>/* clang-format off */
+#^^^^^^^^^^^^^^^^^^^^^^^ inline-styles.ng
+>
+>@Component({
+#^^^^^^^^^^^^^ inline-styles.ng
+>//// Property key/value test
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ inline-styles.ng
+>  styles: [ '.example { width: 100px; }' ],
+#^^ inline-styles.ng
+#  ^^^^^^ inline-styles.ng meta.object-literal.key.ts
+#        ^ inline-styles.ng meta.object-literal.key.ts punctuation.separator.key-value.ts
+#         ^ inline-styles.ng
+#          ^ inline-styles.ng meta.array.literal.ts meta.brace.square.ts
+#           ^ inline-styles.ng
+#            ^ inline-styles.ng string
+#             ^^^^^^^^^^^^^^^^^^^^^^^^^^ inline-styles.ng
+#                                       ^ inline-styles.ng string
+#                                        ^ inline-styles.ng
+#                                         ^ inline-styles.ng meta.array.literal.ts meta.brace.square.ts
+#                                          ^^ inline-styles.ng
+>
+>//// Multiple styles test
+#^^^^^^^^^^^^^^^^^^^^^^^^^^ inline-styles.ng
+>  styles: [
+#^^ inline-styles.ng
+#  ^^^^^^ inline-styles.ng meta.object-literal.key.ts
+#        ^ inline-styles.ng meta.object-literal.key.ts punctuation.separator.key-value.ts
+#         ^ inline-styles.ng
+#          ^ inline-styles.ng meta.array.literal.ts meta.brace.square.ts
+>    '.example { width: 100px; }',
+#^^^^ inline-styles.ng
+#    ^ inline-styles.ng string
+#     ^^^^^^^^^^^^^^^^^^^^^^^^^^ inline-styles.ng
+#                               ^ inline-styles.ng string
+#                                ^^ inline-styles.ng
+>    '.example { height: 100px; }',
+#^^^^ inline-styles.ng
+#    ^ inline-styles.ng string
+#     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ inline-styles.ng
+#                                ^ inline-styles.ng string
+#                                 ^^ inline-styles.ng
+>  ],
+#^^ inline-styles.ng
+#  ^ inline-styles.ng meta.array.literal.ts meta.brace.square.ts
+#   ^^ inline-styles.ng
+>
+>//// String delimiter tests
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^ inline-styles.ng
+>  styles: [ `.example { width: 100px; }` ],
+#^^ inline-styles.ng
+#  ^^^^^^ inline-styles.ng meta.object-literal.key.ts
+#        ^ inline-styles.ng meta.object-literal.key.ts punctuation.separator.key-value.ts
+#         ^ inline-styles.ng
+#          ^ inline-styles.ng meta.array.literal.ts meta.brace.square.ts
+#           ^ inline-styles.ng
+#            ^ inline-styles.ng string
+#             ^^^^^^^^^^^^^^^^^^^^^^^^^^ inline-styles.ng
+#                                       ^ inline-styles.ng string
+#                                        ^ inline-styles.ng
+#                                         ^ inline-styles.ng meta.array.literal.ts meta.brace.square.ts
+#                                          ^^ inline-styles.ng
+>  styles: [ ".example { width: 100px; }" ],
+#^^ inline-styles.ng
+#  ^^^^^^ inline-styles.ng meta.object-literal.key.ts
+#        ^ inline-styles.ng meta.object-literal.key.ts punctuation.separator.key-value.ts
+#         ^ inline-styles.ng
+#          ^ inline-styles.ng meta.array.literal.ts meta.brace.square.ts
+#           ^ inline-styles.ng
+#            ^ inline-styles.ng string
+#             ^^^^^^^^^^^^^^^^^^^^^^^^^^ inline-styles.ng
+#                                       ^ inline-styles.ng string
+#                                        ^ inline-styles.ng
+#                                         ^ inline-styles.ng meta.array.literal.ts meta.brace.square.ts
+#                                          ^^ inline-styles.ng
+>  styles: [ '.example { width: 100px; }' ],
+#^^ inline-styles.ng
+#  ^^^^^^ inline-styles.ng meta.object-literal.key.ts
+#        ^ inline-styles.ng meta.object-literal.key.ts punctuation.separator.key-value.ts
+#         ^ inline-styles.ng
+#          ^ inline-styles.ng meta.array.literal.ts meta.brace.square.ts
+#           ^ inline-styles.ng
+#            ^ inline-styles.ng string
+#             ^^^^^^^^^^^^^^^^^^^^^^^^^^ inline-styles.ng
+#                                       ^ inline-styles.ng string
+#                                        ^ inline-styles.ng
+#                                         ^ inline-styles.ng meta.array.literal.ts meta.brace.square.ts
+#                                          ^^ inline-styles.ng
+>
+>//// Parenthesization tests
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^ inline-styles.ng
+>  styles: ( (( [ ( '.example { width: 100px; }' ) ] )) ),
+#^^ inline-styles.ng
+#  ^^^^^^ inline-styles.ng meta.object-literal.key.ts
+#        ^ inline-styles.ng meta.object-literal.key.ts punctuation.separator.key-value.ts
+#         ^ inline-styles.ng
+#          ^ inline-styles.ng meta.brace.round.ts
+#           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ inline-styles.ng
+#                                                ^ inline-styles.ng meta.brace.round.ts
+#                                                 ^^^^^^^ inline-styles.ng
+#                                                        ^^ inline-styles.ng
+>})
+#^^^ inline-styles.ng
+>export class TMComponent{}
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^ inline-styles.ng
+>

--- a/syntaxes/test/data/inline-styles.ts.snap
+++ b/syntaxes/test/data/inline-styles.ts.snap
@@ -13,7 +13,7 @@
 #          ^ inline-styles.ng meta.array.literal.ts meta.brace.square.ts
 #           ^ inline-styles.ng
 #            ^ inline-styles.ng string
-#             ^^^^^^^^^^^^^^^^^^^^^^^^^^ inline-styles.ng
+#             ^^^^^^^^^^^^^^^^^^^^^^^^^^ inline-styles.ng source.css
 #                                       ^ inline-styles.ng string
 #                                        ^ inline-styles.ng
 #                                         ^ inline-styles.ng meta.array.literal.ts meta.brace.square.ts
@@ -30,13 +30,13 @@
 >    '.example { width: 100px; }',
 #^^^^ inline-styles.ng
 #    ^ inline-styles.ng string
-#     ^^^^^^^^^^^^^^^^^^^^^^^^^^ inline-styles.ng
+#     ^^^^^^^^^^^^^^^^^^^^^^^^^^ inline-styles.ng source.css
 #                               ^ inline-styles.ng string
 #                                ^^ inline-styles.ng
 >    '.example { height: 100px; }',
 #^^^^ inline-styles.ng
 #    ^ inline-styles.ng string
-#     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ inline-styles.ng
+#     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ inline-styles.ng source.css
 #                                ^ inline-styles.ng string
 #                                 ^^ inline-styles.ng
 >  ],
@@ -54,7 +54,7 @@
 #          ^ inline-styles.ng meta.array.literal.ts meta.brace.square.ts
 #           ^ inline-styles.ng
 #            ^ inline-styles.ng string
-#             ^^^^^^^^^^^^^^^^^^^^^^^^^^ inline-styles.ng
+#             ^^^^^^^^^^^^^^^^^^^^^^^^^^ inline-styles.ng source.css
 #                                       ^ inline-styles.ng string
 #                                        ^ inline-styles.ng
 #                                         ^ inline-styles.ng meta.array.literal.ts meta.brace.square.ts
@@ -67,7 +67,7 @@
 #          ^ inline-styles.ng meta.array.literal.ts meta.brace.square.ts
 #           ^ inline-styles.ng
 #            ^ inline-styles.ng string
-#             ^^^^^^^^^^^^^^^^^^^^^^^^^^ inline-styles.ng
+#             ^^^^^^^^^^^^^^^^^^^^^^^^^^ inline-styles.ng source.css
 #                                       ^ inline-styles.ng string
 #                                        ^ inline-styles.ng
 #                                         ^ inline-styles.ng meta.array.literal.ts meta.brace.square.ts
@@ -80,7 +80,7 @@
 #          ^ inline-styles.ng meta.array.literal.ts meta.brace.square.ts
 #           ^ inline-styles.ng
 #            ^ inline-styles.ng string
-#             ^^^^^^^^^^^^^^^^^^^^^^^^^^ inline-styles.ng
+#             ^^^^^^^^^^^^^^^^^^^^^^^^^^ inline-styles.ng source.css
 #                                       ^ inline-styles.ng string
 #                                        ^ inline-styles.ng
 #                                         ^ inline-styles.ng meta.array.literal.ts meta.brace.square.ts

--- a/syntaxes/test/driver.ts
+++ b/syntaxes/test/driver.ts
@@ -3,7 +3,7 @@
 //   yarn test:syntaxes [options]
 //
 // Options:
-//   -u, --update    update snapshot files (always passes)
+//   -u    update snapshot files (always passes)
 
 import 'jasmine';
 

--- a/syntaxes/test/dummy/css.tmLanguage-dummy.json
+++ b/syntaxes/test/dummy/css.tmLanguage-dummy.json
@@ -1,0 +1,4 @@
+{
+  "comment": "Dummy HTML TextMate grammar for use in testing",
+  "scopeName": "source.css"
+}


### PR DESCRIPTION
Adds a TextMate grammar for inline styles in a component.

Unfortunately, we cannot merge this grammar conviniently with the one
specified for inline templates, because though the directions of grammar
recurse are similar for both, they apply different grammars for
matches. For instance, an inline template and style both match a string
literal, but the former applies an HTML grammar while the later applies
a CSS grammar. To distinguish between the two, we have to create two
different grammar recurse paths at the closest divergence of the
grammars (for convinience, at `template` and `style` properties in a
`@Component` definition).

Attached to the PR for this commit are images demonstrating this change.
The second image shows that commenting out the style property applies
the regular comment grammar to the entire style string. For some reason,
however, running a commented style through the snapshot tests leads to
an incorrect and undeterministic result. This is likely an issue with the
test framework; I will investigate and update the tests in a future PR.

Partially addresses #483 ([comment](https://github.com/angular/vscode-ng-language-service/issues/483#issuecomment-566367049))

<img width="395" alt="Screen Shot 2019-12-17 at 6 37 35 PM" src="https://user-images.githubusercontent.com/20735482/71048210-2dc9b100-2104-11ea-8aec-b755dbf8745d.png">
<img width="395" alt="Screen Shot 2019-12-17 at 7 14 53 PM" src="https://user-images.githubusercontent.com/20735482/71048211-2dc9b100-2104-11ea-8e58-e67b843d7f7f.png">
