### PR TITLE
fix: disable AutoImportProviderProject

### DIFF
--- a/server/src/session.ts
+++ b/server/src/session.ts
@@ -83,6 +83,11 @@ export class Session {
           scriptKind: ts.ScriptKind.External,
         },
       ],
+      preferences: {
+        // We don't want the AutoImportProvider projects to be created. See
+        // https://devblogs.microsoft.com/typescript/announcing-typescript-4-0/#smarter-auto-imports
+        includePackageJsonAutoImports: 'off',
+      },
     });
 
     projSvc.configurePlugin({


### PR DESCRIPTION
TypeScript 4.0 added a new feature to provider smarter auto-imports,
(see https://devblogs.microsoft.com/typescript/announcing-typescript-4-0/#smarter-auto-imports)
but feature is not needed in Angular language service. We should turn this
off to improve performance.