### PR TITLE
Properly parse nested ternary expressions

### DIFF
--- a/syntaxes/expression.json
+++ b/syntaxes/expression.json
@@ -563,7 +563,7 @@
       "match": "\\\\(x\\h{2}|[0-2][0-7]{0,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.|$)"
     },
     "ternaryExpression": {
-      "begin": "(?!\\?\\.\\s*[^[:digit:]])(\\?)(?!\\?)",
+      "begin": "(?!\\?\\.\\s*[^[:digit:]])(\\?)",
       "beginCaptures": {
         "1": {
           "name": "keyword.operator.ternary.ts"

--- a/syntaxes/expression.json
+++ b/syntaxes/expression.json
@@ -563,27 +563,15 @@
       "match": "\\\\(x\\h{2}|[0-2][0-7]{0,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.|$)"
     },
     "ternaryExpression": {
-      "begin": "(?=\\?)(?!\\?\\.)",
-      "end": "(?=$|\"|[;,})\\]])",
-      "patterns": [
-        {
-          "include": "#ternaryOperator"
-        },
-        {
-          "include": "#ngExpression"
-        }
-      ]
-    },
-    "ternaryOperator": {
-      "begin": "(\\?)(?!\\.)",
+      "begin": "(?!\\?\\.\\s*[^[:digit:]])(\\?)(?!\\?)",
       "beginCaptures": {
-        "0": {
+        "1": {
           "name": "keyword.operator.ternary.ts"
         }
       },
-      "end": "(:)",
+      "end": "\\s*(:)",
       "endCaptures": {
-        "0": {
+        "1": {
           "name": "keyword.operator.ternary.ts"
         }
       },

--- a/syntaxes/src/expression.ts
+++ b/syntaxes/src/expression.ts
@@ -593,8 +593,12 @@ export const Expression: GrammarDefinition = {
       match: /\\(x\h{2}|[0-2][0-7]{0,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.|$)/,
     },
 
+    // Derived from
+    // https://github.com/sheetalkamat/TypeScript-TmLanguage-VsCode/blob/04219109f3e2090f787c0fa8743e73a4bd1ad876/syntaxes/TypeScript.tmLanguage.json#L2830-L2848
     ternaryExpression: {
-      begin: /(?!\?\.\s*[^[:digit:]])(\?)(?!\?)/,
+      // 1. negative lookahead (?!\?\.\s*[^[:digit:]]) ensures safe navigation does not match
+      // 2. match the ternary question mark with (\?)
+      begin: /(?!\?\.\s*[^[:digit:]])(\?)/,
       beginCaptures: {
         1: {
           name: 'keyword.operator.ternary.ts',

--- a/syntaxes/src/expression.ts
+++ b/syntaxes/src/expression.ts
@@ -594,28 +594,15 @@ export const Expression: GrammarDefinition = {
     },
 
     ternaryExpression: {
-      begin: /(?=\?)(?!\?\.)/,
-      end: /(?=$|"|[;,})\]])/,
-      patterns: [
-        {
-          include: '#ternaryOperator',
-        },
-        {
-          include: '#ngExpression',
-        },
-      ],
-    },
-
-    ternaryOperator: {
-      begin: /(\?)(?!\.)/,
+      begin: /(?!\?\.\s*[^[:digit:]])(\?)(?!\?)/,
       beginCaptures: {
-        0: {
+        1: {
           name: 'keyword.operator.ternary.ts',
         },
       },
-      end: /(:)/,
+      end: /\s*(:)/,
       endCaptures: {
-        0: {
+        1: {
           name: 'keyword.operator.ternary.ts',
         },
       },

--- a/syntaxes/test/data/expression.html
+++ b/syntaxes/test/data/expression.html
@@ -70,6 +70,7 @@
 {{ condition ? ['123'] : { test: 'a' } }}
 {{ condition ? 'test' : "test" }}
 {{ condition ? [function(), variable] : {} }}
+{{ condition ? condition2 ? condition3 ? 1 : 2 : 3 : 4 }}
 
 <!-- Microsyntax -->
 <!-- Let Expression -->

--- a/syntaxes/test/data/expression.html
+++ b/syntaxes/test/data/expression.html
@@ -71,6 +71,8 @@
 {{ condition ? 'test' : "test" }}
 {{ condition ? [function(), variable] : {} }}
 {{ condition ? condition2 ? condition3 ? 1 : 2 : 3 : 4 }}
+<!-- Don't match safe navigations -->
+{{ condition?.a : 1 }}
 
 <!-- Microsyntax -->
 <!-- Let Expression -->

--- a/syntaxes/test/data/expression.html.snap
+++ b/syntaxes/test/data/expression.html.snap
@@ -825,6 +825,18 @@
 #                                                     ^ template.ng expression.ng constant.numeric.decimal.ts
 #                                                      ^ template.ng expression.ng
 #                                                       ^^ template.ng punctuation.definition.block.ts
+><!-- Don't match safe navigations -->
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.ng
+>{{ condition?.a : 1 }}
+#^^ template.ng punctuation.definition.block.ts
+#  ^ template.ng expression.ng
+#   ^^^^^^^^^ template.ng expression.ng variable.other.readwrite.ts
+#            ^^ template.ng expression.ng punctuation.accessor.ts
+#              ^ template.ng expression.ng variable.other.property.ts
+#               ^^^ template.ng expression.ng
+#                  ^ template.ng expression.ng constant.numeric.decimal.ts
+#                   ^ template.ng expression.ng
+#                    ^^ template.ng punctuation.definition.block.ts
 >
 ><!-- Microsyntax -->
 #^^^^^^^^^^^^^^^^^^^^^ template.ng

--- a/syntaxes/test/data/expression.html.snap
+++ b/syntaxes/test/data/expression.html.snap
@@ -756,8 +756,7 @@
 #                                 ^ template.ng expression.ng string.quoted.single.ts punctuation.definition.string.begin.ts
 #                                  ^ template.ng expression.ng string.quoted.single.ts
 #                                   ^ template.ng expression.ng string.quoted.single.ts punctuation.definition.string.end.ts
-#                                    ^ template.ng expression.ng
-#                                     ^^ template.ng expression.ng
+#                                    ^^^ template.ng expression.ng
 #                                       ^^ template.ng punctuation.definition.block.ts
 >{{ condition ? 'test' : "test" }}
 #^^ template.ng punctuation.definition.block.ts
@@ -794,9 +793,38 @@
 #                                    ^ template.ng expression.ng meta.array.literal.ts meta.brace.square.ts
 #                                     ^ template.ng expression.ng
 #                                      ^ template.ng expression.ng keyword.operator.ternary.ts
-#                                       ^^ template.ng expression.ng
-#                                         ^^ template.ng expression.ng
+#                                       ^^^^ template.ng expression.ng
 #                                           ^^ template.ng punctuation.definition.block.ts
+>{{ condition ? condition2 ? condition3 ? 1 : 2 : 3 : 4 }}
+#^^ template.ng punctuation.definition.block.ts
+#  ^ template.ng expression.ng
+#   ^^^^^^^^^ template.ng expression.ng variable.other.readwrite.ts
+#            ^ template.ng expression.ng
+#             ^ template.ng expression.ng keyword.operator.ternary.ts
+#              ^ template.ng expression.ng
+#               ^^^^^^^^^^ template.ng expression.ng variable.other.readwrite.ts
+#                         ^ template.ng expression.ng
+#                          ^ template.ng expression.ng keyword.operator.ternary.ts
+#                           ^ template.ng expression.ng
+#                            ^^^^^^^^^^ template.ng expression.ng variable.other.readwrite.ts
+#                                      ^ template.ng expression.ng
+#                                       ^ template.ng expression.ng keyword.operator.ternary.ts
+#                                        ^ template.ng expression.ng
+#                                         ^ template.ng expression.ng constant.numeric.decimal.ts
+#                                          ^ template.ng expression.ng
+#                                           ^ template.ng expression.ng keyword.operator.ternary.ts
+#                                            ^ template.ng expression.ng
+#                                             ^ template.ng expression.ng constant.numeric.decimal.ts
+#                                              ^ template.ng expression.ng
+#                                               ^ template.ng expression.ng keyword.operator.ternary.ts
+#                                                ^ template.ng expression.ng
+#                                                 ^ template.ng expression.ng constant.numeric.decimal.ts
+#                                                  ^ template.ng expression.ng
+#                                                   ^ template.ng expression.ng keyword.operator.ternary.ts
+#                                                    ^ template.ng expression.ng
+#                                                     ^ template.ng expression.ng constant.numeric.decimal.ts
+#                                                      ^ template.ng expression.ng
+#                                                       ^^ template.ng punctuation.definition.block.ts
 >
 ><!-- Microsyntax -->
 #^^^^^^^^^^^^^^^^^^^^^ template.ng


### PR DESCRIPTION
The previous implementation of the template grammar for ternary
expressions would not match nested ternary expressions. In this commit
we update the matcher to use the TypeScript TM grammar's implementation
to do this correctly. Screenshots attached to the PR for this commit
demonstrate the change in a "real" template.

Closes #957
<img width="1551" alt="Screen Shot 2020-11-05 at 9 40 32 PM" src="https://user-images.githubusercontent.com/20735482/98323701-14498600-1fb0-11eb-922e-cc8c181fbcfb.png">
<img width="1551" alt="Screen Shot 2020-11-05 at 9 39 59 PM" src="https://user-images.githubusercontent.com/20735482/98323704-16134980-1fb0-11eb-8c5b-0c4df6d0a0a3.png">


