### PR TITLE
fix: check that a language service exists for discovered projects

### DIFF
--- a/server/src/project_service.ts
+++ b/server/src/project_service.ts
@@ -116,4 +116,14 @@ export class ProjectService {
 
     return project;
   }
+
+  /**
+   * Returns a language service for a default project created for the specified `scriptInfo`. If the
+   * project does not support a language service, nothing is returned.
+   */
+  getDefaultLanguageService(scriptInfo: ts.server.ScriptInfo): ts.LanguageService|undefined {
+    const project = this.getDefaultProjectForScriptInfo(scriptInfo);
+    if (!project?.languageServiceEnabled) return;
+    return project.getLanguageService();
+  }
 }

--- a/server/src/session.ts
+++ b/server/src/session.ts
@@ -134,7 +134,7 @@ export class Session {
         continue;
       }
       const project = this.projectService.getDefaultProjectForScriptInfo(scriptInfo);
-      const ngLS = project ?.getLanguageService();
+      const ngLS = project?.getLanguageService();
       if (!project?.languageServiceEnabled || !ngLS) {
         continue;
       }
@@ -268,7 +268,7 @@ export class Session {
 
     const {fileName} = scriptInfo;
     const project = this.projectService.getDefaultProjectForScriptInfo(scriptInfo);
-    const langSvc = project ?.getLanguageService();
+    const langSvc = project?.getLanguageService();
     if (!project?.languageServiceEnabled || !langSvc) {
       return;
     }
@@ -315,7 +315,7 @@ export class Session {
       return;
     }
     const project = this.projectService.getDefaultProjectForScriptInfo(scriptInfo);
-    const langSvc = project ?.getLanguageService();
+    const langSvc = project?.getLanguageService();
     if (!project?.languageServiceEnabled || !langSvc) {
       return;
     }
@@ -360,7 +360,7 @@ export class Session {
     }
     const {fileName} = scriptInfo;
     const project = this.projectService.getDefaultProjectForScriptInfo(scriptInfo);
-    const langSvc = project ?.getLanguageService();
+    const langSvc = project?.getLanguageService();
     if (!project?.languageServiceEnabled || !langSvc) {
       return;
     }

--- a/server/src/session.ts
+++ b/server/src/session.ts
@@ -134,10 +134,11 @@ export class Session {
         continue;
       }
       const project = this.projectService.getDefaultProjectForScriptInfo(scriptInfo);
-      if (!project || !project.languageServiceEnabled) {
+      const ngLS = project ?.getLanguageService();
+      if (!ngLS) {
         continue;
       }
-      const ngLS = project.getLanguageService();
+
       const diagnostics = ngLS.getSemanticDiagnostics(fileName);
       // Need to send diagnostics even if it's empty otherwise editor state will
       // not be updated.
@@ -267,12 +268,12 @@ export class Session {
 
     const {fileName} = scriptInfo;
     const project = this.projectService.getDefaultProjectForScriptInfo(scriptInfo);
-    if (!project || !project.languageServiceEnabled) {
+    const langSvc = project ?.getLanguageService();
+    if (!langSvc) {
       return;
     }
 
     const offset = lspPositionToTsPosition(scriptInfo, position);
-    const langSvc = project.getLanguageService();
     const definition = langSvc.getDefinitionAndBoundSpan(fileName, offset);
     if (!definition || !definition.definitions) {
       return;
@@ -314,11 +315,11 @@ export class Session {
       return;
     }
     const project = this.projectService.getDefaultProjectForScriptInfo(scriptInfo);
-    if (!project || !project.languageServiceEnabled) {
+    const langSvc = project ?.getLanguageService();
+    if (!langSvc) {
       return;
     }
     const offset = lspPositionToTsPosition(scriptInfo, position);
-    const langSvc = project.getLanguageService();
     const info = langSvc.getQuickInfoAtPosition(scriptInfo.fileName, offset);
     if (!info) {
       return;
@@ -359,11 +360,11 @@ export class Session {
     }
     const {fileName} = scriptInfo;
     const project = this.projectService.getDefaultProjectForScriptInfo(scriptInfo);
-    if (!project || !project.languageServiceEnabled) {
+    const langSvc = project ?.getLanguageService();
+    if (!langSvc) {
       return;
     }
     const offset = lspPositionToTsPosition(scriptInfo, position);
-    const langSvc = project.getLanguageService();
     const completions = langSvc.getCompletionsAtPosition(
         fileName, offset,
         {

--- a/server/src/session.ts
+++ b/server/src/session.ts
@@ -133,9 +133,9 @@ export class Session {
       if (!scriptInfo) {
         continue;
       }
-      const project = this.projectService.getDefaultProjectForScriptInfo(scriptInfo);
-      const ngLS = project?.getLanguageService();
-      if (!project?.languageServiceEnabled || !ngLS) {
+
+      const ngLS = this.projectService.getDefaultLanguageService(scriptInfo);
+      if (!ngLS) {
         continue;
       }
 
@@ -267,9 +267,8 @@ export class Session {
     }
 
     const {fileName} = scriptInfo;
-    const project = this.projectService.getDefaultProjectForScriptInfo(scriptInfo);
-    const langSvc = project?.getLanguageService();
-    if (!project?.languageServiceEnabled || !langSvc) {
+    const langSvc = this.projectService.getDefaultLanguageService(scriptInfo);
+    if (!langSvc) {
       return;
     }
 
@@ -314,9 +313,8 @@ export class Session {
     if (!scriptInfo) {
       return;
     }
-    const project = this.projectService.getDefaultProjectForScriptInfo(scriptInfo);
-    const langSvc = project?.getLanguageService();
-    if (!project?.languageServiceEnabled || !langSvc) {
+    const langSvc = this.projectService.getDefaultLanguageService(scriptInfo);
+    if (!langSvc) {
       return;
     }
     const offset = lspPositionToTsPosition(scriptInfo, position);
@@ -359,9 +357,8 @@ export class Session {
       return;
     }
     const {fileName} = scriptInfo;
-    const project = this.projectService.getDefaultProjectForScriptInfo(scriptInfo);
-    const langSvc = project?.getLanguageService();
-    if (!project?.languageServiceEnabled || !langSvc) {
+    const langSvc = this.projectService.getDefaultLanguageService(scriptInfo);
+    if (!langSvc) {
       return;
     }
     const offset = lspPositionToTsPosition(scriptInfo, position);

--- a/server/src/session.ts
+++ b/server/src/session.ts
@@ -135,7 +135,7 @@ export class Session {
       }
       const project = this.projectService.getDefaultProjectForScriptInfo(scriptInfo);
       const ngLS = project ?.getLanguageService();
-      if (!ngLS) {
+      if (!project?.languageServiceEnabled || !ngLS) {
         continue;
       }
 
@@ -269,7 +269,7 @@ export class Session {
     const {fileName} = scriptInfo;
     const project = this.projectService.getDefaultProjectForScriptInfo(scriptInfo);
     const langSvc = project ?.getLanguageService();
-    if (!langSvc) {
+    if (!project?.languageServiceEnabled || !langSvc) {
       return;
     }
 
@@ -316,7 +316,7 @@ export class Session {
     }
     const project = this.projectService.getDefaultProjectForScriptInfo(scriptInfo);
     const langSvc = project ?.getLanguageService();
-    if (!langSvc) {
+    if (!project?.languageServiceEnabled || !langSvc) {
       return;
     }
     const offset = lspPositionToTsPosition(scriptInfo, position);
@@ -361,7 +361,7 @@ export class Session {
     const {fileName} = scriptInfo;
     const project = this.projectService.getDefaultProjectForScriptInfo(scriptInfo);
     const langSvc = project ?.getLanguageService();
-    if (!langSvc) {
+    if (!project?.languageServiceEnabled || !langSvc) {
       return;
     }
     const offset = lspPositionToTsPosition(scriptInfo, position);


### PR DESCRIPTION
It appears that in some cases, a language service might not exist for a
project (https://github.com/microsoft/TypeScript/blob/d2c5d54242c69effbed0ebb27033047e0c995589/src/testRunner/unittests/tsserver/typingsInstaller.ts#L1951)
even if the `languageServiceEnabled` property on the project is `true`
(#557). To fix this, bail out of providing language service features
anytime a language service is not found by performing a strict null
check.

Closes #557.