### PR TITLE
build: ignore .npmrc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.npmrc
 .vscode-test
 .DS_Store
 node_modules


### PR DESCRIPTION
npmrc is used to store permission token for publishing to wombat proxy.
The token must never be checked in.