### PR TITLE
test: kill server instance after each test

### DIFF
--- a/integration/lsp/test_utils.ts
+++ b/integration/lsp/test_utils.ts
@@ -42,10 +42,14 @@ export function createConnection(serverOptions: ServerOptions): MessageConnectio
     // execArgv: ['--inspect-brk=9229']
   });
 
-  return createMessageConnection(
+  const connection = createMessageConnection(
       new IPCMessageReader(server),
       new IPCMessageWriter(server),
   );
+  connection.onDispose(() => {
+    server.kill();
+  });
+  return connection;
 }
 
 export function initializeServer(client: MessageConnection): Promise<lsp.InitializeResult> {


### PR DESCRIPTION
Currently we spawn a new process for the language server for each test.
However, they are all kept alive. This PR fixes the resource leak by killing
the server after each test.