### PR TITLE
feat: add getReferencesAtPosition to capabilities

### DIFF
--- a/integration/lsp/viewengine_spec.ts
+++ b/integration/lsp/viewengine_spec.ts
@@ -124,6 +124,7 @@ describe('initialization', () => {
         definitionProvider: true,
         typeDefinitionProvider: false,
         hoverProvider: true,
+        referencesProvider: false,
         workspace: {
           workspaceFolders: {
             supported: true,


### PR DESCRIPTION
The Angular Language Service for Ivy will have a be able to provide
references for a template location so we need to add `referencesProvider` to the capabilities.