### PR TITLE
Catch failure to open script when language service is disabled

### DIFF
--- a/server/src/project_service.ts
+++ b/server/src/project_service.ts
@@ -53,7 +53,7 @@ export class ProjectService {
   }
 
   /**
-  * Open file whose contents is managed by the client
+   * Open file whose contents is managed by the client
    * @param filename is absolute pathname
    * @param fileContent is a known version of the file content that is more up to date than the one
    *     on disk

--- a/server/src/project_service.ts
+++ b/server/src/project_service.ts
@@ -53,7 +53,7 @@ export class ProjectService {
   }
 
   /**
-   * Open file whose contents is managed by the client
+  * Open file whose contents is managed by the client
    * @param filename is absolute pathname
    * @param fileContent is a known version of the file content that is more up to date than the one
    *     on disk

--- a/server/src/session.ts
+++ b/server/src/session.ts
@@ -52,7 +52,7 @@ export class Session {
       useSingleInferredProject: true,
       useInferredProjectPerProjectRoot: true,
       typingsInstaller: ts.server.nullTypingsInstaller,
-      suppressDiagnosticEvents: false,
+      suppressDiagnosticEvents: true,
       eventHandler: (e) => this.handleProjectServiceEvent(e),
       globalPlugins: ['@angular/language-service'],
       pluginProbeLocations: [options.ngProbeLocation],
@@ -85,11 +85,14 @@ export class Session {
         break;
       case ts.server.ProjectLoadingFinishEvent: {
         const {project} = event.data;
-        // Disable language service if project is not Angular
-        this.checkIsAngularProject(project);
-        if (this.isProjectLoading) {
-          this.isProjectLoading = false;
-          this.connection.sendNotification(projectLoadingNotification.finish);
+        try {
+          // Disable language service if project is not Angular
+          this.checkIsAngularProject(project);
+        } finally {
+          if (this.isProjectLoading) {
+            this.isProjectLoading = false;
+            this.connection.sendNotification(projectLoadingNotification.finish);
+          }
         }
         break;
       }

--- a/server/src/session.ts
+++ b/server/src/session.ts
@@ -52,6 +52,11 @@ export class Session {
       useSingleInferredProject: true,
       useInferredProjectPerProjectRoot: true,
       typingsInstaller: ts.server.nullTypingsInstaller,
+      // Not supressing diagnostic events can cause a type error to be thrown when the
+      // language server session gets an event for a file that is outside the project
+      // managed by the project service, and for which a program does not exist in the
+      // corresponding project's language service.
+      // See https://github.com/angular/vscode-ng-language-service/issues/693
       suppressDiagnosticEvents: true,
       eventHandler: (e) => this.handleProjectServiceEvent(e),
       globalPlugins: ['@angular/language-service'],


### PR DESCRIPTION
This commit supresses diagnostic events sent by a project service
regarding changes to a project. Today, not supressing such events
can cause a type error to be thrown when the language server session
begins handling events for a file that is outside the project managed by
the project service, and for which a program does not exist in the
corresponding project's language service.

This commit also wraps blocks that terminate in setting a notification
status to always complete their notification.

Closes #693
Closes #696