### PR TITLE
fix: match external templates to project on startup

### DIFF
--- a/integration/lsp/ivy_spec.ts
+++ b/integration/lsp/ivy_spec.ts
@@ -11,18 +11,19 @@ import * as lsp from 'vscode-languageserver-protocol';
 
 import {NgccComplete, ProjectLanguageService, ProjectLanguageServiceParams, RunNgcc, RunNgccParams} from '../../common/notifications';
 
-import {APP_COMPONENT, createConnection, initializeServer, openTextDocument} from './test_utils';
+import {APP_COMPONENT, createConnection, FOO_TEMPLATE, initializeServer, openTextDocument} from './test_utils';
 
 describe('Angular Ivy language server', () => {
   jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000; /* 10 seconds */
 
   let client: MessageConnection;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     client = createConnection({
       ivy: true,
     });
     client.listen();
+    await initializeServer(client);
   });
 
   afterEach(() => {
@@ -30,28 +31,24 @@ describe('Angular Ivy language server', () => {
   });
 
   it('should send ngcc notification after a project has finished loading', async () => {
-    await initializeServer(client);
     openTextDocument(client, APP_COMPONENT);
     const configFilePath = await onRunNgccNotification(client);
     expect(configFilePath.endsWith('integration/project/tsconfig.json')).toBeTrue();
   });
 
   it('should disable language service until ngcc has completed', async () => {
-    await initializeServer(client);
     openTextDocument(client, APP_COMPONENT);
     const languageServiceEnabled = await onLanguageServiceStateNotification(client);
     expect(languageServiceEnabled).toBeFalse();
   });
 
   it('should re-enable language service once ngcc has completed', async () => {
-    await initializeServer(client);
     openTextDocument(client, APP_COMPONENT);
     const languageServiceEnabled = await waitForNgcc(client);
     expect(languageServiceEnabled).toBeTrue();
   });
 
   it('should handle hover on inline template', async () => {
-    await initializeServer(client);
     openTextDocument(client, APP_COMPONENT);
     const languageServiceEnabled = await waitForNgcc(client);
     expect(languageServiceEnabled).toBeTrue();
@@ -65,6 +62,23 @@ describe('Angular Ivy language server', () => {
       language: 'typescript',
       value: '(property) AppComponent.name: string',
     });
+  });
+
+  it('should show existing diagnostics on external template', async () => {
+    client.sendNotification(lsp.DidOpenTextDocumentNotification.type, {
+      textDocument: {
+        uri: `file://${FOO_TEMPLATE}`,
+        languageId: 'typescript',
+        version: 1,
+        text: `{{ doesnotexist }}`,
+      },
+    });
+    const languageServiceEnabled = await waitForNgcc(client);
+    expect(languageServiceEnabled).toBeTrue();
+    const diagnostics = await getDiagnosticsForFile(client, FOO_TEMPLATE);
+    expect(diagnostics.length).toBe(1);
+    expect(diagnostics[0].message)
+        .toBe(`Property 'doesnotexist' does not exist on type 'FooComponent'.`);
   });
 });
 
@@ -81,6 +95,18 @@ function onLanguageServiceStateNotification(client: MessageConnection): Promise<
     client.onNotification(ProjectLanguageService, (params: ProjectLanguageServiceParams) => {
       resolve(params.languageServiceEnabled);
     });
+  });
+}
+
+function getDiagnosticsForFile(
+    client: MessageConnection, fileName: string): Promise<lsp.Diagnostic[]> {
+  return new Promise(resolve => {
+    client.onNotification(
+        lsp.PublishDiagnosticsNotification.type, (params: lsp.PublishDiagnosticsParams) => {
+          if (params.uri === `file://${fileName}`) {
+            resolve(params.diagnostics);
+          }
+        });
   });
 }
 

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -74,3 +74,8 @@ export function lspRangeToTsPositions(
   const end = lspPositionToTsPosition(scriptInfo, range.end);
   return [start, end];
 }
+
+export function isConfiguredProject(project: ts.server.Project):
+    project is ts.server.ConfiguredProject {
+  return project.projectKind === ts.server.ProjectKind.Configured;
+}


### PR DESCRIPTION
Currently, Ivy LS is not able to match external projects to their external
templates if no TS files are open. This is because Ivy LS does not implement
`getExternalFiles()`.

To fix this, we take a different route:
After ngcc has run, we send diagnostics for all the open files. But in the
case where all open files are external templates, we first get diagnostics
for a root TS file, then process the rest. Processing a root TS file triggers
a global analysis, during which we match the external templates to their
project.

For a more detailed explanation, see
https://github.com/angular/vscode-ng-language-service/wiki/Project-Matching-for-External-Templates