### PR TITLE
Suggest strict templates

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -3,6 +3,16 @@
   "version": "0.2.0",
   "configurations": [
     {
+      "name": "Integration test: Attach to server",
+      "port": 9330,
+      "request": "attach",
+      "skipFiles": [
+        "<node_internals>/**"
+      ],
+      "outFiles": ["${workspaceRoot}/dist/integration/lsp/*.js"],
+      "type": "node"
+    },
+    {
       "type": "extensionHost",
       "request": "launch",
       "name": "Launch Client",

--- a/common/notifications.ts
+++ b/common/notifications.ts
@@ -18,3 +18,11 @@ export interface ProjectLanguageServiceParams {
 
 export const ProjectLanguageService =
     new NotificationType<ProjectLanguageServiceParams>('angular/projectLanguageService');
+
+export interface SuggestStrictModeParams {
+  configFilePath: string;
+  message: string;
+}
+
+export const SuggestStrictMode =
+    new NotificationType<SuggestStrictModeParams>('angular/suggestStrictMode');

--- a/integration/lsp/test_utils.ts
+++ b/integration/lsp/test_utils.ts
@@ -18,6 +18,7 @@ const PROJECT_PATH = `${PACKAGE_ROOT}/integration/project`;
 export const APP_COMPONENT = `${PROJECT_PATH}/app/app.component.ts`;
 export const FOO_TEMPLATE = `${PROJECT_PATH}/app/foo.component.html`;
 export const FOO_COMPONENT = `${PROJECT_PATH}/app/foo.component.ts`;
+export const TSCONFIG = `${PROJECT_PATH}/tsconfig.json`;
 
 export interface ServerOptions {
   ivy: boolean;
@@ -40,7 +41,7 @@ export function createConnection(serverOptions: ServerOptions): MessageConnectio
       TSC_NONPOLLING_WATCHER: 'true',
     },
     // uncomment to debug server process
-    // execArgv: ['--inspect-brk=9229']
+    // execArgv: ['--inspect-brk=9330']
   });
 
   const connection = createMessageConnection(
@@ -86,4 +87,23 @@ export function openTextDocument(client: MessageConnection, filePath: string) {
       text: fs.readFileSync(filePath, 'utf-8'),
     },
   });
+}
+
+export function createTracer(): lsp.Tracer {
+  return {
+    log(messageOrDataObject: string|any, data?: string) {
+      if (typeof messageOrDataObject === 'string') {
+        const message = messageOrDataObject;
+        console.log(`[Trace - ${(new Date().toLocaleTimeString())}] ${message}`);
+        if (data) {
+          console.log(data);
+        }
+      } else {
+        const dataObject = messageOrDataObject;
+        console.log(
+            `[Trace - ${(new Date().toLocaleTimeString())}] ` +
+            JSON.stringify(dataObject, null, 2));
+      }
+    },
+  };
 }

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "test:syntaxes": "yarn compile:syntaxes-test && yarn build:syntaxes && jasmine dist/syntaxes/test/driver.js"
   },
   "dependencies": {
-    "@angular/language-service": "v11.2.0-next.0",
+    "@angular/language-service": "11.2.0-next.0",
     "typescript": "~4.1.0",
     "vscode-jsonrpc": "6.0.0",
     "vscode-languageclient": "7.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@angular/language-service@v11.2.0-next.0":
+"@angular/language-service@11.2.0-next.0":
   version "11.2.0-next.0"
   resolved "https://registry.yarnpkg.com/@angular/language-service/-/language-service-11.2.0-next.0.tgz#092281d39b87c74cebcc3506ae8bd61fcf8dbec9"
   integrity sha512-+NMO2WAk932zqho1mPK4L5WLDMWukPBLe47uVQ1PPkVmAIo26pQ3y9oGxOlOYTQtWO9HDV72NazNnV5kIBX7rQ==


### PR DESCRIPTION
This commit adds a prompt to encourage users turn on `strictTemplates` so
that they can get the most out of Angular language service.

<img width="805" alt="Screen Shot 2021-02-03 at 11 06 10 AM" src="https://user-images.githubusercontent.com/2941178/106796209-eb1cae00-660f-11eb-82f5-933c958c9004.png">

PR close #1053