### PR TITLE
build: add repository field to server/package.json

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -2,6 +2,10 @@
   "name": "@angular/language-server",
   "description": "LSP server for Angular Language Service",
   "version": "0.901.3",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/angular/vscode-ng-language-service.git"
+  },
   "author": "Angular",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
"repository" field is needed for wombat proxy to check permissions.