### PR TITLE
fix: ngcc progress not reported

### DIFF
--- a/server/src/ngcc.ts
+++ b/server/src/ngcc.ts
@@ -47,6 +47,7 @@ export async function resolveAndRunNgcc(tsconfig: string, progress: Progress): P
       ],
       {
         cwd: resolve(cwd),
+        silent: true,  // pipe stderr and stdout so that we can report progress
       });
 
   let stderr = '';


### PR DESCRIPTION
ngcc progress is supposed to be reported to the client, but since the child
process is not silenced, stdio got inherited from the parent process. As a
result, ngcc progress shows up in the Output panel of Angular language service
instead of the status bar in vscode.