### PR TITLE
feat: add syntax highlighting grammar for interpolations

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,18 @@
         "embeddedLanguages": {
           "source.css": "css"
         }
+      },
+      {
+        "path": "./syntaxes/template.json",
+        "scopeName": "template.ng",
+        "injectTo": [
+          "text.html"
+        ],
+        "embeddedLanguages": {
+          "text.html": "html",
+          "source.css": "css",
+          "source.js": "javascript"
+        }
       }
     ]
   },

--- a/syntaxes/inline-template.json
+++ b/syntaxes/inline-template.json
@@ -68,6 +68,9 @@
       "patterns": [
         {
           "include": "text.html.basic"
+        },
+        {
+          "include": "template.ng"
         }
       ]
     }

--- a/syntaxes/template.json
+++ b/syntaxes/template.json
@@ -1,0 +1,31 @@
+{
+  "scopeName": "template.ng",
+  "injectionSelector": "L:text.html -comment",
+  "patterns": [
+    {
+      "include": "#interpolation"
+    }
+  ],
+  "repository": {
+    "interpolation": {
+      "begin": "{{",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.block.ts"
+        }
+      },
+      "end": "}}",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.block.ts"
+        }
+      },
+      "contentName": "source.js",
+      "patterns": [
+        {
+          "include": "source.js"
+        }
+      ]
+    }
+  }
+}

--- a/syntaxes/test/cases.json
+++ b/syntaxes/test/cases.json
@@ -1,12 +1,17 @@
 [
   {
     "scopeName": "inline-template.ng",
-    "grammarFiles": ["syntaxes/inline-template.json"],
+    "grammarFiles": ["syntaxes/inline-template.json", "syntaxes/template.json"],
     "testFile": "syntaxes/test/data/inline-template.ts"
   },
   {
     "scopeName": "inline-styles.ng",
     "grammarFiles": ["syntaxes/inline-styles.json"],
     "testFile": "syntaxes/test/data/inline-styles.ts"
+  },
+  {
+    "scopeName": "template.ng",
+    "grammarFiles": ["syntaxes/template.json"],
+    "testFile": "syntaxes/test/data/template.html"
   }
 ]

--- a/syntaxes/test/data/inline-template.ts
+++ b/syntaxes/test/data/inline-template.ts
@@ -1,18 +1,19 @@
 /* clang-format off */
 
+/* Inline template recognition tests */
 @Component({
-//// Property key/value test
+  //// Property key/value test
   template: '<div></div>',
 
-//// String delimiter tests
+  //// String delimiter tests
   template: `<div></div>`,
   template: "<div></div>",
   template: '<div></div>',
 
-//// Parenthesization tests
+  //// Parenthesization tests
   template: ( (( '<div></div>' )) ),
 
-//// Comments tests
+  //// Comments tests
   // template: '<div></div>'
   /*
    * template: '<div></div>'
@@ -20,5 +21,12 @@
   /**
    * template: '<div></div>'
    */
+})
+export class TMComponent{}
+
+/* Template syntax tests */
+@Component({
+  // Interpolation test
+  template: '{{property}}',
 })
 export class TMComponent{}

--- a/syntaxes/test/data/inline-template.ts.snap
+++ b/syntaxes/test/data/inline-template.ts.snap
@@ -1,10 +1,12 @@
 >/* clang-format off */
 #^^^^^^^^^^^^^^^^^^^^^^^ inline-template.ng
 >
