### PR TITLE
feat: textmate grammar for template event bindings

### DIFF
--- a/syntaxes/template.json
+++ b/syntaxes/template.json
@@ -65,7 +65,7 @@
           "include": "source.js"
         }
       ]
-		},
+    },
 
     "eventBinding": {
       "begin": "(\\(\\s*@?[-_a-zA-Z0-9.$]*\\s*\\))(=)([\"'])",

--- a/syntaxes/template.json
+++ b/syntaxes/template.json
@@ -7,6 +7,9 @@
     },
     {
       "include": "#propertyBinding"
+    },
+    {
+      "include": "#eventBinding"
     }
   ],
   "repository": {
@@ -56,6 +59,39 @@
         }
       },
       "name": "meta.ng-binding.property.html",
+      "contentName": "source.js",
+      "patterns": [
+        {
+          "include": "source.js"
+        }
+      ]
+		},
+
+    "eventBinding": {
+      "begin": "(\\(\\s*@?[-_a-zA-Z0-9.$]*\\s*\\))(=)([\"'])",
+      "beginCaptures": {
+        "1": {
+          "name": "entity.other.attribute-name.html entity.other.ng-binding-name.event.html",
+          "patterns": [
+            {
+              "include": "#bindingKey"
+            }
+          ]
+        },
+        "2": {
+          "name": "punctuation.separator.key-value.html"
+        },
+        "3": {
+          "name": "string.quoted.html punctuation.definition.string.begin.html"
+        }
+      },
+      "end": "\\3",
+      "endCaptures": {
+        "0": {
+          "name": "string.quoted.html punctuation.definition.string.end.html"
+        }
+      },
+      "name": "meta.ng-binding.event.html",
       "contentName": "source.js",
       "patterns": [
         {

--- a/syntaxes/test/data/template.html
+++ b/syntaxes/test/data/template.html
@@ -18,7 +18,7 @@
 
 <!-- Event binding test -->
 <button (click)="onClick($event)"></button>
-<input [ngModel]="model" (ngModelChange)="onModelChange($event)" />
+<input (ngModelChange)="onModelChange($event)" />
 <div (@animation.done)="onAnimationDone($event)"></div>
 <div (someEvent)="
     if (isCondition) {

--- a/syntaxes/test/data/template.html
+++ b/syntaxes/test/data/template.html
@@ -15,3 +15,22 @@
 <div [myProperty$]="val"></div>
 <div [%invalidProperty]="val"></div>
 <div [invalidProperty)="val"></div>
+
+<!-- Event binding test -->
+<button (click)="onClick($event)"></button>
+<input [ngModel]="model" (ngModelChange)="onModelChange($event)" />
+<div (@animation.done)="onAnimationDone($event)"></div>
+<div (someEvent)="
+    if (isCondition) {
+        methodIfTrue($event);
+    } else {
+        methodIfFalse($event);
+    }
+"></div>
+<div ( extraSpacing )="onExtraSpacing($event)"></div>
+<my-component (myEvent)="onMyEvent($event)"></my-component>
+<my-component (my-event)="onMyEvent($event)"></my-component>
+<my-component (my_event)="onMyEvent($event)"></my-component>
+<my-component (myEvent$)="onMyEvent($event)"></my-component>
+<my-component (%invalidEvent)="onMyEvent($event)"></my-component>
+<my-component (invalidEvent]="onMyEvent($event)"></my-component>

--- a/syntaxes/test/data/template.html.snap
+++ b/syntaxes/test/data/template.html.snap
@@ -110,24 +110,16 @@
 #                 ^^^^^^^^^^^^^^^ template.ng meta.ng-binding.event.html source.js
 #                                ^ template.ng meta.ng-binding.event.html string.quoted.html punctuation.definition.string.end.html
 #                                 ^^^^^^^^^^^ template.ng
-><input [ngModel]="model" (ngModelChange)="onModelChange($event)" />
+><input (ngModelChange)="onModelChange($event)" />
 #^^^^^^^ template.ng
-#       ^ template.ng meta.ng-binding.property.html entity.other.attribute-name.html entity.other.ng-binding-name.property.html punctuation.definition.ng-binding-name.begin.html
-#        ^^^^^^^ template.ng meta.ng-binding.property.html entity.other.attribute-name.html entity.other.ng-binding-name.property.html
-#               ^ template.ng meta.ng-binding.property.html entity.other.attribute-name.html entity.other.ng-binding-name.property.html punctuation.definition.ng-binding-name.end.html
-#                ^ template.ng meta.ng-binding.property.html punctuation.separator.key-value.html
-#                 ^ template.ng meta.ng-binding.property.html string.quoted.html punctuation.definition.string.begin.html
-#                  ^^^^^ template.ng meta.ng-binding.property.html source.js
-#                       ^ template.ng meta.ng-binding.property.html string.quoted.html punctuation.definition.string.end.html
-#                        ^ template.ng
-#                         ^ template.ng meta.ng-binding.event.html entity.other.attribute-name.html entity.other.ng-binding-name.event.html punctuation.definition.ng-binding-name.begin.html
-#                          ^^^^^^^^^^^^^ template.ng meta.ng-binding.event.html entity.other.attribute-name.html entity.other.ng-binding-name.event.html
-#                                       ^ template.ng meta.ng-binding.event.html entity.other.attribute-name.html entity.other.ng-binding-name.event.html punctuation.definition.ng-binding-name.end.html
-#                                        ^ template.ng meta.ng-binding.event.html punctuation.separator.key-value.html
-#                                         ^ template.ng meta.ng-binding.event.html string.quoted.html punctuation.definition.string.begin.html
-#                                          ^^^^^^^^^^^^^^^^^^^^^ template.ng meta.ng-binding.event.html source.js
-#                                                               ^ template.ng meta.ng-binding.event.html string.quoted.html punctuation.definition.string.end.html
-#                                                                ^^^^ template.ng
+#       ^ template.ng meta.ng-binding.event.html entity.other.attribute-name.html entity.other.ng-binding-name.event.html punctuation.definition.ng-binding-name.begin.html
+#        ^^^^^^^^^^^^^ template.ng meta.ng-binding.event.html entity.other.attribute-name.html entity.other.ng-binding-name.event.html
+#                     ^ template.ng meta.ng-binding.event.html entity.other.attribute-name.html entity.other.ng-binding-name.event.html punctuation.definition.ng-binding-name.end.html
+#                      ^ template.ng meta.ng-binding.event.html punctuation.separator.key-value.html
+#                       ^ template.ng meta.ng-binding.event.html string.quoted.html punctuation.definition.string.begin.html
+#                        ^^^^^^^^^^^^^^^^^^^^^ template.ng meta.ng-binding.event.html source.js
+#                                             ^ template.ng meta.ng-binding.event.html string.quoted.html punctuation.definition.string.end.html
+#                                              ^^^^ template.ng
 ><div (@animation.done)="onAnimationDone($event)"></div>
 #^^^^^ template.ng
 #     ^ template.ng meta.ng-binding.event.html entity.other.attribute-name.html entity.other.ng-binding-name.event.html punctuation.definition.ng-binding-name.begin.html

--- a/syntaxes/test/data/template.html.snap
+++ b/syntaxes/test/data/template.html.snap
@@ -98,3 +98,121 @@
 ><div [invalidProperty)="val"></div>
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.ng
 >
+><!-- Event binding test -->
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.ng
+><button (click)="onClick($event)"></button>
+#^^^^^^^^ template.ng
+#        ^ template.ng meta.ng-binding.event.html entity.other.attribute-name.html entity.other.ng-binding-name.event.html punctuation.definition.ng-binding-name.begin.html
+#         ^^^^^ template.ng meta.ng-binding.event.html entity.other.attribute-name.html entity.other.ng-binding-name.event.html
+#              ^ template.ng meta.ng-binding.event.html entity.other.attribute-name.html entity.other.ng-binding-name.event.html punctuation.definition.ng-binding-name.end.html
+#               ^ template.ng meta.ng-binding.event.html punctuation.separator.key-value.html
+#                ^ template.ng meta.ng-binding.event.html string.quoted.html punctuation.definition.string.begin.html
+#                 ^^^^^^^^^^^^^^^ template.ng meta.ng-binding.event.html source.js
+#                                ^ template.ng meta.ng-binding.event.html string.quoted.html punctuation.definition.string.end.html
+#                                 ^^^^^^^^^^^ template.ng
+><input [ngModel]="model" (ngModelChange)="onModelChange($event)" />
+#^^^^^^^ template.ng
+#       ^ template.ng meta.ng-binding.property.html entity.other.attribute-name.html entity.other.ng-binding-name.property.html punctuation.definition.ng-binding-name.begin.html
+#        ^^^^^^^ template.ng meta.ng-binding.property.html entity.other.attribute-name.html entity.other.ng-binding-name.property.html
+#               ^ template.ng meta.ng-binding.property.html entity.other.attribute-name.html entity.other.ng-binding-name.property.html punctuation.definition.ng-binding-name.end.html
+#                ^ template.ng meta.ng-binding.property.html punctuation.separator.key-value.html
+#                 ^ template.ng meta.ng-binding.property.html string.quoted.html punctuation.definition.string.begin.html
+#                  ^^^^^ template.ng meta.ng-binding.property.html source.js
+#                       ^ template.ng meta.ng-binding.property.html string.quoted.html punctuation.definition.string.end.html
+#                        ^ template.ng
+#                         ^ template.ng meta.ng-binding.event.html entity.other.attribute-name.html entity.other.ng-binding-name.event.html punctuation.definition.ng-binding-name.begin.html
+#                          ^^^^^^^^^^^^^ template.ng meta.ng-binding.event.html entity.other.attribute-name.html entity.other.ng-binding-name.event.html
+#                                       ^ template.ng meta.ng-binding.event.html entity.other.attribute-name.html entity.other.ng-binding-name.event.html punctuation.definition.ng-binding-name.end.html
+#                                        ^ template.ng meta.ng-binding.event.html punctuation.separator.key-value.html
+#                                         ^ template.ng meta.ng-binding.event.html string.quoted.html punctuation.definition.string.begin.html
+#                                          ^^^^^^^^^^^^^^^^^^^^^ template.ng meta.ng-binding.event.html source.js
+#                                                               ^ template.ng meta.ng-binding.event.html string.quoted.html punctuation.definition.string.end.html
+#                                                                ^^^^ template.ng
+><div (@animation.done)="onAnimationDone($event)"></div>
+#^^^^^ template.ng
+#     ^ template.ng meta.ng-binding.event.html entity.other.attribute-name.html entity.other.ng-binding-name.event.html punctuation.definition.ng-binding-name.begin.html
+#      ^^^^^^^^^^ template.ng meta.ng-binding.event.html entity.other.attribute-name.html entity.other.ng-binding-name.event.html
+#                ^ template.ng meta.ng-binding.event.html entity.other.attribute-name.html entity.other.ng-binding-name.event.html punctuation.accessor.html
+#                 ^^^^ template.ng meta.ng-binding.event.html entity.other.attribute-name.html entity.other.ng-binding-name.event.html
+#                     ^ template.ng meta.ng-binding.event.html entity.other.attribute-name.html entity.other.ng-binding-name.event.html punctuation.definition.ng-binding-name.end.html
+#                      ^ template.ng meta.ng-binding.event.html punctuation.separator.key-value.html
+#                       ^ template.ng meta.ng-binding.event.html string.quoted.html punctuation.definition.string.begin.html
+#                        ^^^^^^^^^^^^^^^^^^^^^^^ template.ng meta.ng-binding.event.html source.js
+#                                               ^ template.ng meta.ng-binding.event.html string.quoted.html punctuation.definition.string.end.html
+#                                                ^^^^^^^^ template.ng
+><div (someEvent)="
+#^^^^^ template.ng
+#     ^ template.ng meta.ng-binding.event.html entity.other.attribute-name.html entity.other.ng-binding-name.event.html punctuation.definition.ng-binding-name.begin.html
+#      ^^^^^^^^^ template.ng meta.ng-binding.event.html entity.other.attribute-name.html entity.other.ng-binding-name.event.html
+#               ^ template.ng meta.ng-binding.event.html entity.other.attribute-name.html entity.other.ng-binding-name.event.html punctuation.definition.ng-binding-name.end.html
+#                ^ template.ng meta.ng-binding.event.html punctuation.separator.key-value.html
+#                 ^ template.ng meta.ng-binding.event.html string.quoted.html punctuation.definition.string.begin.html
+>    if (isCondition) {
+#^^^^^^^^^^^^^^^^^^^^^^^ template.ng meta.ng-binding.event.html source.js
+>        methodIfTrue($event);
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.ng meta.ng-binding.event.html source.js
+>    } else {
+#^^^^^^^^^^^^^ template.ng meta.ng-binding.event.html source.js
+>        methodIfFalse($event);
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.ng meta.ng-binding.event.html source.js
+>    }
+#^^^^^^ template.ng meta.ng-binding.event.html source.js
+>"></div>
+#^ template.ng meta.ng-binding.event.html string.quoted.html punctuation.definition.string.end.html
+# ^^^^^^^^ template.ng
+><div ( extraSpacing )="onExtraSpacing($event)"></div>
+#^^^^^ template.ng
+#     ^ template.ng meta.ng-binding.event.html entity.other.attribute-name.html entity.other.ng-binding-name.event.html punctuation.definition.ng-binding-name.begin.html
+#      ^ template.ng meta.ng-binding.event.html entity.other.attribute-name.html entity.other.ng-binding-name.event.html
+#       ^^^^^^^^^^^^ template.ng meta.ng-binding.event.html entity.other.attribute-name.html entity.other.ng-binding-name.event.html
+#                   ^ template.ng meta.ng-binding.event.html entity.other.attribute-name.html entity.other.ng-binding-name.event.html
+#                    ^ template.ng meta.ng-binding.event.html entity.other.attribute-name.html entity.other.ng-binding-name.event.html punctuation.definition.ng-binding-name.end.html
+#                     ^ template.ng meta.ng-binding.event.html punctuation.separator.key-value.html
+#                      ^ template.ng meta.ng-binding.event.html string.quoted.html punctuation.definition.string.begin.html
+#                       ^^^^^^^^^^^^^^^^^^^^^^ template.ng meta.ng-binding.event.html source.js
+#                                             ^ template.ng meta.ng-binding.event.html string.quoted.html punctuation.definition.string.end.html
+#                                              ^^^^^^^^ template.ng
+><my-component (myEvent)="onMyEvent($event)"></my-component>
+#^^^^^^^^^^^^^^ template.ng
+#              ^ template.ng meta.ng-binding.event.html entity.other.attribute-name.html entity.other.ng-binding-name.event.html punctuation.definition.ng-binding-name.begin.html
+#               ^^^^^^^ template.ng meta.ng-binding.event.html entity.other.attribute-name.html entity.other.ng-binding-name.event.html
+#                      ^ template.ng meta.ng-binding.event.html entity.other.attribute-name.html entity.other.ng-binding-name.event.html punctuation.definition.ng-binding-name.end.html
+#                       ^ template.ng meta.ng-binding.event.html punctuation.separator.key-value.html
+#                        ^ template.ng meta.ng-binding.event.html string.quoted.html punctuation.definition.string.begin.html
+#                         ^^^^^^^^^^^^^^^^^ template.ng meta.ng-binding.event.html source.js
+#                                          ^ template.ng meta.ng-binding.event.html string.quoted.html punctuation.definition.string.end.html
+#                                           ^^^^^^^^^^^^^^^^^ template.ng
+><my-component (my-event)="onMyEvent($event)"></my-component>
+#^^^^^^^^^^^^^^ template.ng
+#              ^ template.ng meta.ng-binding.event.html entity.other.attribute-name.html entity.other.ng-binding-name.event.html punctuation.definition.ng-binding-name.begin.html
+#               ^^^^^^^^ template.ng meta.ng-binding.event.html entity.other.attribute-name.html entity.other.ng-binding-name.event.html
+#                       ^ template.ng meta.ng-binding.event.html entity.other.attribute-name.html entity.other.ng-binding-name.event.html punctuation.definition.ng-binding-name.end.html
+#                        ^ template.ng meta.ng-binding.event.html punctuation.separator.key-value.html
+#                         ^ template.ng meta.ng-binding.event.html string.quoted.html punctuation.definition.string.begin.html
+#                          ^^^^^^^^^^^^^^^^^ template.ng meta.ng-binding.event.html source.js
+#                                           ^ template.ng meta.ng-binding.event.html string.quoted.html punctuation.definition.string.end.html
+#                                            ^^^^^^^^^^^^^^^^^ template.ng
+><my-component (my_event)="onMyEvent($event)"></my-component>
+#^^^^^^^^^^^^^^ template.ng
+#              ^ template.ng meta.ng-binding.event.html entity.other.attribute-name.html entity.other.ng-binding-name.event.html punctuation.definition.ng-binding-name.begin.html
+#               ^^^^^^^^ template.ng meta.ng-binding.event.html entity.other.attribute-name.html entity.other.ng-binding-name.event.html
+#                       ^ template.ng meta.ng-binding.event.html entity.other.attribute-name.html entity.other.ng-binding-name.event.html punctuation.definition.ng-binding-name.end.html
+#                        ^ template.ng meta.ng-binding.event.html punctuation.separator.key-value.html
+#                         ^ template.ng meta.ng-binding.event.html string.quoted.html punctuation.definition.string.begin.html
+#                          ^^^^^^^^^^^^^^^^^ template.ng meta.ng-binding.event.html source.js
+#                                           ^ template.ng meta.ng-binding.event.html string.quoted.html punctuation.definition.string.end.html
+#                                            ^^^^^^^^^^^^^^^^^ template.ng
+><my-component (myEvent$)="onMyEvent($event)"></my-component>
+#^^^^^^^^^^^^^^ template.ng
+#              ^ template.ng meta.ng-binding.event.html entity.other.attribute-name.html entity.other.ng-binding-name.event.html punctuation.definition.ng-binding-name.begin.html
+#               ^^^^^^^^ template.ng meta.ng-binding.event.html entity.other.attribute-name.html entity.other.ng-binding-name.event.html
+#                       ^ template.ng meta.ng-binding.event.html entity.other.attribute-name.html entity.other.ng-binding-name.event.html punctuation.definition.ng-binding-name.end.html
+#                        ^ template.ng meta.ng-binding.event.html punctuation.separator.key-value.html
+#                         ^ template.ng meta.ng-binding.event.html string.quoted.html punctuation.definition.string.begin.html
+#                          ^^^^^^^^^^^^^^^^^ template.ng meta.ng-binding.event.html source.js
+#                                           ^ template.ng meta.ng-binding.event.html string.quoted.html punctuation.definition.string.end.html
+#                                            ^^^^^^^^^^^^^^^^^ template.ng
+><my-component (%invalidEvent)="onMyEvent($event)"></my-component>
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.ng
+><my-component (invalidEvent]="onMyEvent($event)"></my-component>
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.ng


### PR DESCRIPTION
This PR adds TextMate grammar scopes for event binding syntax in Angular templates — identical to the property binding syntax but with scope names changed where appropriate. (Partially addresses #483)

Changes from the default HTML grammar:
- The entire attribute key-value pair gets the scope `meta.ng-binding.event.html`
- The attribute key (inlcluding punctuation) gets `entity.other.ng-binding-name.event.html` (in addition to `entity.other.attribute-name.html` as a fallback)
- Parens in the attribute key get `punctuation.definition.ng-binding.begin/end.html`
- Dots in the attribute key get `punctuation.accessor.html`
- The attribute value is parsed as embedded JavaScript

Screenshot with the default VS Code Dark theme:

![image](https://user-images.githubusercontent.com/13191586/72308594-cb07fe80-364a-11ea-8cdd-6fdf01b139ce.png)

And with a custom theme designed to support the scopes:

![image](https://user-images.githubusercontent.com/13191586/72308646-e115bf00-364a-11ea-9a62-1fe4f5e2a252.png)