### PR TITLE
ci: report error if files are not formatted

### DIFF
--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -12,6 +12,7 @@ find . -name "*.ts" \
 find syntaxes/ -name "*.json" \
   -exec yarn prettier --write {} +
 
-if [[ ! -z "${CI_MODE}" ]]; then
-  git diff --diff-filter=ACMRT --exit-code || (echo "Files not formatted; please run 'yarn format'." && exit 1)
+if [[ -n "$(git status --porcelain)" ]]; then
+  echo "Files not formatted; please run 'yarn format'."
+  exit 1
 fi

--- a/syntaxes/test/cases.json
+++ b/syntaxes/test/cases.json
@@ -2,7 +2,11 @@
   {
     "name": "inline template",
     "scopeName": "inline-template.ng",
-    "grammarFiles": ["syntaxes/inline-template.json", "syntaxes/template.json", "syntaxes/expression.json"],
+    "grammarFiles": [
+      "syntaxes/inline-template.json",
+      "syntaxes/template.json",
+      "syntaxes/expression.json"
+    ],
     "testFile": "syntaxes/test/data/inline-template.ts"
   },
   {


### PR DESCRIPTION
#846 updated some JSON files. One of them was not formatted properly, but our CI failed to detect that.
There are multiple reasons:
1. The current format script skips over formatting checks if CI_MODE is true. (I wonder why we skip it in the first place?)
2. CircleCI was not setup to run the build-test workflow if PR is opened from a forked repo.

(2) is fixed by updating CircleCI config whereas (1) is fixed by this PR.