### PR TITLE
test: add angularCompilerOptions to test project

### DIFF
--- a/integration/project/tsconfig.json
+++ b/integration/project/tsconfig.json
@@ -6,5 +6,9 @@
     "typeRoots": [
       "node_modules/@types"
     ]
+  },
+  "angularCompilerOptions": {
+    "strictTemplates": true,
+    "strictInjectionParameters": true
   }
 }


### PR DESCRIPTION
This commit adds `angularCompilerOptions` for Ivy in the test project.