### PR TITLE
docs: remove typescript version from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@ and external templates including:
 * Quick info
 * Go to definition
 
-This extension uses `typescript@3.6.x`.
-
 ## Download
 
 Download the extension from [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=Angular.ng-template).


### PR DESCRIPTION
Having the version hardcoded in the docs make it prone to go out of
date, and now that we prioritize the bundled version, users should
automatically get the latest typescript.