### PR TITLE
build: publish using wombat

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -11,5 +11,8 @@
     "@angular/language-service": "9.1.2",
     "vscode-languageserver": "6.1.1",
     "vscode-uri": "2.1.1"
+  },
+  "publishConfig": {
+    "registry": "https://wombat-dressing-room.appspot.com"
   }
 }


### PR DESCRIPTION
Sets the package.json publishConfig to use the wombat-dressing-room
registry.