### PR TITLE
fix: move ngcc operation to server

### DIFF
--- a/client/src/progress-reporter.ts
+++ b/client/src/progress-reporter.ts
@@ -10,43 +10,18 @@ import * as vscode from 'vscode';
 
 const EMPTY_DISPOSABLE = vscode.Disposable.from();
 
-class ProgressReporter implements vscode.Progress<unknown> {
+export class ProgressReporter implements vscode.Progress<unknown> {
   private lastMessage: vscode.Disposable = EMPTY_DISPOSABLE;
 
   report(value: unknown) {
     this.lastMessage.dispose();  // clear the last message
     // See https://code.visualstudio.com/api/references/icons-in-labels for
     // icons available in vscode. "~spin" animates the icon.
-    this.lastMessage = vscode.window.setStatusBarMessage(`$(loading~spin) Angular: ${value}`);
+    this.lastMessage = vscode.window.setStatusBarMessage(`$(sync~spin) Angular: ${value}`);
   }
 
   finish() {
     this.lastMessage.dispose();
     this.lastMessage = EMPTY_DISPOSABLE;
-  }
-}
-
-interface Task<R> {
-  (progress: vscode.Progress<string>): Promise<R>;
-}
-
-/**
- * Show progress in the editor. Progress is shown while running the given `task`
- * callback and while the promise it returns is in the pending state.
- * If the given `task` returns a rejected promise, this function will reject with
- * the same promise.
- */
-export async function withProgress<R>(options: vscode.ProgressOptions, task: Task<R>): Promise<R> {
-  // Although not strictly compatible, the signature of this function follows
-  // the signature of vscode.window.withProgress() to make it easier to switch
-  // to the official API if we choose to do so later.
-  const reporter = new ProgressReporter();
-  if (options.title) {
-    reporter.report(options.title);
-  }
-  try {
-    return await task(reporter);
-  } finally {
-    reporter.finish();
   }
 }

--- a/common/notifications.ts
+++ b/common/notifications.ts
@@ -18,19 +18,3 @@ export interface ProjectLanguageServiceParams {
 
 export const ProjectLanguageService =
     new NotificationType<ProjectLanguageServiceParams>('angular/projectLanguageService');
-
-export interface RunNgccParams {
-  configFilePath: string;
-}
-
-export const RunNgcc = new NotificationType<RunNgccParams>('angular/runNgcc');
-
-export type NgccCompleteParams = {
-  configFilePath: string; success: true;
-}|{
-  configFilePath: string;
-  success: false;
-  error: string;
-};
-
-export const NgccComplete = new NotificationType<NgccCompleteParams>('angular/ngccComplete');

--- a/common/progress.ts
+++ b/common/progress.ts
@@ -1,0 +1,21 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ProgressType} from 'vscode-jsonrpc';
+
+export type NgccProgress = {
+  done: false,
+  configFilePath: string,
+  message: string,
+}|{
+  done: true,
+  configFilePath: string,
+  success: boolean,
+};
+export const NgccProgressToken = 'ngcc';
+export const NgccProgressType = new ProgressType<NgccProgress>();

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -6,7 +6,6 @@ set -ex -o pipefail
 (
   cd integration/project
   yarn
-  yarn ngcc
 )
 
 # Server unit tests


### PR DESCRIPTION
This commit fixes a bug in which ngcc could not be resolved from the client
when the extension is running in the production vscode environment.

This is because internally, the client depends on `require.resolve` to look
for `ngcc` given the directory where the `tsconfig.json` is.
However, vscode provides its own [`require` mechanism][1], which is different
from Node.js. In particular, the bug is due to `require.resolve` not honoring
the `paths` parameter provided to the method. See Node.js [documentation][2] on
`require.resolve`.

We did not catch this bug because the custom `require` is not used
in the extension development host.

In order to mitigate this, we have a few options:

1. Use an external [`resolve` package][3] in the client to perform node module resolution
2. Bundle ngcc with the client
3. Move ngcc operation to the server

(1) is not ideal because it adds an external dependency to the extension

(2) could potentially lead to compatibility issues due to different version
of ngcc in the extension vs user's project.

(3) would not only solve this issue, but also provides the additional benefit
of reducing the work needed to integrate the language server for clients
other than vscode (vim, emacs, for example).
This is because the client needs to do some extra work to find ngcc then
launch it, and report back to the server that the operation has completed.
With this change, the server handles ngcc completely, and no work is needed
on the client side.

As an aside, the initial motivation for implementing ngcc on the client
side is to provide the guarantee that the server is idempotent, i.e. it should
not produce the side effect of modifying files on disk, which ngcc does.
However, at this point, the benefits outweigh the cons, so ngcc operation is
moved to the server.

[1]: https://github.com/microsoft/vscode/blob/92adef0bac1260a6273443a2132428fdfc28a31f/src/vs/loader.js#L743-L745
[2]: https://nodejs.org/docs/latest-v12.x/api/modules.html#modules_require_resolve_request_options
[3]: https://www.npmjs.com/package/resolve