### PR TITLE
docs: Update README for @angular/language-server

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -3,4 +3,5 @@
 This package contains the Language Server Protocol ([LSP](https://microsoft.github.io/language-server-protocol/)) implementation of the Angular Language Service.
 
 ## Usage
-See `node index.js --help`
+
+See `node server.js --help`


### PR DESCRIPTION
It seems that it has been changed from `index.js` to `server.js`, so I updated the document.