### PR TITLE
fix: whitelist all html elements

### DIFF
--- a/syntaxes/inline-template.json
+++ b/syntaxes/inline-template.json
@@ -67,7 +67,7 @@
       "contentName": "text.html",
       "patterns": [
         {
-          "include": "text.html.basic"
+          "include": "text.html.derivative"
         },
         {
           "include": "template.ng"

--- a/syntaxes/test/dummy/html.tmLanguage-dummy.json
+++ b/syntaxes/test/dummy/html.tmLanguage-dummy.json
@@ -1,4 +1,4 @@
 {
   "comment": "Dummy HTML TextMate grammar for use in testing",
-  "scopeName": "text.html.basic"
+  "scopeName": "text.html.derivative"
 }


### PR DESCRIPTION
The `html.basic` grammar whitelists only W3 and custom HTML elements.
Some Angular users may use elements that do not have the custom format
(hyphen-separated), so just whitelist all elements. Fixes cases like
`<popover></popover>` being highlighted incorrectly.

Closes #526.