### PR TITLE
feat: client-side implementation for ngcc feature

### DIFF
--- a/client/src/command-ngcc.ts
+++ b/client/src/command-ngcc.ts
@@ -1,0 +1,65 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {spawn} from 'child_process';
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+function resolveNgccFrom(directory: string): string|null {
+  try {
+    return require.resolve(`@angular/compiler-cli/ngcc/main-ngcc.js`, {
+      paths: [directory],
+    });
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve ngcc from the directory that contains the specified `tsconfig` and
+ * run ngcc.
+ */
+export async function resolveAndRunNgcc(
+    tsconfig: string, progress: vscode.Progress<string>): Promise<void> {
+  const directory = path.dirname(tsconfig);
+  const ngcc = resolveNgccFrom(directory);
+  if (!ngcc) {
+    throw new Error(`Failed to resolve ngcc from ${directory}`);
+  }
+  const childProcess = spawn(
+      ngcc,
+      [
+        '--tsconfig',
+        tsconfig,
+      ],
+      {
+        cwd: directory,
+      });
+
+  childProcess.stdout.on('data', (data: Buffer) => {
+    for (let entry of data.toString().split('\n')) {
+      entry = entry.trim();
+      if (entry) {
+        progress.report(entry);
+      }
+    }
+  });
+
+  return new Promise((resolve, reject) => {
+    childProcess.on('error', (error: Error) => {
+      reject(error);
+    });
+    childProcess.on('close', (code: number) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        throw new Error(`ngcc for ${tsconfig} returned exit code ${code}`);
+      }
+    });
+  });
+}

--- a/client/src/progress-reporter.ts
+++ b/client/src/progress-reporter.ts
@@ -1,0 +1,52 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as vscode from 'vscode';
+
+const EMPTY_DISPOSABLE = vscode.Disposable.from();
+
+class ProgressReporter implements vscode.Progress<unknown> {
+  private lastMessage: vscode.Disposable = EMPTY_DISPOSABLE;
+
+  report(value: unknown) {
+    this.lastMessage.dispose();  // clear the last message
+    // See https://code.visualstudio.com/api/references/icons-in-labels for
+    // icons available in vscode. "~spin" animates the icon.
+    this.lastMessage = vscode.window.setStatusBarMessage(`$(loading~spin) Angular: ${value}`);
+  }
+
+  finish() {
+    this.lastMessage.dispose();
+    this.lastMessage = EMPTY_DISPOSABLE;
+  }
+}
+
+interface Task<R> {
+  (progress: vscode.Progress<string>): Promise<R>;
+}
+
+/**
+ * Show progress in the editor. Progress is shown while running the given `task`
+ * callback and while the promise it returns is in the pending state.
+ * If the given `task` returns a rejected promise, this function will reject with
+ * the same promise.
+ */
+export async function withProgress<R>(options: vscode.ProgressOptions, task: Task<R>): Promise<R> {
+  // Although not strictly compatible, the signature of this function follows
+  // the signature of vscode.window.withProgress() to make it easier to switch
+  // to the official API if we choose to do so later.
+  const reporter = new ProgressReporter();
+  if (options.title) {
+    reporter.report(options.title);
+  }
+  try {
+    return await task(reporter);
+  } finally {
+    reporter.finish();
+  }
+}

--- a/common/notifications.ts
+++ b/common/notifications.ts
@@ -6,9 +6,31 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {NotificationType0} from 'vscode-jsonrpc';
+import {NotificationType, NotificationType0} from 'vscode-jsonrpc';
 
-export const projectLoadingNotification = {
-  start: new NotificationType0('angular/projectLoadingStart'),
-  finish: new NotificationType0('angular/projectLoadingFinish')
+export const ProjectLoadingStart = new NotificationType0('angular/projectLoadingStart');
+export const ProjectLoadingFinish = new NotificationType0('angular/projectLoadingFinish');
+
+export interface ProjectLanguageServiceParams {
+  projectName: string;
+  languageServiceEnabled: boolean;
+}
+
+export const ProjectLanguageService =
+    new NotificationType<ProjectLanguageServiceParams>('angular/projectLanguageService');
+
+export interface RunNgccParams {
+  configFilePath: string;
+}
+
+export const RunNgcc = new NotificationType<RunNgccParams>('angular/runNgcc');
+
+export type NgccCompleteParams = {
+  configFilePath: string; success: true;
+}|{
+  configFilePath: string;
+  success: false;
+  error: string;
 };
+
+export const NgccComplete = new NotificationType<NgccCompleteParams>('angular/ngccComplete');

--- a/server/src/session.ts
+++ b/server/src/session.ts
@@ -9,7 +9,7 @@
 import * as ts from 'typescript/lib/tsserverlibrary';
 import * as lsp from 'vscode-languageserver';
 
-import {projectLoadingNotification} from '../../common/out/notifications';
+import * as notification from '../../common/out/notifications';
 
 import {tsCompletionEntryToLspCompletionItem} from './completion';
 import {tsDiagnosticToLspDiagnostic} from './diagnostic';
@@ -114,7 +114,7 @@ export class Session {
     switch (event.eventName) {
       case ts.server.ProjectLoadingStartEvent:
         this.isProjectLoading = true;
-        this.connection.sendNotification(projectLoadingNotification.start);
+        this.connection.sendNotification(notification.ProjectLoadingStart);
         this.logger.info(`Loading new project: ${event.data.reason}`);
         break;
       case ts.server.ProjectLoadingFinishEvent: {
@@ -125,7 +125,7 @@ export class Session {
         } finally {
           if (this.isProjectLoading) {
             this.isProjectLoading = false;
-            this.connection.sendNotification(projectLoadingNotification.finish);
+            this.connection.sendNotification(notification.ProjectLoadingFinish);
           }
         }
         break;
@@ -285,7 +285,7 @@ export class Session {
     } catch (error) {
       if (this.isProjectLoading) {
         this.isProjectLoading = false;
-        this.connection.sendNotification(projectLoadingNotification.finish);
+        this.connection.sendNotification(notification.ProjectLoadingFinish);
       }
       if (error.stack) {
         this.error(error.stack);


### PR DESCRIPTION
This commit implements the client-side work to support the ngcc feature.

The idea is as follows:

1. Client receives notification from server
2. Client runs ngcc
3. Client sends notification to server once ngcc is done

Watch screen recording [here](https://drive.google.com/file/d/1U1RpRD7SOKfx3E0uOjKh36LyqCkiSTiF/view?usp=sharing)