### PR TITLE
test: build integration test in ES2017

### DIFF
--- a/common/tsconfig.json
+++ b/common/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "composite": true,
     "outDir": "out",
-    "rootDir": ".",
+    "rootDir": "."
   },
   "include": ["*.ts"]
 }

--- a/integration/tsconfig.json
+++ b/integration/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
+    "target": "ES2017",
     "outDir": "out"
   },
   "references": [


### PR DESCRIPTION
Since integration test is only used locally, building it in ES2017
helps debugging (less verbose JS output).