### PR TITLE
fix: do not disable language service if ngcc fails

### DIFF
--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -129,10 +129,10 @@ function registerProgressHandlers(client: lsp.LanguageClient, context: vscode.Ex
           progressReporters.delete(configFilePath);
           if (!params.success) {
             const selection = await vscode.window.showErrorMessage(
-                `Failed to run ngcc. Ivy language service is disabled. ` +
+                `Angular extension might not work correctly because ngcc operation failed. ` +
+                    `Try to invoke ngcc manually by running 'npm/yarn run ngcc'. ` +
                     `Please see the extension output for more information.`,
-                {modal: true},
-                'See error message',
+                'Show output',
             );
             if (selection) {
               client.outputChannel.show();

--- a/server/src/session.ts
+++ b/server/src/session.ts
@@ -152,9 +152,11 @@ export class Session {
       });
     }
 
-    if (!success) {
-      return;
-    }
+    // Re-enable language service even if ngcc fails, because users could fix
+    // the problem by running ngcc themselves. If we keep language service
+    // disabled, there's no way users could use the extension even after
+    // resolving ngcc issues. On the client side, we will warn users about
+    // potentially degraded experience.
 
     this.reenableLanguageServiceForProject(configFilePath);
   }


### PR DESCRIPTION
Re-enable language service even if ngcc fails, because users could fix the
problem by running ngcc themselves. If we keep language service disabled,
there's no way users could use the extension even after resolving ngcc issues.
On the client side, we warn users about potentially degraded experience.

Fix #1041

<img width="934" alt="Screen Shot 2020-12-22 at 2 40 19 PM" src="https://user-images.githubusercontent.com/2941178/102939991-29954980-4464-11eb-9c4a-e7101616a6b5.png">
