### PR TITLE
feat: add --logToConsole flag

### DIFF
--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -178,7 +178,7 @@ function getProbeLocations(configValue: string|null, bundled: string): string[] 
  */
 function constructArgs(ctx: vscode.ExtensionContext, debug: boolean): string[] {
   const config = vscode.workspace.getConfiguration();
-  const args: string[] = [];
+  const args: string[] = ['--logToConsole'];
 
   const ngLog: string = config.get('angular.log', 'off');
   if (ngLog !== 'off') {

--- a/server/src/cmdline_utils.ts
+++ b/server/src/cmdline_utils.ts
@@ -35,6 +35,7 @@ interface CommandLineOptions {
   ivy: boolean;
   logFile?: string;
   logVerbosity?: string;
+  logToConsole: boolean;
   ngProbeLocations: string[];
   tsProbeLocations: string[];
 }
@@ -45,6 +46,7 @@ export function parseCommandLine(argv: string[]): CommandLineOptions {
     ivy: hasArgument(argv, '--experimental-ivy'),
     logFile: findArgument(argv, '--logFile'),
     logVerbosity: findArgument(argv, '--logVerbosity'),
+    logToConsole: hasArgument(argv, '--logToConsole'),
     ngProbeLocations: parseStringArray(argv, '--ngProbeLocations'),
     tsProbeLocations: parseStringArray(argv, '--tsProbeLocations'),
   };
@@ -58,8 +60,9 @@ export function generateHelpMessage(argv: string[]) {
   Options:
     --help: Prints help message.
     --experimental-ivy: Enables the Ivy language service. Defaults to false.
-    --logFile: Location to log messages. Logging is disabled if not provided.
+    --logFile: Location to log messages. Logging to file is disabled if not provided.
     --logVerbosity: terse|normal|verbose|requestTime. See ts.server.LogLevel.
+    --logToConsole: Enables logging to console via 'window/logMessage'. Defaults to false.
     --ngProbeLocations: Path of @angular/language-service. Required.
     --tsProbeLocations: Path of typescript. Required.
 

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -39,6 +39,7 @@ const session = new Session({
   ngPlugin: ng.name,
   ngProbeLocation: ng.resolvedPath,
   ivy: options.ivy,
+  logToConsole: options.logToConsole,
 });
 
 // Log initialization info

--- a/server/src/session.ts
+++ b/server/src/session.ts
@@ -25,6 +25,7 @@ export interface SessionOptions {
   ngPlugin: string;
   ngProbeLocation: string;
   ivy: boolean;
+  logToConsole: boolean;
 }
 
 enum LanguageId {
@@ -45,12 +46,14 @@ export class Session {
   private readonly logger: ts.server.Logger;
   private readonly ivy: boolean;
   private readonly configuredProjToExternalProj = new Map<string, string>();
+  private readonly logToConsole: boolean;
   private diagnosticsTimeout: NodeJS.Timeout|null = null;
   private isProjectLoading = false;
 
   constructor(options: SessionOptions) {
     this.logger = options.logger;
     this.ivy = options.ivy;
+    this.logToConsole = options.logToConsole;
     // Create a connection for the server. The connection uses Node's IPC as a transport.
     this.connection = lsp.createConnection();
     this.addProtocolHandlers(this.connection);
@@ -677,7 +680,9 @@ export class Session {
    * @param message The message to show.
    */
   error(message: string): void {
-    this.connection.console.error(message);
+    if (this.logToConsole) {
+      this.connection.console.error(message);
+    }
     this.logger.msg(message, ts.server.Msg.Err);
   }
 
@@ -687,7 +692,9 @@ export class Session {
    * @param message The message to show.
    */
   warn(message: string): void {
-    this.connection.console.warn(message);
+    if (this.logToConsole) {
+      this.connection.console.warn(message);
+    }
     // ts.server.Msg does not have warning level, so log as info.
     this.logger.msg(`[WARN] ${message}`, ts.server.Msg.Info);
   }
@@ -698,7 +705,9 @@ export class Session {
    * @param message The message to show.
    */
   info(message: string): void {
-    this.connection.console.info(message);
+    if (this.logToConsole) {
+      this.connection.console.info(message);
+    }
     this.logger.msg(message, ts.server.Msg.Info);
   }
 


### PR DESCRIPTION
Provides a flag to turn off console logging completely.
This flag is different from `--logVerbosity`, which is used to control
the verbosity of logging to _file_.

Closes #584 