### PR TITLE
build: update @angular/language-service to v11.1.0-next.0

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -12,7 +12,7 @@
     "node": ">=10.9.0 <13.0.0"
   },
   "dependencies": {
-    "@angular/language-service": "11.0.1",
+    "@angular/language-service": "11.1.0-next.0",
     "vscode-languageserver": "6.1.1",
     "vscode-uri": "2.1.2"
   },

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@angular/language-service@11.0.1":
-  version "11.0.1"
-  resolved "https://registry.yarnpkg.com/@angular/language-service/-/language-service-11.0.1.tgz#1e4cad8eaf67a3b2c83905eef59c67b25185dbc3"
-  integrity sha512-8POlwuyDo5iSVuUFnx24cUZ+x8thzTZg0SFwggs3nNUp+3FH1Dw8UqHJdzIaqGEX9IyKGH56mQXd0W2i8nV82Q==
+"@angular/language-service@11.1.0-next.0":
+  version "11.1.0-next.0"
+  resolved "https://registry.yarnpkg.com/@angular/language-service/-/language-service-11.1.0-next.0.tgz#1e3fd502267a07a283606066f1ebb17310d4b5f7"
+  integrity sha512-I5hux9v0erzepwyI8ilryEVJeaf0LbvL9aYuaXxfqetUe1fmDxYHeSbsGWly4ah1jfQuw13VaGC0YyKXWvbfxg==
 
 vscode-jsonrpc@^5.0.1:
   version "5.0.1"


### PR DESCRIPTION
Use `master` for the `next` version development, stable is now released
from `0.1100.x` branch