### PR TITLE
test: split syntaxes tests into individual specs with names

### DIFF
--- a/syntaxes/test/cases.json
+++ b/syntaxes/test/cases.json
@@ -1,15 +1,18 @@
 [
   {
+    "name": "inline template",
     "scopeName": "inline-template.ng",
     "grammarFiles": ["syntaxes/inline-template.json", "syntaxes/template.json"],
     "testFile": "syntaxes/test/data/inline-template.ts"
   },
   {
+    "name": "inline styles",
     "scopeName": "inline-styles.ng",
     "grammarFiles": ["syntaxes/inline-styles.json"],
     "testFile": "syntaxes/test/data/inline-styles.ts"
   },
   {
+    "name": "template syntax",
     "scopeName": "template.ng",
     "grammarFiles": ["syntaxes/template.json"],
     "testFile": "syntaxes/test/data/template.html"

--- a/syntaxes/test/driver.ts
+++ b/syntaxes/test/driver.ts
@@ -14,6 +14,7 @@ import * as util from 'util';
 import * as SNAPSHOT_TEST_CASES from './cases.json';
 
 interface TestCase {
+  name: string;
   scopeName: string;
   grammarFiles: string[];
   testFile: string;
@@ -48,10 +49,10 @@ async function snapshotTest({scopeName, grammarFiles, testFile}: TestCase): Prom
 }
 
 describe('snapshot tests', async () => {
-  it('should pass all cases', async () => {
-    for (let tc of SNAPSHOT_TEST_CASES) {
+  for (let tc of SNAPSHOT_TEST_CASES) {
+    it(`should work for ${tc.name}`, async () => {
       const ec = await snapshotTest(tc);
       expect(ec).toBe(0);
-    }
-  });
+    });
+  }
 });


### PR DESCRIPTION
Names each syntaxes test case and runs each case in an individual spec
rather than having all cases run as one spec. Provides more meaningful
output on failures.