### PR TITLE
Issue #909 - Explicit support for workspaceFolders

### DIFF
--- a/integration/lsp/smoke_spec.ts
+++ b/integration/lsp/smoke_spec.ts
@@ -108,7 +108,8 @@ describe('Angular Language Service', () => {
           'completionProvider':
               {'resolveProvider': false, 'triggerCharacters': ['<', '.', '*', '[', '(', '$', '|']},
           'definitionProvider': true,
-          'hoverProvider': true
+          'hoverProvider': true,
+          'workspace': {'workspaceFolders': {'supported': true}}
         }
       }
     });
@@ -136,7 +137,8 @@ describe('Angular Language Service', () => {
           'completionProvider':
               {'resolveProvider': false, 'triggerCharacters': ['<', '.', '*', '[', '(', '$', '|']},
           'definitionProvider': true,
-          'hoverProvider': true
+          'hoverProvider': true,
+          'workspace': {'workspaceFolders': {'supported': true}}
         }
       }
     });

--- a/server/src/session.ts
+++ b/server/src/session.ts
@@ -240,6 +240,9 @@ export class Session {
         },
         definitionProvider: true,
         hoverProvider: true,
+        workspace: {
+          workspaceFolders: {supported: true},
+        },
       },
     };
   }


### PR DESCRIPTION
As per https://microsoft.github.io/language-server-protocol/specification#workspace_workspaceFolders
, it's recommended that Language Servers that can work with multi-root
workspaces declare support for workspaceFolders.

For the angular language server, it's able to work with any file,
independently of the workspace root; so it's naturally able to work with
multiple roots.
Declaring support for workspaceFolders allows clients that use the
workspaceFolder heuristic as a way to decide of server instance
multiplicity (should it be a single instance or 1 instance per root) to
decide of starting only 1 instance of the LS. Without such information
from the LS, the client integration has to audit the LS, and force some
strategy to decide of the multiplicity, often in an hardcoded way; at
the risk of being incorrect in the future if server changes its own
strategy.
So declaring workspaceFolders allow to automate a better integration in
clients.

Signed-off-by: Mickael Istria <mistria@redhat.com>