+>/* Inline template recognition tests */
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ inline-template.ng
 >@Component({
 #^^^^^^^^^^^^^ inline-template.ng
->//// Property key/value test
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ inline-template.ng
+>  //// Property key/value test
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ inline-template.ng
 >  template: '<div></div>',
 #^^ inline-template.ng
 #  ^^^^^^^^ inline-template.ng meta.object-literal.key.ts
@@ -15,8 +17,8 @@
 #                        ^ inline-template.ng string
 #                         ^^ inline-template.ng
 >
->//// String delimiter tests
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^ inline-template.ng
+>  //// String delimiter tests
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ inline-template.ng
 >  template: `<div></div>`,
 #^^ inline-template.ng
 #  ^^^^^^^^ inline-template.ng meta.object-literal.key.ts
@@ -45,8 +47,8 @@
 #                        ^ inline-template.ng string
 #                         ^^ inline-template.ng
 >
->//// Parenthesization tests
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^ inline-template.ng
+>  //// Parenthesization tests
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ inline-template.ng
 >  template: ( (( '<div></div>' )) ),
 #^^ inline-template.ng
 #  ^^^^^^^^ inline-template.ng meta.object-literal.key.ts
@@ -67,8 +69,8 @@
 #                                  ^ inline-template.ng meta.brace.round.ts
 #                                   ^^ inline-template.ng
 >
->//// Comments tests
-#^^^^^^^^^^^^^^^^^^^^ inline-template.ng
+>  //// Comments tests
+#^^^^^^^^^^^^^^^^^^^^^^ inline-template.ng
 >  // template: '<div></div>'
 #^^^^^ inline-template.ng
 #     ^^^^^^^^ inline-template.ng meta.object-literal.key.ts
@@ -89,6 +91,28 @@
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ inline-template.ng
 >   */
 #^^^^^^ inline-template.ng
+>})
+#^^^ inline-template.ng
+>export class TMComponent{}
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^ inline-template.ng
+>
+>/* Template syntax tests */
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^ inline-template.ng
+>@Component({
+#^^^^^^^^^^^^^ inline-template.ng
+>  // Interpolation test
+#^^^^^^^^^^^^^^^^^^^^^^^^ inline-template.ng
+>  template: '{{property}}',
+#^^ inline-template.ng
+#  ^^^^^^^^ inline-template.ng meta.object-literal.key.ts
+#          ^ inline-template.ng meta.object-literal.key.ts punctuation.separator.key-value.ts
+#           ^ inline-template.ng
+#            ^ inline-template.ng string
+#             ^^ inline-template.ng text.html punctuation.definition.block.ts
+#               ^^^^^^^^ inline-template.ng text.html source.js
+#                       ^^ inline-template.ng text.html punctuation.definition.block.ts
+#                         ^ inline-template.ng string
+#                          ^^ inline-template.ng
 >})
 #^^^ inline-template.ng
 >export class TMComponent{}

--- a/syntaxes/test/data/template.html
+++ b/syntaxes/test/data/template.html
@@ -1,0 +1,2 @@
+<!-- Interpolation test -->
+<div>{{ call(1 + 2 + 3) }}</div>

--- a/syntaxes/test/data/template.html.snap
+++ b/syntaxes/test/data/template.html.snap
@@ -1,0 +1,9 @@
+><!-- Interpolation test -->
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.ng
+><div>{{ call(1 + 2 + 3) }}</div>
+#^^^^^ template.ng
+#     ^^ template.ng punctuation.definition.block.ts
+#       ^^^^^^^^^^^^^^^^^ template.ng source.js
+#                        ^^ template.ng punctuation.definition.block.ts
+#                          ^^^^^^^ template.ng
+>

--- a/syntaxes/test/dummy/css.tmLanguage-dummy.json
+++ b/syntaxes/test/dummy/css.tmLanguage-dummy.json
@@ -1,4 +1,4 @@
 {
-  "comment": "Dummy HTML TextMate grammar for use in testing",
+  "comment": "Dummy CSS TextMate grammar for use in testing",
   "scopeName": "source.css"
 }

--- a/syntaxes/test/dummy/js.tmLanguage-dummy.json
+++ b/syntaxes/test/dummy/js.tmLanguage-dummy.json
@@ -1,0 +1,4 @@
+{
+  "comment": "Dummy HTML TextMate grammar for use in testing",
+  "scopeName": "source.js"
+}

--- a/syntaxes/test/dummy/js.tmLanguage-dummy.json
+++ b/syntaxes/test/dummy/js.tmLanguage-dummy.json
@@ -1,4 +1,4 @@
 {
-  "comment": "Dummy HTML TextMate grammar for use in testing",
+  "comment": "Dummy JS TextMate grammar for use in testing",
   "scopeName": "source.js"
 }


### PR DESCRIPTION
Adds a grammar for Angular interpolations. Because the grammar relies
only on regex expressions, we cannot currently support any interpolation
delimiters other than the default `{{`/`}}` -- to do more would require
a more sophisticated highlighting solution.

For convinience, everything inside an interpolation is treated as
JavaScript syntax, even though the expressions available in an Angular
interpolations are a distinct subset of JavaScript.

Attached to this PR are several before/after images of this change.

Partially addresses #483.

| | Before   | After |
|:---:| :---:       |    :----:   | 
|Inline template| <img alt="Screen Shot 2019-12-18 at 11 23 55 AM" src="https://user-images.githubusercontent.com/20735482/71110496-04a13300-218d-11ea-8ca3-4db23a4474a7.png">| <img alt="Screen Shot 2019-12-18 at 11 24 13 AM" src="https://user-images.githubusercontent.com/20735482/71110494-04a13300-218d-11ea-9607-05d63050d2eb.png"> |
|External template|<img width="404" alt="Screen Shot 2019-12-18 at 11 23 27 AM" src="https://user-images.githubusercontent.com/20735482/71110497-0539c980-218d-11ea-95ef-df6f71d4ee6e.png"> | <img width="404" alt="Screen Shot 2019-12-18 at 11 22 57 AM" src="https://user-images.githubusercontent.com/20735482/71110498-0539c980-218d-11ea-844c-4137bb027f67.png">