### PR TITLE
build: support Node 14

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -9,7 +9,7 @@
   "author": "Angular",
   "license": "MIT",
   "engines": {
-    "node": ">=10.9.0 <13.0.0"
+    "node": ">=10.9.0 <15.0.0"
   },
   "bin": {
     "ngserver": "./bin/ngserver"


### PR DESCRIPTION
Adds support for Node 14, which is the latest Active LTS, according to
https://nodejs.org/en/about/releases/

(vscode is still on Node 12.14.x)

Close https://github.com/angular/vscode-ng-language-service/issues/1040