### PR TITLE
feat: add --experimental-ivy flag for Ivy language service

### DIFF
--- a/server/src/cmdline_utils.ts
+++ b/server/src/cmdline_utils.ts
@@ -28,6 +28,11 @@ function hasArgument(argv: string[], argName: string): boolean {
 
 interface CommandLineOptions {
   help: boolean;
+  /**
+   * If true, use the Ivy version of Angular LS. For now this is only used for
+   * development.
+   */
+  ivy: boolean;
   logFile?: string;
   logVerbosity?: string;
   ngProbeLocations: string[];
@@ -37,6 +42,7 @@ interface CommandLineOptions {
 export function parseCommandLine(argv: string[]): CommandLineOptions {
   return {
     help: hasArgument(argv, '--help'),
+    ivy: hasArgument(argv, '--experimental-ivy'),
     logFile: findArgument(argv, '--logFile'),
     logVerbosity: findArgument(argv, '--logVerbosity'),
     ngProbeLocations: parseStringArray(argv, '--ngProbeLocations'),
@@ -45,6 +51,7 @@ export function parseCommandLine(argv: string[]): CommandLineOptions {
 }
 
 export function generateHelpMessage(argv: string[]) {
+  // Do not expose --experimental-ivy flag since it's only used for development.
   return `Angular Language Service that implements the Language Server Protocol (LSP).
 
   Usage: ${argv[0]} ${argv[1]} [options]

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -27,7 +27,7 @@ const logger = createLogger({
 });
 
 const ts = resolveTsServer(options.tsProbeLocations);
-const ng = resolveNgLangSvc(options.ngProbeLocations);
+const ng = resolveNgLangSvc(options.ngProbeLocations, options.ivy);
 
 // ServerHost provides native OS functionality
 const host = new ServerHost();
@@ -36,13 +36,14 @@ const host = new ServerHost();
 const session = new Session({
   host,
   logger,
+  ngPlugin: ng.name,
   ngProbeLocation: ng.resolvedPath,
 });
 
 // Log initialization info
 session.info(`Angular language server process ID: ${process.pid}`);
-session.info(`Using typescript v${ts.version} from ${ts.resolvedPath}`);
-session.info(`Using @angular/language-service v${ng.version} from ${ng.resolvedPath}`);
+session.info(`Using ${ts.name} v${ts.version} from ${ts.resolvedPath}`);
+session.info(`Using ${ng.name} v${ng.version} from ${ng.resolvedPath}`);
 session.info(`Log file: ${logger.getLogFileName()}`);
 if (process.env.NG_DEBUG === 'true') {
   session.info('Angular Language Service is running under DEBUG mode');

--- a/server/src/session.ts
+++ b/server/src/session.ts
@@ -19,6 +19,7 @@ import {filePathToUri, lspPositionToTsPosition, lspRangeToTsPositions, tsTextSpa
 export interface SessionOptions {
   host: ServerHost;
   logger: Logger;
+  ngPlugin: string;
   ngProbeLocation: string;
 }
 
@@ -62,7 +63,7 @@ export class Session {
       // See https://github.com/angular/vscode-ng-language-service/issues/693
       suppressDiagnosticEvents: true,
       eventHandler: (e) => this.handleProjectServiceEvent(e),
-      globalPlugins: ['@angular/language-service'],
+      globalPlugins: [options.ngPlugin],
       pluginProbeLocations: [options.ngProbeLocation],
       allowLocalPluginLoads: false,  // do not load plugins from tsconfig.json
     });
@@ -79,7 +80,7 @@ export class Session {
     });
 
     projSvc.configurePlugin({
-      pluginName: '@angular/language-service',
+      pluginName: options.ngPlugin,
       configuration: {
         angularOnly: true,
       },

--- a/server/src/tests/version_provider_spec.ts
+++ b/server/src/tests/version_provider_spec.ts
@@ -18,9 +18,19 @@ describe('Node Module Resolver', () => {
   });
 
   it('should be able to resolve Angular language service', () => {
-    const result = resolveNgLangSvc(probeLocations);
+    const result = resolveNgLangSvc(probeLocations, false /* ivy */);
     expect(result).toBeDefined();
+    // TODO: This will fail in the next update of @angular/language-service
+    // because language-service.umd.js is renamed to language-service.js
     expect(result.resolvedPath).toMatch(/language-service.umd.js$/);
+  });
+
+  it('should be able to resolve Ivy version of Angular language service', () => {
+    const result = resolveNgLangSvc(probeLocations, true /* ivy */);
+    expect(result).toBeDefined();
+    // TODO: This will fail in the next update of @angular/language-service
+    // because ivy.umd.js is renamed to ivy.js
+    expect(result.resolvedPath).toMatch(/ivy.umd.js$/);
   });
 });
 


### PR DESCRIPTION
This commit adds a hidden flag `--ivy` to load the Ivy version of
`@angular/language-service`.
This flag is hidden for now because it is only used for development.

The second entry point is resolved from `@angular/language-service/ivy.umd`
but in the next update it'll be `@angular/language-service/ivy` due to
the renaming done in https://github.com/angular/angular/pull/38086