### PR TITLE
fix: correctly specify embedded languages in an Angular template

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,9 @@
           "source.ts"
         ],
         "embeddedLanguages": {
-          "source.html": "html"
+          "text.html": "html",
+          "source.css": "css",
+          "source.js": "javascript"
         }
       },
       {

--- a/syntaxes/inline-template.json
+++ b/syntaxes/inline-template.json
@@ -64,6 +64,7 @@
           "name": "string"
         }
       },
+      "contentName": "text.html",
       "patterns": [
         {
           "include": "text.html.basic"

--- a/syntaxes/test/data/inline-template.ts.snap
+++ b/syntaxes/test/data/inline-template.ts.snap
@@ -11,7 +11,7 @@
 #          ^ inline-template.ng meta.object-literal.key.ts punctuation.separator.key-value.ts
 #           ^ inline-template.ng
 #            ^ inline-template.ng string
-#             ^^^^^^^^^^^ inline-template.ng
+#             ^^^^^^^^^^^ inline-template.ng text.html
 #                        ^ inline-template.ng string
 #                         ^^ inline-template.ng
 >
@@ -23,7 +23,7 @@
 #          ^ inline-template.ng meta.object-literal.key.ts punctuation.separator.key-value.ts
 #           ^ inline-template.ng
 #            ^ inline-template.ng string
-#             ^^^^^^^^^^^ inline-template.ng
+#             ^^^^^^^^^^^ inline-template.ng text.html
 #                        ^ inline-template.ng string
 #                         ^^ inline-template.ng
 >  template: "<div></div>",
@@ -32,7 +32,7 @@
 #          ^ inline-template.ng meta.object-literal.key.ts punctuation.separator.key-value.ts
 #           ^ inline-template.ng
 #            ^ inline-template.ng string
-#             ^^^^^^^^^^^ inline-template.ng
+#             ^^^^^^^^^^^ inline-template.ng text.html
 #                        ^ inline-template.ng string
 #                         ^^ inline-template.ng
 >  template: '<div></div>',
@@ -41,7 +41,7 @@
 #          ^ inline-template.ng meta.object-literal.key.ts punctuation.separator.key-value.ts
 #           ^ inline-template.ng
 #            ^ inline-template.ng string
-#             ^^^^^^^^^^^ inline-template.ng
+#             ^^^^^^^^^^^ inline-template.ng text.html
 #                        ^ inline-template.ng string
 #                         ^^ inline-template.ng
 >
@@ -58,7 +58,7 @@
 #               ^ inline-template.ng meta.brace.round.ts
 #                ^ inline-template.ng
 #                 ^ inline-template.ng string
-#                  ^^^^^^^^^^^ inline-template.ng
+#                  ^^^^^^^^^^^ inline-template.ng text.html
 #                             ^ inline-template.ng string
 #                              ^ inline-template.ng
 #                               ^ inline-template.ng meta.brace.round.ts
@@ -75,7 +75,7 @@
 #             ^ inline-template.ng meta.object-literal.key.ts punctuation.separator.key-value.ts
 #              ^ inline-template.ng
 #               ^ inline-template.ng string
-#                ^^^^^^^^^^^ inline-template.ng
+#                ^^^^^^^^^^^ inline-template.ng text.html
 #                           ^ inline-template.ng string
 >  /*
 #^^^^^ inline-template.ng


### PR DESCRIPTION
Previously, HTML was not recognized as an embedded language in an
inline template because the scope matching it (source.html) was never
used in the inline template grammar. This commits fixes that and renames
the embedded scope to the colloquial "text.html", as well as adding
embedded language scopes for CSS and JavaScript.

Attached to the PR for this commit is an animated GIF with a preview of
the changes.

![embedded-langs](https://user-images.githubusercontent.com/20735482/71059513-acd0e080-2128-11ea-9188-8e80e38c02c8.gif)