### PR TITLE
feat: new command 'openLogFile' for opening log file from editor

### DIFF
--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -8,25 +8,49 @@
 
 import * as vscode from 'vscode';
 import * as lsp from 'vscode-languageclient';
+import {ServerOptions} from '../../common/out/initialize';
 
 /**
  * Represent a vscode command with an ID and an impl function `execute`.
  */
 interface Command {
   id: string;
-  execute(): Promise<vscode.Disposable>;
+  execute(): Promise<unknown>;
 }
 
 /**
  * Restart the language server by killing the process then spanwing a new one.
  * @param client language client
+ * @param context extension context for adding disposables
  */
-function restartNgServer(client: lsp.LanguageClient): Command {
+function restartNgServer(client: lsp.LanguageClient, context: vscode.ExtensionContext): Command {
   return {
     id: 'angular.restartNgServer',
     async execute() {
       await client.stop();
-      return client.start();
+      context.subscriptions.push(client.start());
+    },
+  };
+}
+
+/**
+ * Open the current server log file in a new editor.
+ */
+function openLogFile(client: lsp.LanguageClient): Command {
+  return {
+    id: 'angular.openLogFile',
+    async execute() {
+      const serverOptions: ServerOptions|undefined = client.initializeResult?.serverOptions;
+      if (!serverOptions?.logFile) {
+        // TODO: We could show a MessageItem to help users automatically update
+        // the configuration option then restart the server, but we currently do
+        // not reload the server options when restarting the server.
+        vscode.window.showErrorMessage(
+            `Angular Server logging is off. Please set 'angular.log' and reload the window.`);
+        return;
+      }
+      const document = await vscode.workspace.openTextDocument(serverOptions.logFile);
+      return vscode.window.showTextDocument(document);
     },
   };
 }
@@ -34,15 +58,17 @@ function restartNgServer(client: lsp.LanguageClient): Command {
 /**
  * Register all supported vscode commands for the Angular extension.
  * @param client language client
+ * @param context extension context for adding disposables
  */
-export function registerCommands(client: lsp.LanguageClient): vscode.Disposable[] {
+export function registerCommands(
+    client: lsp.LanguageClient, context: vscode.ExtensionContext): void {
   const commands: Command[] = [
-    restartNgServer(client),
+    restartNgServer(client, context),
+    openLogFile(client),
   ];
 
-  const disposables = commands.map((command) => {
-    return vscode.commands.registerCommand(command.id, command.execute);
-  });
-
-  return disposables;
+  for (const command of commands) {
+    const disposable = vscode.commands.registerCommand(command.id, command.execute);
+    context.subscriptions.push(disposable);
+  }
 }

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -53,7 +53,8 @@ export function activate(context: vscode.ExtensionContext) {
 
   // Push the disposable to the context's subscriptions so that the
   // client can be deactivated on extension deactivation
-  context.subscriptions.push(...registerCommands(client), client.start());
+  registerCommands(client, context);
+  context.subscriptions.push(client.start());
 
   client.onDidChangeState((e: lsp.StateChangeEvent) => {
     if (e.newState === lsp.State.Running) {

--- a/common/initialize.ts
+++ b/common/initialize.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export interface ServerOptions {
+  logFile?: string;
+}

--- a/integration/lsp/viewengine_spec.ts
+++ b/integration/lsp/viewengine_spec.ts
@@ -114,7 +114,7 @@ describe('initialization', () => {
     });
     client.listen();
     const response = await initializeServer(client);
-    expect(response).toEqual({
+    expect(response).toEqual(jasmine.objectContaining({
       capabilities: {
         textDocumentSync: 2,
         completionProvider: {
@@ -130,7 +130,7 @@ describe('initialization', () => {
           },
         },
       },
-    });
+    }));
     client.dispose();
   });
 });

--- a/package.json
+++ b/package.json
@@ -22,6 +22,11 @@
         "command": "angular.restartNgServer",
         "title": "Restart Angular Language server",
         "category": "Angular"
+      },
+      {
+        "command": "angular.openLogFile",
+        "title": "Open Angular Server log",
+        "category": "Angular"
       }
     ],
     "configuration": {

--- a/server/src/session.ts
+++ b/server/src/session.ts
@@ -9,6 +9,7 @@
 import * as ts from 'typescript/lib/tsserverlibrary';
 import * as lsp from 'vscode-languageserver';
 
+import {ServerOptions} from '../../common/out/initialize';
 import * as notification from '../../common/out/notifications';
 
 import {tsCompletionEntryToLspCompletionItem} from './completion';
@@ -248,6 +249,9 @@ export class Session {
   }
 
   private onInitialize(params: lsp.InitializeParams): lsp.InitializeResult {
+    const serverOptions: ServerOptions = {
+      logFile: this.logger.getLogFileName(),
+    };
     return {
       capabilities: {
         textDocumentSync: lsp.TextDocumentSyncKind.Incremental,
@@ -264,6 +268,7 @@ export class Session {
           workspaceFolders: {supported: true},
         },
       },
+      serverOptions,
     };
   }
 


### PR DESCRIPTION
Add a new command for opening the Angular log file right from the editor.

Screenshot of new command:
<img width="1792" alt="Screen Shot 2020-11-20 at 3 03 35 PM" src="https://user-images.githubusercontent.com/2941178/99859023-b7b7a080-2b43-11eb-8d43-f910b9655e91.png">

Screenshot of log file with highlighting:
<img width="1792" alt="Screen Shot 2020-11-20 at 3 03 45 PM" src="https://user-images.githubusercontent.com/2941178/99859036-c1410880-2b43-11eb-9873-3d9503b3d2e2.png">

Screenshot of failure:
<img width="1792" alt="Screen Shot 2020-11-20 at 3 12 46 PM" src="https://user-images.githubusercontent.com/2941178/99859089-e2095e00-2b43-11eb-9635-583f80af0bc0.png">

Closes #990 