### PR TITLE
fix: enable type definition provider for Ivy only

### DIFF
--- a/integration/lsp/viewengine_spec.ts
+++ b/integration/lsp/viewengine_spec.ts
@@ -122,7 +122,7 @@ describe('initialization', () => {
           triggerCharacters: ['<', '.', '*', '[', '(', '$', '|'],
         },
         definitionProvider: true,
-        typeDefinitionProvider: true,
+        typeDefinitionProvider: false,
         hoverProvider: true,
         workspace: {
           workspaceFolders: {

--- a/server/src/session.ts
+++ b/server/src/session.ts
@@ -258,7 +258,7 @@ export class Session {
           triggerCharacters: ['<', '.', '*', '[', '(', '$', '|']
         },
         definitionProvider: true,
-        typeDefinitionProvider: true,
+        typeDefinitionProvider: this.ivy,
         hoverProvider: true,
         workspace: {
           workspaceFolders: {supported: true},


### PR DESCRIPTION
View Engine language service does not support `getTypeDefinitionAtPosition`.

See https://github.com/angular/angular/blob/3a6e7b5d2a54d011832191b96df5d8fd28a28740/packages/language-service/src/ts_plugin.ts#L113-L116