### PR TITLE
feat: add grammar for two-way bindings

### DIFF
--- a/syntaxes/template.json
+++ b/syntaxes/template.json
@@ -10,6 +10,9 @@
     },
     {
       "include": "#eventBinding"
+    },
+    {
+      "include": "#twoWayBinding"
     }
   ],
   "repository": {
@@ -92,6 +95,39 @@
         }
       },
       "name": "meta.ng-binding.event.html",
+      "contentName": "source.js",
+      "patterns": [
+        {
+          "include": "source.js"
+        }
+      ]
+    },
+
+    "twoWayBinding": {
+      "begin": "(\\[\\s*\\(\\s*@?[-_a-zA-Z0-9.$]*\\s*\\)\\s*\\])(=)([\"'])",
+      "beginCaptures": {
+        "1": {
+          "name": "entity.other.attribute-name.html entity.other.ng-binding-name.two-way.html",
+          "patterns": [
+            {
+              "include": "#bindingKey"
+            }
+          ]
+        },
+        "2": {
+          "name": "punctuation.separator.key-value.html"
+        },
+        "3": {
+          "name": "string.quoted.html punctuation.definition.string.begin.html"
+        }
+      },
+      "end": "\\3",
+      "endCaptures": {
+        "0": {
+          "name": "string.quoted.html punctuation.definition.string.end.html"
+        }
+      },
+      "name": "meta.ng-binding.two-way.html",
       "contentName": "source.js",
       "patterns": [
         {

--- a/syntaxes/test/data/template.html
+++ b/syntaxes/test/data/template.html
@@ -34,3 +34,13 @@
 <my-component (myEvent$)="onMyEvent($event)"></my-component>
 <my-component (%invalidEvent)="onMyEvent($event)"></my-component>
 <my-component (invalidEvent]="onMyEvent($event)"></my-component>
+
+<!-- Two-way binding test -->
+<button [(click)]="clickProp"></button>
+<div [( extraSpacing )]="extraSpacing"></div>
+<div [(@animation.done)]="animation"></div>
+<my-component [(my-prop)]="myProp"></my-component>
+<my-component [(my_prop)]="myProp"></my-component>
+<my-component [($my_prop)]="myProp"></my-component>
+<my-component [(%invalid)]="invalid"></my-component>
+<my-component ([invalid)]="invalid"></my-component>

--- a/syntaxes/test/data/template.html.snap
+++ b/syntaxes/test/data/template.html.snap
@@ -208,3 +208,75 @@
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.ng
 ><my-component (invalidEvent]="onMyEvent($event)"></my-component>
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.ng
+>
+><!-- Two-way binding test -->
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.ng
+><button [(click)]="clickProp"></button>
+#^^^^^^^^ template.ng
+#        ^^ template.ng meta.ng-binding.two-way.html entity.other.attribute-name.html entity.other.ng-binding-name.two-way.html punctuation.definition.ng-binding-name.begin.html
+#          ^^^^^ template.ng meta.ng-binding.two-way.html entity.other.attribute-name.html entity.other.ng-binding-name.two-way.html
+#               ^^ template.ng meta.ng-binding.two-way.html entity.other.attribute-name.html entity.other.ng-binding-name.two-way.html punctuation.definition.ng-binding-name.end.html
+#                 ^ template.ng meta.ng-binding.two-way.html punctuation.separator.key-value.html
+#                  ^ template.ng meta.ng-binding.two-way.html string.quoted.html punctuation.definition.string.begin.html
+#                   ^^^^^^^^^ template.ng meta.ng-binding.two-way.html source.js
+#                            ^ template.ng meta.ng-binding.two-way.html string.quoted.html punctuation.definition.string.end.html
+#                             ^^^^^^^^^^^ template.ng
+><div [( extraSpacing )]="extraSpacing"></div>
+#^^^^^ template.ng
+#     ^^ template.ng meta.ng-binding.two-way.html entity.other.attribute-name.html entity.other.ng-binding-name.two-way.html punctuation.definition.ng-binding-name.begin.html
+#       ^ template.ng meta.ng-binding.two-way.html entity.other.attribute-name.html entity.other.ng-binding-name.two-way.html
+#        ^^^^^^^^^^^^ template.ng meta.ng-binding.two-way.html entity.other.attribute-name.html entity.other.ng-binding-name.two-way.html
+#                    ^ template.ng meta.ng-binding.two-way.html entity.other.attribute-name.html entity.other.ng-binding-name.two-way.html
+#                     ^^ template.ng meta.ng-binding.two-way.html entity.other.attribute-name.html entity.other.ng-binding-name.two-way.html punctuation.definition.ng-binding-name.end.html
+#                       ^ template.ng meta.ng-binding.two-way.html punctuation.separator.key-value.html
+#                        ^ template.ng meta.ng-binding.two-way.html string.quoted.html punctuation.definition.string.begin.html
+#                         ^^^^^^^^^^^^ template.ng meta.ng-binding.two-way.html source.js
+#                                     ^ template.ng meta.ng-binding.two-way.html string.quoted.html punctuation.definition.string.end.html
+#                                      ^^^^^^^^ template.ng
+><div [(@animation.done)]="animation"></div>
+#^^^^^ template.ng
+#     ^^ template.ng meta.ng-binding.two-way.html entity.other.attribute-name.html entity.other.ng-binding-name.two-way.html punctuation.definition.ng-binding-name.begin.html
+#       ^^^^^^^^^^ template.ng meta.ng-binding.two-way.html entity.other.attribute-name.html entity.other.ng-binding-name.two-way.html
+#                 ^ template.ng meta.ng-binding.two-way.html entity.other.attribute-name.html entity.other.ng-binding-name.two-way.html punctuation.accessor.html
+#                  ^^^^ template.ng meta.ng-binding.two-way.html entity.other.attribute-name.html entity.other.ng-binding-name.two-way.html
+#                      ^^ template.ng meta.ng-binding.two-way.html entity.other.attribute-name.html entity.other.ng-binding-name.two-way.html punctuation.definition.ng-binding-name.end.html
+#                        ^ template.ng meta.ng-binding.two-way.html punctuation.separator.key-value.html
+#                         ^ template.ng meta.ng-binding.two-way.html string.quoted.html punctuation.definition.string.begin.html
+#                          ^^^^^^^^^ template.ng meta.ng-binding.two-way.html source.js
+#                                   ^ template.ng meta.ng-binding.two-way.html string.quoted.html punctuation.definition.string.end.html
+#                                    ^^^^^^^^ template.ng
+><my-component [(my-prop)]="myProp"></my-component>
+#^^^^^^^^^^^^^^ template.ng
+#              ^^ template.ng meta.ng-binding.two-way.html entity.other.attribute-name.html entity.other.ng-binding-name.two-way.html punctuation.definition.ng-binding-name.begin.html
+#                ^^^^^^^ template.ng meta.ng-binding.two-way.html entity.other.attribute-name.html entity.other.ng-binding-name.two-way.html
+#                       ^^ template.ng meta.ng-binding.two-way.html entity.other.attribute-name.html entity.other.ng-binding-name.two-way.html punctuation.definition.ng-binding-name.end.html
+#                         ^ template.ng meta.ng-binding.two-way.html punctuation.separator.key-value.html
+#                          ^ template.ng meta.ng-binding.two-way.html string.quoted.html punctuation.definition.string.begin.html
+#                           ^^^^^^ template.ng meta.ng-binding.two-way.html source.js
+#                                 ^ template.ng meta.ng-binding.two-way.html string.quoted.html punctuation.definition.string.end.html
+#                                  ^^^^^^^^^^^^^^^^^ template.ng
+><my-component [(my_prop)]="myProp"></my-component>
+#^^^^^^^^^^^^^^ template.ng
+#              ^^ template.ng meta.ng-binding.two-way.html entity.other.attribute-name.html entity.other.ng-binding-name.two-way.html punctuation.definition.ng-binding-name.begin.html
+#                ^^^^^^^ template.ng meta.ng-binding.two-way.html entity.other.attribute-name.html entity.other.ng-binding-name.two-way.html
+#                       ^^ template.ng meta.ng-binding.two-way.html entity.other.attribute-name.html entity.other.ng-binding-name.two-way.html punctuation.definition.ng-binding-name.end.html
+#                         ^ template.ng meta.ng-binding.two-way.html punctuation.separator.key-value.html
+#                          ^ template.ng meta.ng-binding.two-way.html string.quoted.html punctuation.definition.string.begin.html
+#                           ^^^^^^ template.ng meta.ng-binding.two-way.html source.js
+#                                 ^ template.ng meta.ng-binding.two-way.html string.quoted.html punctuation.definition.string.end.html
+#                                  ^^^^^^^^^^^^^^^^^ template.ng
+><my-component [($my_prop)]="myProp"></my-component>
+#^^^^^^^^^^^^^^ template.ng
+#              ^^ template.ng meta.ng-binding.two-way.html entity.other.attribute-name.html entity.other.ng-binding-name.two-way.html punctuation.definition.ng-binding-name.begin.html
+#                ^^^^^^^^ template.ng meta.ng-binding.two-way.html entity.other.attribute-name.html entity.other.ng-binding-name.two-way.html
+#                        ^^ template.ng meta.ng-binding.two-way.html entity.other.attribute-name.html entity.other.ng-binding-name.two-way.html punctuation.definition.ng-binding-name.end.html
+#                          ^ template.ng meta.ng-binding.two-way.html punctuation.separator.key-value.html
+#                           ^ template.ng meta.ng-binding.two-way.html string.quoted.html punctuation.definition.string.begin.html
+#                            ^^^^^^ template.ng meta.ng-binding.two-way.html source.js
+#                                  ^ template.ng meta.ng-binding.two-way.html string.quoted.html punctuation.definition.string.end.html
+#                                   ^^^^^^^^^^^^^^^^^ template.ng
+><my-component [(%invalid)]="invalid"></my-component>
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.ng
+><my-component ([invalid)]="invalid"></my-component>
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.ng
+>


### PR DESCRIPTION
This commit adds a TextMate grammar for highlighting two-way bindings.

Part of #483.