### PR TITLE
build: use NPM to install node_modules

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -13,7 +13,7 @@ rm -rf **/*.tsbuildinfo
 yarn run compile
 
 # Copy files to package root
-cp package.json yarn.lock angular.png CHANGELOG.md README.md dist/npm
+cp package.json angular.png CHANGELOG.md README.md dist/npm
 # Copy files to server directory
 cp server/package.json server/README.md dist/npm/server
 # Build and copy files to syntaxes directory
@@ -23,9 +23,11 @@ mkdir dist/npm/syntaxes
 cp syntaxes/!(tsconfig).json dist/npm/syntaxes
 
 pushd dist/npm
-yarn install --production --ignore-scripts
+# TODO(kyliau): vsce does not bundle nested node_modules due to bug
+# https://github.com/microsoft/vscode-vsce/issues/432 so install using NPM for now.
+npm install --production --ignore-scripts
 
 sed -i -e 's#./dist/client/extension#./index#' package.json
-../../node_modules/.bin/vsce package --yarn --out ngls.vsix
+../../node_modules/.bin/vsce package
 
 popd


### PR DESCRIPTION
`semver` is a prod dependency of `vscode-languageclient`.
In the old build pipeline, `vscode-languageclient` is declared in
`client/package.json`.
When yarn installs dependencies in the `client` directory, it will put `semver`
next to `vscode-languageclient` in `client/node_modules`.

In the new build pipeline, `vscode-languageclient` is declared in root
`package.json`.
When yarn installs dependencies in the root directory, it chooses not to hoist
`semver`, instead puts it in a nested node_modules under
`node_modules/vscode-languageclient/node_modules`.

There is a bug in vsce that causes it to ignore nested `node_modules`,
resulting in a `vsix` build that is broken. The issue is tracked
[here](https://github.com/microsoft/vscode-vsce/issues/432), but it does not look like a fix will come any time soon.

For now we should install our dependencies using NPM.