### PR TITLE
fix: LS not showing existing diagnostics on file open

### DIFF
--- a/integration/lsp/viewengine_spec.ts
+++ b/integration/lsp/viewengine_spec.ts
@@ -86,6 +86,25 @@ describe('Angular language server', () => {
       },
     });
   });
+
+  it('should show existing diagnostics on external template', async () => {
+    client.sendNotification(lsp.DidOpenTextDocumentNotification.type, {
+      textDocument: {
+        uri: `file://${FOO_TEMPLATE}`,
+        languageId: 'typescript',
+        version: 1,
+        text: `{{ doesnotexist }}`,
+      },
+    });
+    const diagnostics: lsp.Diagnostic[] = await new Promise(resolve => {
+      client.onNotification(
+          lsp.PublishDiagnosticsNotification.type, (params: lsp.PublishDiagnosticsParams) => {
+            resolve(params.diagnostics);
+          });
+    });
+    expect(diagnostics.length).toBe(1);
+    expect(diagnostics[0].message).toContain(`Identifier 'doesnotexist' is not defined.`);
+  });
 });
 
 describe('initialization', () => {

--- a/server/src/session.ts
+++ b/server/src/session.ts
@@ -272,17 +272,9 @@ export class Session {
         // configFileErrors is an empty array even if there's no error, so check length.
         this.connection.console.error(configFileErrors.map(e => e.messageText).join('\n'));
       }
-      if (!configFileName) {
-        // It is not really an error if there is no config file, because the
-        // first call to openClientFile() will create a project for the file if
-        // it does not exist, but the method will not return the config filename.
-        // In subsequent operations, we'll call this.getDefaultProjectForScriptInfo(),
-        // and there we make a second call to openClientFile(). By then, since
-        // the project has already been created, we will receive the config
-        // filename, and we can attach the file to the project it belongs to.
-        return;
-      }
-      const project = this.projectService.findProject(configFileName);
+      const project = configFileName ?
+          this.projectService.findProject(configFileName) :
+          this.projectService.getScriptInfo(filePath)?.containingProjects.find(isConfiguredProject);
       if (!project) {
         this.connection.console.error(`Failed to find project for ${filePath}`);
         return;
@@ -576,4 +568,8 @@ function isAngularProject(project: ts.server.Project, ngCore: string): boolean {
     }
   }
   return false;
+}
+
+function isConfiguredProject(project: ts.server.Project): project is ts.server.ConfiguredProject {
+  return project.projectKind === ts.server.ProjectKind.Configured;
 }


### PR DESCRIPTION
This commit fixes a bug whereby existing diagnostics in an external template
are not shown when the file is opened the first time. Diagnostics only show
up when subsequent edits are made to the file.
This is a regression after upgrading to TS 4.0

Fix https://github.com/angular/vscode-ng-language-service/issues/922