### PR TITLE
perf: delay closing of orphaned projects until next open

### DIFF
--- a/server/src/session.ts
+++ b/server/src/session.ts
@@ -380,6 +380,7 @@ export class Session {
       }
       throw error;
     }
+    this.closeOrphanedExternalProjects();
   }
 
   /**
@@ -406,20 +407,15 @@ export class Session {
       return;
     }
     this.projectService.closeClientFile(filePath);
-    this.maybeCloseExternalProject(filePath);
   }
 
   /**
    * We open external projects for files so that we can prevent TypeScript from closing a project
    * when there is open external HTML template that still references the project. This function
-   * checks if there are no longer any open files in the project for the given `filePath`. If there
+   * checks if there are no longer any open files in any external project. If there
    * aren't, we also close the external project that was created.
    */
-  private maybeCloseExternalProject(filePath: string) {
-    const scriptInfo = this.projectService.getScriptInfo(filePath);
-    if (!scriptInfo) {
-      return;
-    }
+  private closeOrphanedExternalProjects() {
     for (const [configuredProjName, externalProjName] of this.configuredProjToExternalProj) {
       const configuredProj = this.projectService.findProject(configuredProjName);
       if (!configuredProj || configuredProj.isClosed()) {


### PR DESCRIPTION
Currently, when a document is closed, we check to see if there are any other open
files in the associated project for that file. If not, we close the project (more
specifically, we close the _external_ project for the HTML files which releases
the inferred project and results in it being closed as well). If vscode, when
navigating between files, even of the same project, this can result in the
project being closed and then opened immediately because vscode closes
the currently open file before opening the next.

Instead, we wait to close "orphaned" external projects until after the
next file has finished opening. This way, we avoid closing and opening a
project when the two files are part of the same project.

Fixes  https://github.com/angular/vscode-ng-language-service/issues/1092