### PR TITLE
build: add bin field to package.json

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -15,7 +15,7 @@ yarn run compile
 # Copy files to package root
 cp package.json angular.png CHANGELOG.md README.md dist/npm
 # Copy files to server directory
-cp server/package.json server/README.md dist/npm/server
+cp -r server/package.json server/README.md server/bin dist/npm/server
 # Build and copy files to syntaxes directory
 yarn run build:syntaxes
 mkdir dist/npm/syntaxes

--- a/server/bin/ngserver
+++ b/server/bin/ngserver
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+require('./index.js')

--- a/server/package.json
+++ b/server/package.json
@@ -11,6 +11,9 @@
   "engines": {
     "node": ">=10.9.0 <13.0.0"
   },
+  "bin": {
+    "ngserver": "./bin/ngserver"
+  },
   "dependencies": {
     "@angular/language-service": "11.1.0-next.3",
     "vscode-jsonrpc": "6.0.0",


### PR DESCRIPTION
This commits add a `bin` field for the language server so that it can
be invoked as a standalone binary.

PR closes #1048