### PR TITLE
feat: Add typeDefinitionProvider to capabilities

### DIFF
--- a/integration/lsp/smoke_spec.ts
+++ b/integration/lsp/smoke_spec.ts
@@ -108,6 +108,7 @@ describe('Angular Language Service', () => {
           'completionProvider':
               {'resolveProvider': false, 'triggerCharacters': ['<', '.', '*', '[', '(', '$', '|']},
           'definitionProvider': true,
+          'typeDefinitionProvider': true,
           'hoverProvider': true,
           'workspace': {'workspaceFolders': {'supported': true}}
         }
@@ -137,6 +138,7 @@ describe('Angular Language Service', () => {
           'completionProvider':
               {'resolveProvider': false, 'triggerCharacters': ['<', '.', '*', '[', '(', '$', '|']},
           'definitionProvider': true,
+          'typeDefinitionProvider': true,
           'hoverProvider': true,
           'workspace': {'workspaceFolders': {'supported': true}}
         }

--- a/server/src/session.ts
+++ b/server/src/session.ts
@@ -96,6 +96,7 @@ export class Session {
     conn.onDidChangeTextDocument(p => this.onDidChangeTextDocument(p));
     conn.onDidSaveTextDocument(p => this.onDidSaveTextDocument(p));
     conn.onDefinition(p => this.onDefinition(p));
+    conn.onTypeDefinition(p => this.onTypeDefinition(p));
     conn.onHover(p => this.onHover(p));
     conn.onCompletion(p => this.onCompletion(p));
   }
@@ -239,6 +240,7 @@ export class Session {
           triggerCharacters: ['<', '.', '*', '[', '(', '$', '|']
         },
         definitionProvider: true,
+        typeDefinitionProvider: true,
         hoverProvider: true,
         workspace: {
           workspaceFolders: {supported: true},
@@ -353,6 +355,20 @@ export class Session {
     }
     const originSelectionRange = tsTextSpanToLspRange(scriptInfo, definition.textSpan);
     return this.tsDefinitionsToLspLocationLinks(definition.definitions, originSelectionRange);
+  }
+
+  private onTypeDefinition(params: lsp.TextDocumentPositionParams): lsp.LocationLink[]|undefined {
+    const lsInfo = this.getLSAndScriptInfo(params.textDocument);
+    if (lsInfo === undefined) {
+      return;
+    }
+    const {languageService, scriptInfo} = lsInfo;
+    const offset = lspPositionToTsPosition(scriptInfo, params.position);
+    const definitions = languageService.getTypeDefinitionAtPosition(scriptInfo.fileName, offset);
+    if (!definitions) {
+      return;
+    }
+    return this.tsDefinitionsToLspLocationLinks(definitions);
   }
 
   private tsDefinitionsToLspLocationLinks(


### PR DESCRIPTION
See individual commits.

Commit 1: 
Refactor, create some helper functions for common code.

Commit 2: 
The Angular Language Service for Ivy will have a distinction
between "go to definition" and "go to type definition". We
need to add `typeDefinitionProvider` to the capabilities and call
`getTypeDefinitionAtPosition` when type definitions are requested.