### PR TITLE
ci: remove install.sh and cleanup.sh

### DIFF
--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-set -ex -o pipefail
-
-# Clean up from last build
-rm -rf client/out
-rm -rf server/out
-rm -rf syntaxes/out

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-set -ex -o pipefail
-
-yarn


### PR DESCRIPTION
These two files can be removed now that we are no longer using Travis
CI.