### PR TITLE
feat: Trigger autocomplete on '$' character

### DIFF
--- a/integration/lsp/smoke_spec.ts
+++ b/integration/lsp/smoke_spec.ts
@@ -106,7 +106,7 @@ describe('Angular Language Service', () => {
         'capabilities': {
           'textDocumentSync': 2,
           'completionProvider':
-              {'resolveProvider': false, 'triggerCharacters': ['<', '.', '*', '[', '(']},
+              {'resolveProvider': false, 'triggerCharacters': ['<', '.', '*', '[', '(', '$']},
           'definitionProvider': true,
           'hoverProvider': true
         }
@@ -134,7 +134,7 @@ describe('Angular Language Service', () => {
         'capabilities': {
           'textDocumentSync': 2,
           'completionProvider':
-              {'resolveProvider': false, 'triggerCharacters': ['<', '.', '*', '[', '(']},
+              {'resolveProvider': false, 'triggerCharacters': ['<', '.', '*', '[', '(', '$']},
           'definitionProvider': true,
           'hoverProvider': true
         }

--- a/server/src/session.ts
+++ b/server/src/session.ts
@@ -153,10 +153,10 @@ export class Session {
       capabilities: {
         textDocumentSync: lsp.TextDocumentSyncKind.Incremental,
         completionProvider: {
-          /// The server does not provide support to resolve additional information
+          // The server does not provide support to resolve additional information
           // for a completion item.
           resolveProvider: false,
-          triggerCharacters: ['<', '.', '*', '[', '(']
+          triggerCharacters: ['<', '.', '*', '[', '(', '$']
         },
         definitionProvider: true,
         hoverProvider: true,


### PR DESCRIPTION
Trigger autocomplete on '$' for variables like '$event' and '$implicit'
in template bindings.