### PR TITLE
test: run ngcc before test starts

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -6,6 +6,7 @@ set -ex -o pipefail
 (
   cd integration/project
   yarn
+  yarn ngcc
 )
 
 # Server unit tests


### PR DESCRIPTION
We should run `ngcc` before the test starts otherwise ngcc will run
during the LSP tests and potentially run into timeouts.