### PR TITLE
feat: Prompt to use the Ivy Language Service if VE is detected

### DIFF
--- a/common/notifications.ts
+++ b/common/notifications.ts
@@ -26,3 +26,10 @@ export interface SuggestStrictModeParams {
 
 export const SuggestStrictMode =
     new NotificationType<SuggestStrictModeParams>('angular/suggestStrictMode');
+
+export interface SuggestIvyLanguageServiceParams {
+  message: string;
+}
+
+export const SuggestIvyLanguageService =
+    new NotificationType<SuggestIvyLanguageServiceParams>('angular/suggestIvyLanguageServiceMode');

--- a/integration/lsp/test_utils.ts
+++ b/integration/lsp/test_utils.ts
@@ -30,7 +30,7 @@ export function createConnection(serverOptions: ServerOptions): MessageConnectio
     '--tsProbeLocations',
     PACKAGE_ROOT,
     '--ngProbeLocations',
-    SERVER_PATH,
+    [SERVER_PATH, PROJECT_PATH].join(','),
   ];
   if (serverOptions.ivy) {
     argv.push('--experimental-ivy');

--- a/integration/lsp/viewengine_spec.ts
+++ b/integration/lsp/viewengine_spec.ts
@@ -8,6 +8,7 @@
 
 import {MessageConnection} from 'vscode-jsonrpc';
 import * as lsp from 'vscode-languageserver-protocol';
+import {SuggestIvyLanguageService, SuggestIvyLanguageServiceParams} from '../../common/notifications';
 import {APP_COMPONENT, createConnection, FOO_TEMPLATE, initializeServer, openTextDocument} from './test_utils';
 
 describe('Angular language server', () => {
@@ -107,6 +108,12 @@ describe('Angular language server', () => {
     expect(diagnostics.length).toBe(1);
     expect(diagnostics[0].message).toContain(`Identifier 'doesnotexist' is not defined.`);
   });
+
+  it('should prompt to enable Ivy Language Service', async () => {
+    openTextDocument(client, APP_COMPONENT);
+    const message = await onSuggestIvyLanguageService(client);
+    expect(message).toContain('Would you like to enable the new Ivy-native language service');
+  });
 });
 
 describe('initialization', () => {
@@ -138,3 +145,11 @@ describe('initialization', () => {
     client.dispose();
   });
 });
+
+function onSuggestIvyLanguageService(client: MessageConnection): Promise<string> {
+  return new Promise(resolve => {
+    client.onNotification(SuggestIvyLanguageService, (params: SuggestIvyLanguageServiceParams) => {
+      resolve(params.message);
+    });
+  });
+}

--- a/package.json
+++ b/package.json
@@ -57,6 +57,11 @@
           "default": false,
           "description": "This is an experimental feature that enables the Ivy language service."
         },
+        "angular.enable-experimental-ivy-prompt": {
+          "type": "boolean",
+          "default": true,
+          "description": "Prompt to enable the Ivy language service for the workspace when View Engine is in use."
+        },
         "angular.trace.server": {
           "type": "string",
           "scope": "window",

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -37,7 +37,7 @@ const session = new Session({
   host,
   logger,
   ngPlugin: ng.name,
-  ngProbeLocation: ng.resolvedPath,
+  resolvedNgLsPath: ng.resolvedPath,
   ivy: options.ivy,
   logToConsole: options.logToConsole,
 });

--- a/server/src/version_provider.ts
+++ b/server/src/version_provider.ts
@@ -20,7 +20,7 @@ interface NodeModule {
   version: Version;
 }
 
-function resolve(packageName: string, location: string, rootPackage?: string): NodeModule|
+export function resolve(packageName: string, location: string, rootPackage?: string): NodeModule|
     undefined {
   rootPackage = rootPackage || packageName;
   try {


### PR DESCRIPTION
In order to drive adoption of the new Ivy Language Service before it
becomes the default in v12, this commit adds a prompt for users to
enable it if they are using `@angular/core` v9+.

Fixes #1095