### PR TITLE
feat: add configuration for enabling Ivy

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -123,6 +123,11 @@ function constructArgs(ctx: vscode.ExtensionContext, debug: boolean): string[] {
   const ngProbeLocations = getProbeLocations(ngdk, ctx.asAbsolutePath('server'));
   args.push('--ngProbeLocations', ngProbeLocations.join(','));
 
+  const experimentalIvy: boolean = config.get('angular.experimental-ivy', false);
+  if (experimentalIvy) {
+    args.push('--experimental-ivy');
+  }
+
   const tsdk: string|null = config.get('typescript.tsdk', null);
   const tsProbeLocations = getProbeLocations(tsdk, ctx.extensionPath);
   args.push('--tsProbeLocations', tsProbeLocations.join(','));

--- a/integration/project/.vscode/settings.json
+++ b/integration/project/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "angular.experimental-ivy": true
+}

--- a/package.json
+++ b/package.json
@@ -46,6 +46,11 @@
           ],
           "default": "terse",
           "description": "Enables logging of the Angular server to a file. This log can be used to diagnose Angular Server issues. The log may contain file paths, source code, and other potentially sensitive information from your project."
+        },
+        "angular.experimental-ivy": {
+          "type": "boolean",
+          "default": false,
+          "description": "This is an experimental feature that enables the Ivy language service. Please make sure ngcc is run before enabling this flag."
         }
       }
     },

--- a/server/src/cmdline_utils.ts
+++ b/server/src/cmdline_utils.ts
@@ -51,13 +51,13 @@ export function parseCommandLine(argv: string[]): CommandLineOptions {
 }
 
 export function generateHelpMessage(argv: string[]) {
-  // Do not expose --experimental-ivy flag since it's only used for development.
   return `Angular Language Service that implements the Language Server Protocol (LSP).
 
   Usage: ${argv[0]} ${argv[1]} [options]
 
   Options:
     --help: Prints help message.
+    --experimental-ivy: Enables the Ivy language service. Defaults to false.
     --logFile: Location to log messages. Logging is disabled if not provided.
     --logVerbosity: terse|normal|verbose|requestTime. See ts.server.LogLevel.
     --ngProbeLocations: Path of @angular/language-service. Required.


### PR DESCRIPTION
This commit adds a new configuration, `experimental-ivy` to turn on the
Ivy language service.