### PR TITLE
feat: more detailed grammar scopes for template property binding syntax

### DIFF
--- a/syntaxes/template.json
+++ b/syntaxes/template.json
@@ -32,7 +32,7 @@
     },
 
     "ngBinding": {
-      "begin": "([\\[\\(]{1,2})(@?[-_a-zA-Z0-9.$]*)([\\]\\)]{1,2})(=)([\"'])",
+      "begin": "([\\[\\(]{1,2})(?:\\s*)(@?[-_a-zA-Z0-9.$]*)(?:\\s*)([\\]\\)]{1,2})(=)([\"'])",
       "beginCaptures": {
         "1": {
           "name": "punctuation.definition.ng-binding.begin.html"

--- a/syntaxes/template.json
+++ b/syntaxes/template.json
@@ -6,7 +6,7 @@
       "include": "#interpolation"
     },
     {
-      "include": "#ngBinding"
+      "include": "#propertyBinding"
     }
   ],
   "repository": {
@@ -31,35 +31,25 @@
       ]
     },
 
-    "ngBinding": {
-      "begin": "(([\\[\\(]{1,2})(?:\\s*)(@?[-_a-zA-Z0-9.$]*)(?:\\s*)([\\]\\)]{1,2}))(=)([\"'])",
+    "propertyBinding": {
+      "begin": "(\\[\\s*@?[-_a-zA-Z0-9.$]*\\s*])(=)([\"'])",
       "beginCaptures": {
         "1": {
-          "name": "entity.other.attribute-name.html entity.other.ng-binding-name.html"
-        },
-        "2": {
-          "name": "punctuation.definition.ng-binding-name.begin.html"
-        },
-        "3": {
           "name": "entity.other.attribute-name.html entity.other.ng-binding-name.html",
           "patterns": [
             {
-              "match": "\\.",
-              "name": "punctuation.accessor.html"
+              "include": "#bindingKey"
             }
           ]
         },
-        "4": {
-          "name": "punctuation.definition.ng-binding-name.end.html"
-        },
-        "5": {
+        "2": {
           "name": "punctuation.separator.key-value.html"
         },
-        "6": {
+        "3": {
           "name": "string.quoted.html punctuation.definition.string.begin.html"
         }
       },
-      "end": "\\6",
+      "end": "\\3",
       "endCaptures": {
         "0": {
           "name": "string.quoted.html punctuation.definition.string.end.html"

--- a/syntaxes/template.json
+++ b/syntaxes/template.json
@@ -35,7 +35,7 @@
       "begin": "(\\[\\s*@?[-_a-zA-Z0-9.$]*\\s*])(=)([\"'])",
       "beginCaptures": {
         "1": {
-          "name": "entity.other.attribute-name.html entity.other.ng-binding-name.html",
+          "name": "entity.other.attribute-name.html entity.other.ng-binding-name.property.html",
           "patterns": [
             {
               "include": "#bindingKey"
@@ -55,7 +55,7 @@
           "name": "string.quoted.html punctuation.definition.string.end.html"
         }
       },
-      "name": "ng-binding.html",
+      "name": "meta.ng-binding.property.html",
       "contentName": "source.js",
       "patterns": [
         {

--- a/syntaxes/template.json
+++ b/syntaxes/template.json
@@ -72,6 +72,30 @@
           "include": "source.js"
         }
       ]
+    },
+
+    "bindingKey": {
+      "patterns": [
+        {
+          "match": "([\\[\\(]{1,2})(?:\\s*)(@?[-_a-zA-Z0-9.$]*)(?:\\s*)([\\]\\)]{1,2})",
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.ng-binding-name.begin.html"
+            },
+            "2": {
+              "patterns": [
+                {
+                  "match": "\\.",
+                  "name": "punctuation.accessor.html"
+                }
+              ]
+            },
+            "3": {
+              "name": "punctuation.definition.ng-binding-name.end.html"
+            }
+          }
+        }
+      ]
     }
   }
 }

--- a/syntaxes/template.json
+++ b/syntaxes/template.json
@@ -38,7 +38,7 @@
           "name": "punctuation.definition.ng-binding.begin.html"
         },
         "2": {
-          "name": "entity.other.attribute.html entity.other.ng-binding.html",
+          "name": "entity.other.attribute-name.html entity.other.ng-binding-name.html",
           "patterns": [
             {
               "match": "\\.",

--- a/syntaxes/template.json
+++ b/syntaxes/template.json
@@ -32,12 +32,15 @@
     },
 
     "ngBinding": {
-      "begin": "([\\[\\(]{1,2})(?:\\s*)(@?[-_a-zA-Z0-9.$]*)(?:\\s*)([\\]\\)]{1,2})(=)([\"'])",
+      "begin": "(([\\[\\(]{1,2})(?:\\s*)(@?[-_a-zA-Z0-9.$]*)(?:\\s*)([\\]\\)]{1,2}))(=)([\"'])",
       "beginCaptures": {
         "1": {
-          "name": "punctuation.definition.ng-binding-name.begin.html"
+          "name": "entity.other.attribute-name.html entity.other.ng-binding-name.html"
         },
         "2": {
+          "name": "punctuation.definition.ng-binding-name.begin.html"
+        },
+        "3": {
           "name": "entity.other.attribute-name.html entity.other.ng-binding-name.html",
           "patterns": [
             {
@@ -46,17 +49,17 @@
             }
           ]
         },
-        "3": {
+        "4": {
           "name": "punctuation.definition.ng-binding-name.end.html"
         },
-        "4": {
+        "5": {
           "name": "punctuation.separator.key-value.html"
         },
-        "5": {
+        "6": {
           "name": "string.quoted.html punctuation.definition.string.begin.html"
         }
       },
-      "end": "\\5",
+      "end": "\\6",
       "endCaptures": {
         "0": {
           "name": "string.quoted.html punctuation.definition.string.end.html"

--- a/syntaxes/template.json
+++ b/syntaxes/template.json
@@ -6,7 +6,7 @@
       "include": "#interpolation"
     },
     {
-      "include": "#propertyBinding"
+      "include": "#ngBinding"
     }
   ],
   "repository": {
@@ -31,25 +31,38 @@
       ]
     },
 
-    "propertyBinding": {
-      "begin": "(\\[.*\\])(=)(\"|')",
+    "ngBinding": {
+      "begin": "([\\[\\(]{1,2})(@?[-_a-zA-Z0-9.$]*)([\\]\\)]{1,2})(=)([\"'])",
       "beginCaptures": {
         "1": {
-          "name": "entity.other.attribute-name.html"
+          "name": "punctuation.definition.ng-binding.begin.html"
         },
         "2": {
-          "name": "punctuation.separator.key-value.html"
+          "name": "entity.other.attribute.html entity.other.ng-binding.html",
+          "patterns": [
+            {
+              "match": "\\.",
+              "name": "punctuation.accessor.html"
+            }
+          ]
         },
         "3": {
-          "name": "punctuation.definition.string.begin.html string.quoted.html"
+          "name": "punctuation.definition.ng-binding.end.html"
+        },
+        "4": {
+          "name": "punctuation.separator.key-value.html"
+        },
+        "5": {
+          "name": "punctuation.definition.string.begin.html"
         }
       },
-      "end": "\\3",
+      "end": "\\5",
       "endCaptures": {
         "0": {
-          "name": "punctuation.definition.string.end.html string.quoted.html"
+          "name": "punctuation.definition.string.end.html"
         }
       },
+      "name": "string.quoted.html",
       "contentName": "source.js",
       "patterns": [
         {

--- a/syntaxes/template.json
+++ b/syntaxes/template.json
@@ -35,7 +35,7 @@
       "begin": "([\\[\\(]{1,2})(?:\\s*)(@?[-_a-zA-Z0-9.$]*)(?:\\s*)([\\]\\)]{1,2})(=)([\"'])",
       "beginCaptures": {
         "1": {
-          "name": "punctuation.definition.ng-binding.begin.html"
+          "name": "punctuation.definition.ng-binding-name.begin.html"
         },
         "2": {
           "name": "entity.other.attribute-name.html entity.other.ng-binding-name.html",
@@ -47,22 +47,22 @@
           ]
         },
         "3": {
-          "name": "punctuation.definition.ng-binding.end.html"
+          "name": "punctuation.definition.ng-binding-name.end.html"
         },
         "4": {
           "name": "punctuation.separator.key-value.html"
         },
         "5": {
-          "name": "punctuation.definition.string.begin.html"
+          "name": "string.quoted.html punctuation.definition.string.begin.html"
         }
       },
       "end": "\\5",
       "endCaptures": {
         "0": {
-          "name": "punctuation.definition.string.end.html"
+          "name": "string.quoted.html punctuation.definition.string.end.html"
         }
       },
-      "name": "string.quoted.html",
+      "name": "ng-binding.html",
       "contentName": "source.js",
       "patterns": [
         {

--- a/syntaxes/test/data/template.html
+++ b/syntaxes/test/data/template.html
@@ -4,12 +4,6 @@
 <!-- Property binding test -->
 <div [ ngStyle ]="{'max-width.px': i * 2 + 5}"></div>
 
-<!-- Event binding test -->
-<button (click)="onClick($event)">Click me!</button>
-
-<!-- Two-way binding test -->
-<input [(ngModel)]="model" type="text" />
-
 <!-- Multi-line property binding test -->
 <div
     [ngClass]="[

--- a/syntaxes/test/data/template.html
+++ b/syntaxes/test/data/template.html
@@ -3,18 +3,15 @@
 
 <!-- Property binding test -->
 <div [ ngStyle ]="{'max-width.px': i * 2 + 5}"></div>
-
-<!-- Multi-line property binding test -->
-<div
-    [ngClass]="[
-        'class-one',
-        'class-two',
-        'class-three'
-    ]"
-></div>
-
-<!-- HTML attribute binding test -->
-<i
-    class="icon-library icon-{{ iconClassname }}"
-    [attr.aria-label]="iconLabel"
-></i>
+<div [ngClass]="[
+    'class-one',
+    'class-two',
+    'class-three'
+]"></div>
+<div [@animation.trigger]="val"></div>
+<img [attr.aria-label]="val" />
+<div [my-property]="val"></div>
+<div [my_property]="val"></div>
+<div [myProperty$]="val"></div>
+<div [%invalidProperty]="val"></div>
+<div [invalidProperty)="val"></div>

--- a/syntaxes/test/data/template.html
+++ b/syntaxes/test/data/template.html
@@ -3,3 +3,24 @@
 
 <!-- Property binding test -->
 <div [ ngStyle ]="{'max-width.px': i * 2 + 5}"></div>
+
+<!-- Event binding test -->
+<button (click)="onClick($event)">Click me!</button>
+
+<!-- Two-way binding test -->
+<input [(ngModel)]="model" type="text" />
+
+<!-- Multi-line property binding test -->
+<div
+    [ngClass]="[
+        'class-one',
+        'class-two',
+        'class-three'
+    ]"
+></div>
+
+<!-- HTML attribute binding test -->
+<i
+    class="icon-library icon-{{ iconClassname }}"
+    [attr.aria-label]="iconLabel"
+></i>

--- a/syntaxes/test/data/template.html.snap
+++ b/syntaxes/test/data/template.html.snap
@@ -22,32 +22,6 @@
 #                                             ^ template.ng ng-binding.html string.quoted.html punctuation.definition.string.end.html
 #                                              ^^^^^^^^ template.ng
 >
-><!-- Event binding test -->
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.ng
-><button (click)="onClick($event)">Click me!</button>
-#^^^^^^^^ template.ng
-#        ^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html punctuation.definition.ng-binding-name.begin.html
-#         ^^^^^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html
-#              ^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html punctuation.definition.ng-binding-name.end.html
-#               ^ template.ng ng-binding.html punctuation.separator.key-value.html
-#                ^ template.ng ng-binding.html string.quoted.html punctuation.definition.string.begin.html
-#                 ^^^^^^^^^^^^^^^ template.ng ng-binding.html source.js
-#                                ^ template.ng ng-binding.html string.quoted.html punctuation.definition.string.end.html
-#                                 ^^^^^^^^^^^^^^^^^^^^ template.ng
->
-><!-- Two-way binding test -->
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.ng
-><input [(ngModel)]="model" type="text" />
-#^^^^^^^ template.ng
-#       ^^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html punctuation.definition.ng-binding-name.begin.html
-#         ^^^^^^^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html
-#                ^^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html punctuation.definition.ng-binding-name.end.html
-#                  ^ template.ng ng-binding.html punctuation.separator.key-value.html
-#                   ^ template.ng ng-binding.html string.quoted.html punctuation.definition.string.begin.html
-#                    ^^^^^ template.ng ng-binding.html source.js
-#                         ^ template.ng ng-binding.html string.quoted.html punctuation.definition.string.end.html
-#                          ^^^^^^^^^^^^^^^^ template.ng
->
 ><!-- Multi-line property binding test -->
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.ng
 ><div

--- a/syntaxes/test/data/template.html.snap
+++ b/syntaxes/test/data/template.html.snap
@@ -21,52 +21,80 @@
 #                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.ng ng-binding.html source.js
 #                                             ^ template.ng ng-binding.html string.quoted.html punctuation.definition.string.end.html
 #                                              ^^^^^^^^ template.ng
->
-><!-- Multi-line property binding test -->
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.ng
-><div
+><div [ngClass]="[
 #^^^^^ template.ng
->    [ngClass]="[
-#^^^^ template.ng
-#    ^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html punctuation.definition.ng-binding-name.begin.html
-#     ^^^^^^^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html
-#            ^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html punctuation.definition.ng-binding-name.end.html
-#             ^ template.ng ng-binding.html punctuation.separator.key-value.html
-#              ^ template.ng ng-binding.html string.quoted.html punctuation.definition.string.begin.html
-#               ^^ template.ng ng-binding.html source.js
->        'class-one',
-#^^^^^^^^^^^^^^^^^^^^^ template.ng ng-binding.html source.js
->        'class-two',
-#^^^^^^^^^^^^^^^^^^^^^ template.ng ng-binding.html source.js
->        'class-three'
-#^^^^^^^^^^^^^^^^^^^^^^ template.ng ng-binding.html source.js
->    ]"
-#^^^^^ template.ng ng-binding.html source.js
-#     ^ template.ng ng-binding.html string.quoted.html punctuation.definition.string.end.html
->></div>
-#^^^^^^^^ template.ng
->
-><!-- HTML attribute binding test -->
+#     ^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html punctuation.definition.ng-binding-name.begin.html
+#      ^^^^^^^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html
+#             ^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html punctuation.definition.ng-binding-name.end.html
+#              ^ template.ng ng-binding.html punctuation.separator.key-value.html
+#               ^ template.ng ng-binding.html string.quoted.html punctuation.definition.string.begin.html
+#                ^^ template.ng ng-binding.html source.js
+>    'class-one',
+#^^^^^^^^^^^^^^^^^ template.ng ng-binding.html source.js
+>    'class-two',
+#^^^^^^^^^^^^^^^^^ template.ng ng-binding.html source.js
+>    'class-three'
+#^^^^^^^^^^^^^^^^^^ template.ng ng-binding.html source.js
+>]"></div>
+#^ template.ng ng-binding.html source.js
+# ^ template.ng ng-binding.html string.quoted.html punctuation.definition.string.end.html
+#  ^^^^^^^^ template.ng
+><div [@animation.trigger]="val"></div>
+#^^^^^ template.ng
+#     ^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html punctuation.definition.ng-binding-name.begin.html
+#      ^^^^^^^^^^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html
+#                ^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html punctuation.accessor.html
+#                 ^^^^^^^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html
+#                        ^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html punctuation.definition.ng-binding-name.end.html
+#                         ^ template.ng ng-binding.html punctuation.separator.key-value.html
+#                          ^ template.ng ng-binding.html string.quoted.html punctuation.definition.string.begin.html
+#                           ^^^ template.ng ng-binding.html source.js
+#                              ^ template.ng ng-binding.html string.quoted.html punctuation.definition.string.end.html
+#                               ^^^^^^^^ template.ng
+><img [attr.aria-label]="val" />
+#^^^^^ template.ng
+#     ^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html punctuation.definition.ng-binding-name.begin.html
+#      ^^^^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html
+#          ^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html punctuation.accessor.html
+#           ^^^^^^^^^^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html
+#                     ^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html punctuation.definition.ng-binding-name.end.html
+#                      ^ template.ng ng-binding.html punctuation.separator.key-value.html
+#                       ^ template.ng ng-binding.html string.quoted.html punctuation.definition.string.begin.html
+#                        ^^^ template.ng ng-binding.html source.js
+#                           ^ template.ng ng-binding.html string.quoted.html punctuation.definition.string.end.html
+#                            ^^^^ template.ng
+><div [my-property]="val"></div>
+#^^^^^ template.ng
+#     ^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html punctuation.definition.ng-binding-name.begin.html
+#      ^^^^^^^^^^^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html
+#                 ^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html punctuation.definition.ng-binding-name.end.html
+#                  ^ template.ng ng-binding.html punctuation.separator.key-value.html
+#                   ^ template.ng ng-binding.html string.quoted.html punctuation.definition.string.begin.html
+#                    ^^^ template.ng ng-binding.html source.js
+#                       ^ template.ng ng-binding.html string.quoted.html punctuation.definition.string.end.html
+#                        ^^^^^^^^ template.ng
+><div [my_property]="val"></div>
+#^^^^^ template.ng
+#     ^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html punctuation.definition.ng-binding-name.begin.html
+#      ^^^^^^^^^^^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html
+#                 ^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html punctuation.definition.ng-binding-name.end.html
+#                  ^ template.ng ng-binding.html punctuation.separator.key-value.html
+#                   ^ template.ng ng-binding.html string.quoted.html punctuation.definition.string.begin.html
+#                    ^^^ template.ng ng-binding.html source.js
+#                       ^ template.ng ng-binding.html string.quoted.html punctuation.definition.string.end.html
+#                        ^^^^^^^^ template.ng
+><div [myProperty$]="val"></div>
+#^^^^^ template.ng
+#     ^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html punctuation.definition.ng-binding-name.begin.html
+#      ^^^^^^^^^^^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html
+#                 ^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html punctuation.definition.ng-binding-name.end.html
+#                  ^ template.ng ng-binding.html punctuation.separator.key-value.html
+#                   ^ template.ng ng-binding.html string.quoted.html punctuation.definition.string.begin.html
+#                    ^^^ template.ng ng-binding.html source.js
+#                       ^ template.ng ng-binding.html string.quoted.html punctuation.definition.string.end.html
+#                        ^^^^^^^^ template.ng
+><div [%invalidProperty]="val"></div>
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.ng
-><i
-#^^^ template.ng
->    class="icon-library icon-{{ iconClassname }}"
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.ng
-#                             ^^ template.ng punctuation.definition.block.ts
-#                               ^^^^^^^^^^^^^^^ template.ng source.js
-#                                              ^^ template.ng punctuation.definition.block.ts
-#                                                ^^ template.ng
->    [attr.aria-label]="iconLabel"
-#^^^^ template.ng
-#    ^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html punctuation.definition.ng-binding-name.begin.html
-#     ^^^^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html
-#         ^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html punctuation.accessor.html
-#          ^^^^^^^^^^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html
-#                    ^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html punctuation.definition.ng-binding-name.end.html
-#                     ^ template.ng ng-binding.html punctuation.separator.key-value.html
-#                      ^ template.ng ng-binding.html string.quoted.html punctuation.definition.string.begin.html
-#                       ^^^^^^^^^ template.ng ng-binding.html source.js
-#                                ^ template.ng ng-binding.html string.quoted.html punctuation.definition.string.end.html
->></i>
-#^^^^^^ template.ng
+><div [invalidProperty)="val"></div>
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.ng
 >

--- a/syntaxes/test/data/template.html.snap
+++ b/syntaxes/test/data/template.html.snap
@@ -11,11 +11,11 @@
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.ng
 ><div [ ngStyle ]="{'max-width.px': i * 2 + 5}"></div>
 #^^^^^ template.ng
-#     ^ template.ng ng-binding.html punctuation.definition.ng-binding-name.begin.html
-#      ^ template.ng ng-binding.html
+#     ^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html punctuation.definition.ng-binding-name.begin.html
+#      ^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html
 #       ^^^^^^^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html
-#              ^ template.ng ng-binding.html
-#               ^ template.ng ng-binding.html punctuation.definition.ng-binding-name.end.html
+#              ^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html
+#               ^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html punctuation.definition.ng-binding-name.end.html
 #                ^ template.ng ng-binding.html punctuation.separator.key-value.html
 #                 ^ template.ng ng-binding.html string.quoted.html punctuation.definition.string.begin.html
 #                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.ng ng-binding.html source.js
@@ -26,9 +26,9 @@
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.ng
 ><button (click)="onClick($event)">Click me!</button>
 #^^^^^^^^ template.ng
-#        ^ template.ng ng-binding.html punctuation.definition.ng-binding-name.begin.html
+#        ^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html punctuation.definition.ng-binding-name.begin.html
 #         ^^^^^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html
-#              ^ template.ng ng-binding.html punctuation.definition.ng-binding-name.end.html
+#              ^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html punctuation.definition.ng-binding-name.end.html
 #               ^ template.ng ng-binding.html punctuation.separator.key-value.html
 #                ^ template.ng ng-binding.html string.quoted.html punctuation.definition.string.begin.html
 #                 ^^^^^^^^^^^^^^^ template.ng ng-binding.html source.js
@@ -39,9 +39,9 @@
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.ng
 ><input [(ngModel)]="model" type="text" />
 #^^^^^^^ template.ng
-#       ^^ template.ng ng-binding.html punctuation.definition.ng-binding-name.begin.html
+#       ^^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html punctuation.definition.ng-binding-name.begin.html
 #         ^^^^^^^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html
-#                ^^ template.ng ng-binding.html punctuation.definition.ng-binding-name.end.html
+#                ^^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html punctuation.definition.ng-binding-name.end.html
 #                  ^ template.ng ng-binding.html punctuation.separator.key-value.html
 #                   ^ template.ng ng-binding.html string.quoted.html punctuation.definition.string.begin.html
 #                    ^^^^^ template.ng ng-binding.html source.js
@@ -54,9 +54,9 @@
 #^^^^^ template.ng
 >    [ngClass]="[
 #^^^^ template.ng
-#    ^ template.ng ng-binding.html punctuation.definition.ng-binding-name.begin.html
+#    ^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html punctuation.definition.ng-binding-name.begin.html
 #     ^^^^^^^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html
-#            ^ template.ng ng-binding.html punctuation.definition.ng-binding-name.end.html
+#            ^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html punctuation.definition.ng-binding-name.end.html
 #             ^ template.ng ng-binding.html punctuation.separator.key-value.html
 #              ^ template.ng ng-binding.html string.quoted.html punctuation.definition.string.begin.html
 #               ^^ template.ng ng-binding.html source.js
@@ -84,11 +84,11 @@
 #                                                ^^ template.ng
 >    [attr.aria-label]="iconLabel"
 #^^^^ template.ng
-#    ^ template.ng ng-binding.html punctuation.definition.ng-binding-name.begin.html
+#    ^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html punctuation.definition.ng-binding-name.begin.html
 #     ^^^^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html
 #         ^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html punctuation.accessor.html
 #          ^^^^^^^^^^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html
-#                    ^ template.ng ng-binding.html punctuation.definition.ng-binding-name.end.html
+#                    ^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html punctuation.definition.ng-binding-name.end.html
 #                     ^ template.ng ng-binding.html punctuation.separator.key-value.html
 #                      ^ template.ng ng-binding.html string.quoted.html punctuation.definition.string.begin.html
 #                       ^^^^^^^^^ template.ng ng-binding.html source.js

--- a/syntaxes/test/data/template.html.snap
+++ b/syntaxes/test/data/template.html.snap
@@ -11,10 +11,88 @@
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.ng
 ><div [ ngStyle ]="{'max-width.px': i * 2 + 5}"></div>
 #^^^^^ template.ng
-#     ^^^^^^^^^^^ template.ng entity.other.attribute-name.html
-#                ^ template.ng punctuation.separator.key-value.html
-#                 ^ template.ng punctuation.definition.string.begin.html string.quoted.html
-#                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.ng source.js
-#                                             ^ template.ng punctuation.definition.string.end.html string.quoted.html
+#     ^ template.ng ng-binding.html punctuation.definition.ng-binding-name.begin.html
+#      ^ template.ng ng-binding.html
+#       ^^^^^^^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html
+#              ^ template.ng ng-binding.html
+#               ^ template.ng ng-binding.html punctuation.definition.ng-binding-name.end.html
+#                ^ template.ng ng-binding.html punctuation.separator.key-value.html
+#                 ^ template.ng ng-binding.html string.quoted.html punctuation.definition.string.begin.html
+#                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.ng ng-binding.html source.js
+#                                             ^ template.ng ng-binding.html string.quoted.html punctuation.definition.string.end.html
 #                                              ^^^^^^^^ template.ng
+>
+><!-- Event binding test -->
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.ng
+><button (click)="onClick($event)">Click me!</button>
+#^^^^^^^^ template.ng
+#        ^ template.ng ng-binding.html punctuation.definition.ng-binding-name.begin.html
+#         ^^^^^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html
+#              ^ template.ng ng-binding.html punctuation.definition.ng-binding-name.end.html
+#               ^ template.ng ng-binding.html punctuation.separator.key-value.html
+#                ^ template.ng ng-binding.html string.quoted.html punctuation.definition.string.begin.html
+#                 ^^^^^^^^^^^^^^^ template.ng ng-binding.html source.js
+#                                ^ template.ng ng-binding.html string.quoted.html punctuation.definition.string.end.html
+#                                 ^^^^^^^^^^^^^^^^^^^^ template.ng
+>
+><!-- Two-way binding test -->
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.ng
+><input [(ngModel)]="model" type="text" />
+#^^^^^^^ template.ng
+#       ^^ template.ng ng-binding.html punctuation.definition.ng-binding-name.begin.html
+#         ^^^^^^^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html
+#                ^^ template.ng ng-binding.html punctuation.definition.ng-binding-name.end.html
+#                  ^ template.ng ng-binding.html punctuation.separator.key-value.html
+#                   ^ template.ng ng-binding.html string.quoted.html punctuation.definition.string.begin.html
+#                    ^^^^^ template.ng ng-binding.html source.js
+#                         ^ template.ng ng-binding.html string.quoted.html punctuation.definition.string.end.html
+#                          ^^^^^^^^^^^^^^^^ template.ng
+>
+><!-- Multi-line property binding test -->
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.ng
+><div
+#^^^^^ template.ng
+>    [ngClass]="[
+#^^^^ template.ng
+#    ^ template.ng ng-binding.html punctuation.definition.ng-binding-name.begin.html
+#     ^^^^^^^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html
+#            ^ template.ng ng-binding.html punctuation.definition.ng-binding-name.end.html
+#             ^ template.ng ng-binding.html punctuation.separator.key-value.html
+#              ^ template.ng ng-binding.html string.quoted.html punctuation.definition.string.begin.html
+#               ^^ template.ng ng-binding.html source.js
+>        'class-one',
+#^^^^^^^^^^^^^^^^^^^^^ template.ng ng-binding.html source.js
+>        'class-two',
+#^^^^^^^^^^^^^^^^^^^^^ template.ng ng-binding.html source.js
+>        'class-three'
+#^^^^^^^^^^^^^^^^^^^^^^ template.ng ng-binding.html source.js
+>    ]"
+#^^^^^ template.ng ng-binding.html source.js
+#     ^ template.ng ng-binding.html string.quoted.html punctuation.definition.string.end.html
+>></div>
+#^^^^^^^^ template.ng
+>
+><!-- HTML attribute binding test -->
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.ng
+><i
+#^^^ template.ng
+>    class="icon-library icon-{{ iconClassname }}"
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.ng
+#                             ^^ template.ng punctuation.definition.block.ts
+#                               ^^^^^^^^^^^^^^^ template.ng source.js
+#                                              ^^ template.ng punctuation.definition.block.ts
+#                                                ^^ template.ng
+>    [attr.aria-label]="iconLabel"
+#^^^^ template.ng
+#    ^ template.ng ng-binding.html punctuation.definition.ng-binding-name.begin.html
+#     ^^^^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html
+#         ^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html punctuation.accessor.html
+#          ^^^^^^^^^^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html
+#                    ^ template.ng ng-binding.html punctuation.definition.ng-binding-name.end.html
+#                     ^ template.ng ng-binding.html punctuation.separator.key-value.html
+#                      ^ template.ng ng-binding.html string.quoted.html punctuation.definition.string.begin.html
+#                       ^^^^^^^^^ template.ng ng-binding.html source.js
+#                                ^ template.ng ng-binding.html string.quoted.html punctuation.definition.string.end.html
+>></i>
+#^^^^^^ template.ng
 >

--- a/syntaxes/test/data/template.html.snap
+++ b/syntaxes/test/data/template.html.snap
@@ -11,87 +11,87 @@
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.ng
 ><div [ ngStyle ]="{'max-width.px': i * 2 + 5}"></div>
 #^^^^^ template.ng
-#     ^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html punctuation.definition.ng-binding-name.begin.html
-#      ^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html
-#       ^^^^^^^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html
-#              ^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html
-#               ^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html punctuation.definition.ng-binding-name.end.html
-#                ^ template.ng ng-binding.html punctuation.separator.key-value.html
-#                 ^ template.ng ng-binding.html string.quoted.html punctuation.definition.string.begin.html
-#                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.ng ng-binding.html source.js
-#                                             ^ template.ng ng-binding.html string.quoted.html punctuation.definition.string.end.html
+#     ^ template.ng meta.ng-binding.property.html entity.other.attribute-name.html entity.other.ng-binding-name.property.html punctuation.definition.ng-binding-name.begin.html
+#      ^ template.ng meta.ng-binding.property.html entity.other.attribute-name.html entity.other.ng-binding-name.property.html
+#       ^^^^^^^ template.ng meta.ng-binding.property.html entity.other.attribute-name.html entity.other.ng-binding-name.property.html
+#              ^ template.ng meta.ng-binding.property.html entity.other.attribute-name.html entity.other.ng-binding-name.property.html
+#               ^ template.ng meta.ng-binding.property.html entity.other.attribute-name.html entity.other.ng-binding-name.property.html punctuation.definition.ng-binding-name.end.html
+#                ^ template.ng meta.ng-binding.property.html punctuation.separator.key-value.html
+#                 ^ template.ng meta.ng-binding.property.html string.quoted.html punctuation.definition.string.begin.html
+#                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.ng meta.ng-binding.property.html source.js
+#                                             ^ template.ng meta.ng-binding.property.html string.quoted.html punctuation.definition.string.end.html
 #                                              ^^^^^^^^ template.ng
 ><div [ngClass]="[
 #^^^^^ template.ng
-#     ^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html punctuation.definition.ng-binding-name.begin.html
-#      ^^^^^^^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html
-#             ^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html punctuation.definition.ng-binding-name.end.html
-#              ^ template.ng ng-binding.html punctuation.separator.key-value.html
-#               ^ template.ng ng-binding.html string.quoted.html punctuation.definition.string.begin.html
-#                ^^ template.ng ng-binding.html source.js
+#     ^ template.ng meta.ng-binding.property.html entity.other.attribute-name.html entity.other.ng-binding-name.property.html punctuation.definition.ng-binding-name.begin.html
+#      ^^^^^^^ template.ng meta.ng-binding.property.html entity.other.attribute-name.html entity.other.ng-binding-name.property.html
+#             ^ template.ng meta.ng-binding.property.html entity.other.attribute-name.html entity.other.ng-binding-name.property.html punctuation.definition.ng-binding-name.end.html
+#              ^ template.ng meta.ng-binding.property.html punctuation.separator.key-value.html
+#               ^ template.ng meta.ng-binding.property.html string.quoted.html punctuation.definition.string.begin.html
+#                ^^ template.ng meta.ng-binding.property.html source.js
 >    'class-one',
-#^^^^^^^^^^^^^^^^^ template.ng ng-binding.html source.js
+#^^^^^^^^^^^^^^^^^ template.ng meta.ng-binding.property.html source.js
 >    'class-two',
-#^^^^^^^^^^^^^^^^^ template.ng ng-binding.html source.js
+#^^^^^^^^^^^^^^^^^ template.ng meta.ng-binding.property.html source.js
 >    'class-three'
-#^^^^^^^^^^^^^^^^^^ template.ng ng-binding.html source.js
+#^^^^^^^^^^^^^^^^^^ template.ng meta.ng-binding.property.html source.js
 >]"></div>
-#^ template.ng ng-binding.html source.js
-# ^ template.ng ng-binding.html string.quoted.html punctuation.definition.string.end.html
+#^ template.ng meta.ng-binding.property.html source.js
+# ^ template.ng meta.ng-binding.property.html string.quoted.html punctuation.definition.string.end.html
 #  ^^^^^^^^ template.ng
 ><div [@animation.trigger]="val"></div>
 #^^^^^ template.ng
-#     ^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html punctuation.definition.ng-binding-name.begin.html
-#      ^^^^^^^^^^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html
-#                ^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html punctuation.accessor.html
-#                 ^^^^^^^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html
-#                        ^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html punctuation.definition.ng-binding-name.end.html
-#                         ^ template.ng ng-binding.html punctuation.separator.key-value.html
-#                          ^ template.ng ng-binding.html string.quoted.html punctuation.definition.string.begin.html
-#                           ^^^ template.ng ng-binding.html source.js
-#                              ^ template.ng ng-binding.html string.quoted.html punctuation.definition.string.end.html
+#     ^ template.ng meta.ng-binding.property.html entity.other.attribute-name.html entity.other.ng-binding-name.property.html punctuation.definition.ng-binding-name.begin.html
+#      ^^^^^^^^^^ template.ng meta.ng-binding.property.html entity.other.attribute-name.html entity.other.ng-binding-name.property.html
+#                ^ template.ng meta.ng-binding.property.html entity.other.attribute-name.html entity.other.ng-binding-name.property.html punctuation.accessor.html
+#                 ^^^^^^^ template.ng meta.ng-binding.property.html entity.other.attribute-name.html entity.other.ng-binding-name.property.html
+#                        ^ template.ng meta.ng-binding.property.html entity.other.attribute-name.html entity.other.ng-binding-name.property.html punctuation.definition.ng-binding-name.end.html
+#                         ^ template.ng meta.ng-binding.property.html punctuation.separator.key-value.html
+#                          ^ template.ng meta.ng-binding.property.html string.quoted.html punctuation.definition.string.begin.html
+#                           ^^^ template.ng meta.ng-binding.property.html source.js
+#                              ^ template.ng meta.ng-binding.property.html string.quoted.html punctuation.definition.string.end.html
 #                               ^^^^^^^^ template.ng
 ><img [attr.aria-label]="val" />
 #^^^^^ template.ng
-#     ^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html punctuation.definition.ng-binding-name.begin.html
-#      ^^^^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html
-#          ^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html punctuation.accessor.html
-#           ^^^^^^^^^^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html
-#                     ^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html punctuation.definition.ng-binding-name.end.html
-#                      ^ template.ng ng-binding.html punctuation.separator.key-value.html
-#                       ^ template.ng ng-binding.html string.quoted.html punctuation.definition.string.begin.html
-#                        ^^^ template.ng ng-binding.html source.js
-#                           ^ template.ng ng-binding.html string.quoted.html punctuation.definition.string.end.html
+#     ^ template.ng meta.ng-binding.property.html entity.other.attribute-name.html entity.other.ng-binding-name.property.html punctuation.definition.ng-binding-name.begin.html
+#      ^^^^ template.ng meta.ng-binding.property.html entity.other.attribute-name.html entity.other.ng-binding-name.property.html
+#          ^ template.ng meta.ng-binding.property.html entity.other.attribute-name.html entity.other.ng-binding-name.property.html punctuation.accessor.html
+#           ^^^^^^^^^^ template.ng meta.ng-binding.property.html entity.other.attribute-name.html entity.other.ng-binding-name.property.html
+#                     ^ template.ng meta.ng-binding.property.html entity.other.attribute-name.html entity.other.ng-binding-name.property.html punctuation.definition.ng-binding-name.end.html
+#                      ^ template.ng meta.ng-binding.property.html punctuation.separator.key-value.html
+#                       ^ template.ng meta.ng-binding.property.html string.quoted.html punctuation.definition.string.begin.html
+#                        ^^^ template.ng meta.ng-binding.property.html source.js
+#                           ^ template.ng meta.ng-binding.property.html string.quoted.html punctuation.definition.string.end.html
 #                            ^^^^ template.ng
 ><div [my-property]="val"></div>
 #^^^^^ template.ng
-#     ^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html punctuation.definition.ng-binding-name.begin.html
-#      ^^^^^^^^^^^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html
-#                 ^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html punctuation.definition.ng-binding-name.end.html
-#                  ^ template.ng ng-binding.html punctuation.separator.key-value.html
-#                   ^ template.ng ng-binding.html string.quoted.html punctuation.definition.string.begin.html
-#                    ^^^ template.ng ng-binding.html source.js
-#                       ^ template.ng ng-binding.html string.quoted.html punctuation.definition.string.end.html
+#     ^ template.ng meta.ng-binding.property.html entity.other.attribute-name.html entity.other.ng-binding-name.property.html punctuation.definition.ng-binding-name.begin.html
+#      ^^^^^^^^^^^ template.ng meta.ng-binding.property.html entity.other.attribute-name.html entity.other.ng-binding-name.property.html
+#                 ^ template.ng meta.ng-binding.property.html entity.other.attribute-name.html entity.other.ng-binding-name.property.html punctuation.definition.ng-binding-name.end.html
+#                  ^ template.ng meta.ng-binding.property.html punctuation.separator.key-value.html
+#                   ^ template.ng meta.ng-binding.property.html string.quoted.html punctuation.definition.string.begin.html
+#                    ^^^ template.ng meta.ng-binding.property.html source.js
+#                       ^ template.ng meta.ng-binding.property.html string.quoted.html punctuation.definition.string.end.html
 #                        ^^^^^^^^ template.ng
 ><div [my_property]="val"></div>
 #^^^^^ template.ng
-#     ^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html punctuation.definition.ng-binding-name.begin.html
-#      ^^^^^^^^^^^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html
-#                 ^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html punctuation.definition.ng-binding-name.end.html
-#                  ^ template.ng ng-binding.html punctuation.separator.key-value.html
-#                   ^ template.ng ng-binding.html string.quoted.html punctuation.definition.string.begin.html
-#                    ^^^ template.ng ng-binding.html source.js
-#                       ^ template.ng ng-binding.html string.quoted.html punctuation.definition.string.end.html
+#     ^ template.ng meta.ng-binding.property.html entity.other.attribute-name.html entity.other.ng-binding-name.property.html punctuation.definition.ng-binding-name.begin.html
+#      ^^^^^^^^^^^ template.ng meta.ng-binding.property.html entity.other.attribute-name.html entity.other.ng-binding-name.property.html
+#                 ^ template.ng meta.ng-binding.property.html entity.other.attribute-name.html entity.other.ng-binding-name.property.html punctuation.definition.ng-binding-name.end.html
+#                  ^ template.ng meta.ng-binding.property.html punctuation.separator.key-value.html
+#                   ^ template.ng meta.ng-binding.property.html string.quoted.html punctuation.definition.string.begin.html
+#                    ^^^ template.ng meta.ng-binding.property.html source.js
+#                       ^ template.ng meta.ng-binding.property.html string.quoted.html punctuation.definition.string.end.html
 #                        ^^^^^^^^ template.ng
 ><div [myProperty$]="val"></div>
 #^^^^^ template.ng
-#     ^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html punctuation.definition.ng-binding-name.begin.html
-#      ^^^^^^^^^^^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html
-#                 ^ template.ng ng-binding.html entity.other.attribute-name.html entity.other.ng-binding-name.html punctuation.definition.ng-binding-name.end.html
-#                  ^ template.ng ng-binding.html punctuation.separator.key-value.html
-#                   ^ template.ng ng-binding.html string.quoted.html punctuation.definition.string.begin.html
-#                    ^^^ template.ng ng-binding.html source.js
-#                       ^ template.ng ng-binding.html string.quoted.html punctuation.definition.string.end.html
+#     ^ template.ng meta.ng-binding.property.html entity.other.attribute-name.html entity.other.ng-binding-name.property.html punctuation.definition.ng-binding-name.begin.html
+#      ^^^^^^^^^^^ template.ng meta.ng-binding.property.html entity.other.attribute-name.html entity.other.ng-binding-name.property.html
+#                 ^ template.ng meta.ng-binding.property.html entity.other.attribute-name.html entity.other.ng-binding-name.property.html punctuation.definition.ng-binding-name.end.html
+#                  ^ template.ng meta.ng-binding.property.html punctuation.separator.key-value.html
+#                   ^ template.ng meta.ng-binding.property.html string.quoted.html punctuation.definition.string.begin.html
+#                    ^^^ template.ng meta.ng-binding.property.html source.js
+#                       ^ template.ng meta.ng-binding.property.html string.quoted.html punctuation.definition.string.end.html
 #                        ^^^^^^^^ template.ng
 ><div [%invalidProperty]="val"></div>
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.ng


### PR DESCRIPTION
#### Changes:
- Strictly defined characters in the attribute name pattern (fixes #539)
- Reversed the order of `string.quoted.html` and `punctuation.definition.string.begin/end.html` scopes (TM grammar scopes go from less specific on the left to more specific on the right)

#### Additions:
- **Angular bindings** given a unique scope (`ng-binding.html`) — this scope covers the entire key/value pair, analogous to the HTML grammar's `meta.attribute.<attribute-name>.html` scope
- **Angular binding attribute names** given a unique scope in addition to `entity.other.attribute-name.html` (`entity.other.ng-binding-name.html`) — this scope covers the entire _key_, including punctuation
- **Punctuation** in Angular binding keys given unique scopes:
    - **Brackets and parens** get `punctuation.definition.ng-binding-name.begin/end.html` scopes
    - **Dots** in the attribute name get `punctuation.accessor.html` scope
- Updated template snapshots and added test cases to cover all the changes made above