### PR TITLE
fix: do not use require() to read JSON files

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
             "null"
           ],
           "default": null,
-          "description": "Specifies the folder path to @angular/language-service."
+          "description": "Specifies the folder path to @angular/language-service.",
+          "scope": "machine"
         },
         "angular.log": {
           "type": "string",

--- a/server/src/version_provider.ts
+++ b/server/src/version_provider.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import * as fs from 'fs';
+
 const MIN_TS_VERSION = '3.9';
 const MIN_NG_VERSION = '10.0';
 
@@ -25,7 +27,9 @@ function resolve(packageName: string, location: string, rootPackage?: string): N
     const packageJsonPath = require.resolve(`${rootPackage}/package.json`, {
       paths: [location],
     });
-    const packageJson = require(packageJsonPath);
+    // Do not use require() to read JSON files since it's a potential security
+    // vulnerability.
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
     const resolvedPath = require.resolve(packageName, {
       paths: [location],
     });


### PR DESCRIPTION
This commit fixes a potential security vulnerability caused by the use of
require() to read a JSON file. If there is a JS file named `package.json.js`
in the node_modules, we would unknowingly execute the remote code while
trying to require() it.

Even though we only load `typescript` and `@angular/language-service`,
we cannot guarantee the content of these packages when they are installed
on users' machines.

Thanks @ddworken for reporting this issue and @koto for surfacing it to the
Angular team.