### PR TITLE
build: move temp file for banner to server/out/banner

### DIFF
--- a/banner.rollup.config.js
+++ b/banner.rollup.config.js
@@ -2,7 +2,7 @@ module.exports = [
   {
     input: 'server/out/banner/banner.js',
     output: {
-      file: 'dist/server/banner.js',
+      file: 'server/out/banner/banner.rollup.js',
       format: 'cjs',
     },
     external: [

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -23,7 +23,7 @@ module.exports = [
     output: {
       file: 'dist/server/index.js',
       format: 'amd',
-      banner: fs.readFileSync('dist/server/banner.js', 'utf8'),
+      banner: fs.readFileSync('server/out/banner/banner.rollup.js', 'utf8'),
     },
     external: [
       'fs',


### PR DESCRIPTION
Currently the rollup-ed banner file in dist/server/banner.js is included
in the release but it is unnecessary.

This commit moves it to server/out/banner/banner.rollup.js and thus removes
it from the dist folder.