### PR TITLE
fix: explicitly type argument for Promise in TS 4.1

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -69,7 +69,7 @@ function registerNotificationHandlers(client: lsp.LanguageClient) {
           location: vscode.ProgressLocation.Window,
           title: 'Initializing Angular language features',
         },
-        () => new Promise((resolve) => {
+        () => new Promise<void>((resolve) => {
           client.onNotification(notification.ProjectLoadingFinish, resolve);
         }),
     );


### PR DESCRIPTION
TS 4.1 introduced a breaking change in which `resolve` no longer has an
optional parameter, so by default, it must now be passed a value, or
an explicit type argument must be added.

See https://devblogs.microsoft.com/typescript/announcing-typescript-4-1/#resolves-parameters-are-no-longer-optional-in-promises