### PR TITLE
fix: run format check iff on CI

### DIFF
--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -12,7 +12,7 @@ find . -name "*.ts" \
 find syntaxes/ -name "*.json" \
   -exec yarn prettier --write {} +
 
-if [[ -n "$(git status --porcelain)" ]]; then
+if [[ -n "${CIRCLECI}" && -n "$(git status --porcelain)" ]]; then
   echo "Files not formatted; please run 'yarn format'."
   exit 1
 fi


### PR DESCRIPTION
When running `yarn format` locally the CI check should not be triggered.

Run the formatting check only when "CIRCLECI" is present in the environment
variables.
`CIRCLECI` is a built-in environment variable that's always set according to
https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables