### PR TITLE
feat: Prioritize workspace version when resolving ts and ng

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -92,13 +92,13 @@ function getProbeLocations(configValue: string|null, bundled: string): string[] 
   if (configValue) {
     locations.push(configValue);
   }
-  // If not, look in workspaces currently open
+  // Prioritize the bundled version
+  locations.push(bundled);
+  // Look in workspaces currently open
   const workspaceFolders = vscode.workspace.workspaceFolders || [];
   for (const folder of workspaceFolders) {
     locations.push(folder.uri.fsPath);
   }
-  // If all else fails, load the bundled version
-  locations.push(bundled);
   return locations;
 }
 


### PR DESCRIPTION
This commit refactors the client code to priortize the bundled version
over workspace version when resolving both typescript and
`@angular/language-service`.
This is important for good user experience so that users automatically
get the latest version that's thoroughly tested when they upgrade the
extension.

For a complete reasoning of the work and follow up discussion see
https://github.com/angular/vscode-ng-language-service/issues/556