### PR TITLE
Apply Angular template grammar syntax only to HTML derivative files

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
         "path": "./syntaxes/template.json",
         "scopeName": "template.ng",
         "injectTo": [
-          "text.html"
+          "text.html.derivative"
         ],
         "embeddedLanguages": {
           "text.html": "html",


### PR DESCRIPTION
Inject the template syntax grammar to HTML derivative files (the scope
given to component HTML files) rather than just base HTML grammar. This
prevents the grammar being applied on more specific HTML syntaxes.

Closes #667