### PR TITLE
fix: enable debug mode only when it is strictly turned on

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -44,7 +44,7 @@ export function activate(context: vscode.ExtensionContext) {
   };
 
   // Create the language client and start the client.
-  const forceDebug = !!process.env['NG_DEBUG'];
+  const forceDebug = process.env['NG_DEBUG'] === 'true';
   const client =
       new lsp.LanguageClient('Angular Language Service', serverOptions, clientOptions, forceDebug);
 

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -44,7 +44,7 @@ session.info(`Angular language server process ID: ${process.pid}`);
 session.info(`Using typescript v${ts.version} from ${ts.resolvedPath}`);
 session.info(`Using @angular/language-service v${ng.version} from ${ng.resolvedPath}`);
 session.info(`Log file: ${logger.getLogFileName()}`);
-if (process.env.NG_DEBUG) {
+if (process.env.NG_DEBUG === 'true') {
   session.info('Angular Language Service is running under DEBUG mode');
 }
 if (process.env.TSC_NONPOLLING_WATCHER !== 'true') {


### PR DESCRIPTION
Enable debug mode in the language server if `NG_DEBUG` is strictly
"true". This fixes issues where `NG_DEBUG=false` would enable debug
mode.

Closes #579