### PR TITLE
build: upgrade typescript to 3.7.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "test:syntaxes": "yarn compile:syntaxes-test && jasmine syntaxes/test/driver.js"
   },
   "dependencies": {
-    "typescript": "~3.6.4"
+    "typescript": "~3.7.4"
   },
   "devDependencies": {
     "@types/jasmine": "3.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1131,10 +1131,10 @@ typed-rest-client@1.2.0:
     tunnel "0.0.4"
     underscore "1.8.3"
 
-typescript@~3.6.4:
-  version "3.6.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.4.tgz#b18752bb3792bc1a0281335f7f6ebf1bbfc5b91d"
-  integrity sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==
+typescript@~3.7.4:
+  version "3.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.4.tgz#1743a5ec5fef6a1fa9f3e4708e33c81c73876c19"
+  integrity sha512-A25xv5XCtarLwXpcDNZzCGvW2D1S3/bACratYBx2sax8PefsFhlYmkQicKHvpYflFS8if4zne5zT5kpJ7pzuvw==
 
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"


### PR DESCRIPTION
https://github.com/angular/angular/pull/33717 upgraded Angular monorepo
to TypeScript 3.7.4, so we could now upgrade to ts 3.7

This would fix the error with "no config file found for *.html" if no
TypeScript file is open.

PR closes https://github.com/angular/vscode-ng-language-service/issues/546