### PR TITLE
Properly inject Angular template grammar in inline templates

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,8 @@
         "path": "./syntaxes/template.json",
         "scopeName": "template.ng",
         "injectTo": [
-          "text.html.derivative"
+          "text.html.derivative",
+          "source.ts"
         ],
         "embeddedLanguages": {
           "text.html": "html",


### PR DESCRIPTION
It seems that to get inline templates to be syntax highlighted with the
angular template grammar correctly, we not only need to include the
`template.ng` grammar pattern when matching an inline template (which
previously worked only for interpolations but would not seem to
correctly recognize template bindings); we also need to tell VSCode that
it should inject the template grammar in TypeScript files.

I cannot find a way to test this (since it differs from the TextMate
grammar tests, as this change instructs VSCode specifically how to add
the grammars), but screenshots attached to the PR for this commit
demonstrate before- and after-this-change syntax highlight on an inline
template. Furthermore non-template TypeScript should not be matched by
the template grammar, since the template grammar can only be injected
when the base grammar is matched to be HTML (which only happens when we
match an inline template).

I couldn't figure this out a couple months back, but looked back today
and got it almost immediately :) I guess some time away is a good thing.

Closes #768

<img width="1510" alt="Screen Shot 2020-11-05 at 8 58 49 PM" src="https://user-images.githubusercontent.com/20735482/98321493-d5fd9800-1faa-11eb-8595-8160768f0eb3.png">
<img width="1510" alt="Screen Shot 2020-11-05 at 8 58 06 PM" src="https://user-images.githubusercontent.com/20735482/98321495-d72ec500-1faa-11eb-8e29-9d6d814527de.png">
