### PR TITLE
fix: misleading error message about missing config when opening new file

### DIFF
--- a/server/src/session.ts
+++ b/server/src/session.ts
@@ -205,6 +205,7 @@ export class Session {
       const {configFileName} = this.projectService.openClientFile(scriptInfo.fileName);
       if (!configFileName) {
         // Failed to find a config file. There is nothing we could do.
+        this.connection.console.error(`No config file for ${scriptInfo.fileName}`);
         return;
       }
       project = this.projectService.findProject(configFileName);
@@ -266,7 +267,13 @@ export class Session {
         this.connection.console.error(configFileErrors.map(e => e.messageText).join('\n'));
       }
       if (!configFileName) {
-        this.connection.console.error(`No config file for ${filePath}`);
+        // It is not really an error if there is no config file, because the
+        // first call to openClientFile() will create a project for the file if
+        // it does not exist, but the method will not return the config filename.
+        // In subsequent operations, we'll call this.getDefaultProjectForScriptInfo(),
+        // and there we make a second call to openClientFile(). By then, since
+        // the project has already been created, we will receive the config
+        // filename, and we can attach the file to the project it belongs to.
         return;
       }
       const project = this.projectService.findProject(configFileName);


### PR DESCRIPTION
This commit fixes a false alarm that says a config file cannot be found
when the language server tries to open a file for the first time.

We actually make two calls to `openClientFile()`.

1. In the first call, if the project doesn't already exist, the method
   will create a project but it will not return the config filename.
2. In the second call, since the project has already been created,
   the call to `openClientFile()` should succeed and we should receive a
   config filename. If we don't receive one then it is an error, and we
   should log message here instead of logging it in step (1).