### PR TITLE
fix: mark project as dirty after enabling language service

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -6,6 +6,7 @@ set -ex -o pipefail
 (
   cd integration/project
   yarn
+  yarn ngcc
 )
 
 # Server unit tests

--- a/server/src/session.ts
+++ b/server/src/session.ts
@@ -125,6 +125,11 @@ export class Session {
       return;
     }
     project.enableLanguageService();
+    // When the language service got disabled, the program was discarded via
+    // languageService.cleanupSemanticCache(). However, the program is not
+    // recreated when the language service is re-enabled. We manually mark the
+    // project as dirty to force update the graph.
+    project.markAsDirty();
     this.info(`Enabling Ivy language service for ${project.projectName}.`);
   }
 


### PR DESCRIPTION
This commit fixes a bug in which the program becomes unavailable after
the language service is re-enabled, resulting in a crash.

When the language service is disabled, the program gets discarded.
However, when the language service is re-enabled, the program is not
recreated.

This bug was difficult to reproduce because it was masked by the fact that
during normal startup, ngcc gets run, and in the process, ngcc generates a
lockfile named `__ngcc_lock_file__` in the `node_modules` directory.
This triggers the directory watcher, and through a long chain of events,
reloads the Configured project, therefore re-creating the program.

Without ngcc run (make it a no-op), the extension will crash because the
language service is unable to return the program.