### PR TITLE
feat: add textmate grammar for template property bindings

### DIFF
--- a/syntaxes/template.json
+++ b/syntaxes/template.json
@@ -4,6 +4,9 @@
   "patterns": [
     {
       "include": "#interpolation"
+    },
+    {
+      "include": "#propertyBinding"
     }
   ],
   "repository": {
@@ -18,6 +21,33 @@
       "endCaptures": {
         "0": {
           "name": "punctuation.definition.block.ts"
+        }
+      },
+      "contentName": "source.js",
+      "patterns": [
+        {
+          "include": "source.js"
+        }
+      ]
+    },
+
+    "propertyBinding": {
+      "begin": "(\\[.*\\])(=)(\"|')",
+      "beginCaptures": {
+        "1": {
+          "name": "entity.other.attribute-name.html"
+        },
+        "2": {
+          "name": "punctuation.separator.key-value.html"
+        },
+        "3": {
+          "name": "punctuation.definition.string.begin.html string.quoted.html"
+        }
+      },
+      "end": "\\3",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.html string.quoted.html"
         }
       },
       "contentName": "source.js",

--- a/syntaxes/test/data/template.html
+++ b/syntaxes/test/data/template.html
@@ -1,2 +1,5 @@
 <!-- Interpolation test -->
 <div>{{ call(1 + 2 + 3) }}</div>
+
+<!-- Property binding test -->
+<div [ ngStyle ]="{'max-width.px': i * 2 + 5}"></div>

--- a/syntaxes/test/data/template.html.snap
+++ b/syntaxes/test/data/template.html.snap
@@ -7,3 +7,14 @@
 #                        ^^ template.ng punctuation.definition.block.ts
 #                          ^^^^^^^ template.ng
 >
+><!-- Property binding test -->
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.ng
+><div [ ngStyle ]="{'max-width.px': i * 2 + 5}"></div>
+#^^^^^ template.ng
+#     ^^^^^^^^^^^ template.ng entity.other.attribute-name.html
+#                ^ template.ng punctuation.separator.key-value.html
+#                 ^ template.ng punctuation.definition.string.begin.html string.quoted.html
+#                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.ng source.js
+#                                             ^ template.ng punctuation.definition.string.end.html string.quoted.html
+#                                              ^^^^^^^^ template.ng
+>


### PR DESCRIPTION
Adds syntax highlighting support for template property bindings. In
particular, the expression in the bound property value is highlighted as
JavaScript syntax.

The screenshot attached to the PR for this commit demonstrates the
change.

Partially addresses #483
Closes #253

<img width="886" alt="Screen Shot 2019-12-21 at 12 37 59 PM" src="https://user-images.githubusercontent.com/20735482/71312378-b0e25400-23ef-11ea-81db-88771f97646b.png">