### PR TITLE
fix: strictly define characters in property binding

### DIFF
--- a/syntaxes/template.json
+++ b/syntaxes/template.json
@@ -32,7 +32,7 @@
     },
 
     "propertyBinding": {
-      "begin": "(\\[[ a-zA-Z0-9\\._\\-@]*\\])(=)(\"|')",
+      "begin": "(\\[[ a-zA-Z0-9\\._\\-@$]*\\])(=)(\"|')",
       "beginCaptures": {
         "1": {
           "name": "entity.other.attribute-name.html"

--- a/syntaxes/template.json
+++ b/syntaxes/template.json
@@ -32,7 +32,7 @@
     },
 
     "propertyBinding": {
-      "begin": "(\\[.*\\])(=)(\"|')",
+      "begin": "(\\[[ a-zA-Z0-9\\._\\-@]*\\])(=)(\"|')",
       "beginCaptures": {
         "1": {
           "name": "entity.other.attribute-name.html"

--- a/syntaxes/test/data/template.html
+++ b/syntaxes/test/data/template.html
@@ -3,3 +3,7 @@
 
 <!-- Property binding test -->
 <div [ ngStyle ]="{'max-width.px': i * 2 + 5}"></div>
+<div [@animation.trigger]="val"></div>
+<div [my-property]="val"></div>
+<div [my_property]="val"></div>
+<div attr="[]" [cutAcross]="false"></div>

--- a/syntaxes/test/data/template.html.snap
+++ b/syntaxes/test/data/template.html.snap
@@ -17,4 +17,36 @@
 #                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.ng source.js
 #                                             ^ template.ng punctuation.definition.string.end.html string.quoted.html
 #                                              ^^^^^^^^ template.ng
+><div [@animation.trigger]="val"></div>
+#^^^^^ template.ng
+#     ^^^^^^^^^^^^^^^^^^^^ template.ng entity.other.attribute-name.html
+#                         ^ template.ng punctuation.separator.key-value.html
+#                          ^ template.ng punctuation.definition.string.begin.html string.quoted.html
+#                           ^^^ template.ng source.js
+#                              ^ template.ng punctuation.definition.string.end.html string.quoted.html
+#                               ^^^^^^^^ template.ng
+><div [my-property]="val"></div>
+#^^^^^ template.ng
+#     ^^^^^^^^^^^^^ template.ng entity.other.attribute-name.html
+#                  ^ template.ng punctuation.separator.key-value.html
+#                   ^ template.ng punctuation.definition.string.begin.html string.quoted.html
+#                    ^^^ template.ng source.js
+#                       ^ template.ng punctuation.definition.string.end.html string.quoted.html
+#                        ^^^^^^^^ template.ng
+><div [my_property]="val"></div>
+#^^^^^ template.ng
+#     ^^^^^^^^^^^^^ template.ng entity.other.attribute-name.html
+#                  ^ template.ng punctuation.separator.key-value.html
+#                   ^ template.ng punctuation.definition.string.begin.html string.quoted.html
+#                    ^^^ template.ng source.js
+#                       ^ template.ng punctuation.definition.string.end.html string.quoted.html
+#                        ^^^^^^^^ template.ng
+><div attr="[]" [cutAcross]="false"></div>
+#^^^^^^^^^^^^^^^ template.ng
+#               ^^^^^^^^^^^ template.ng entity.other.attribute-name.html
+#                          ^ template.ng punctuation.separator.key-value.html
+#                           ^ template.ng punctuation.definition.string.begin.html string.quoted.html
+#                            ^^^^^ template.ng source.js
+#                                 ^ template.ng punctuation.definition.string.end.html string.quoted.html
+#                                  ^^^^^^^^ template.ng
 >


### PR DESCRIPTION
Avoids whitelisting all propery binding names, so that proximal but
seperate brackets aren't treated as overlapping of the same property
binding.

The screenshot attached to this PR demonstrates the fix - in previous
versions, `[1, 2, 3]" [ngValue]` would be treated as one property
binding name.

Fixes #539

<img width="967" alt="Screen Shot 2020-01-10 at 7 50 04 AM" src="https://user-images.githubusercontent.com/20735482/72166669-85171600-337e-11ea-85d0-9d4e022e3272.png">
