### PR TITLE
build: output es2017

### DIFF
--- a/integration/tsconfig.json
+++ b/integration/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "target": "ES2017",
     "outDir": "../dist/integration",
     "rootDirs": ["..", "dist"]
   },

--- a/syntaxes/test/driver.ts
+++ b/syntaxes/test/driver.ts
@@ -47,7 +47,7 @@ async function snapshotTest({scopeName, grammarFiles, testFile}: TestCase): Prom
   return spawn('yarn', options, {stdio: 'inherit' /* use parent process IO */}).catch(code => code);
 }
 
-describe('snapshot tests', async () => {
+describe('snapshot tests', () => {
   for (let tc of SNAPSHOT_TEST_CASES) {
     it(`should work for ${tc.name}`, async () => {
       const ec = await snapshotTest(tc);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2015",
+    "target": "es2017",
     "module": "commonjs",
     "moduleResolution": "node",
     "sourceMap": true,


### PR DESCRIPTION
The language server only supports node engine `>=10.9.0 <13.0.0`,
and according to https://node.green/ this version range fully supports
async/await, so we don't have to downlevel to es2015. This will make
the bundle smaller and faster. Also makes debugging easier.

https://github.com/angular/vscode-ng-language-service/blob/7fe63cbae86b1aa56df75dac96d7c008c16a4604/server/package.json#L12