### PR TITLE
feat: enable tracing of LSP messages and payload

### DIFF
--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -64,6 +64,9 @@ export class AngularLanguageClient implements vscode.Disposable {
     // Create the language client and start the client.
     const forceDebug = process.env['NG_DEBUG'] === 'true';
     this.client = new lsp.LanguageClient(
+        // This is the ID for Angular-specific configurations, like angular.log,
+        // angular.ngdk, etc. See contributes.configuration in package.json.
+        'angular',
         this.name,
         serverOptions,
         this.clientOptions,

--- a/package.json
+++ b/package.json
@@ -56,6 +56,17 @@
           "type": "boolean",
           "default": false,
           "description": "This is an experimental feature that enables the Ivy language service."
+        },
+        "angular.trace.server": {
+          "type": "string",
+          "scope": "window",
+          "enum": [
+            "off",
+            "messages",
+            "verbose"
+          ],
+          "default": "off",
+          "description": "Traces the communication between VS Code and the Angular language server."
         }
       }
     },


### PR DESCRIPTION
This commit adds a new configuration `angular.trace.server` to enable tracing
of the messages sent between the LSP client and LSP server.

This configuration is not used by Angular itself. Rather, it's read by the
`vscode-languageclient` package. See
https://github.com/microsoft/vscode-languageserver-node/blob/adb52f1276291b5bf8eaa97e053db8bb699b6872/client/src/common/client.ts#L3431

Once enabled, the request name, request duration, and optionally the request
payload will be logged to the Output console in vscode.

Example log:
```
[Trace - 3:58:03 PM] Received notification 'window/logMessage'.
[Trace - 3:58:03 PM] Received response 'initialize - (0)' in 777ms.
[Trace - 3:58:03 PM] Sending notification 'initialized'.
[Trace - 3:58:03 PM] Sending notification 'textDocument/didOpen'.
[Trace - 3:58:03 PM] Received notification 'angular/projectLoadingStart'.
[Trace - 3:58:08 PM] Received notification 'angular/projectLoadingFinish'.
[Trace - 3:58:09 PM] Received notification '$/progress'.
[Trace - 3:58:09 PM] Received notification 'window/logMessage'.
[Trace - 3:58:10 PM] Received notification 'textDocument/publishDiagnostics'.
[Trace - 3:58:14 PM] Sending request 'textDocument/hover - (2)'.
[Trace - 3:58:14 PM] Received response 'textDocument/hover - (2)' in 39ms.
[Trace - 3:58:15 PM] Sending request 'textDocument/definition - (3)'.
[Trace - 3:58:15 PM] Received response 'textDocument/definition - (3)' in 3ms.
[Trace - 3:58:15 PM] Sending notification 'textDocument/didOpen'.
[Trace - 3:58:15 PM] Received notification 'textDocument/publishDiagnostics'.
[Trace - 3:58:16 PM] Sending notification 'textDocument/didClose'.
[Trace - 3:58:17 PM] Sending request 'textDocument/hover - (4)'.
[Trace - 3:58:17 PM] Received response 'textDocument/hover - (4)' in 13ms.
```