### PR TITLE
feat: add command to go to component(s) from external template

### DIFF
--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -23,8 +23,6 @@ interface GetTcbResponse {
   selections: vscode.Range[];
 }
 
-type GetComponentsForOpenExternalTemplateResponse = Array<{uri: vscode.Uri; range: vscode.Range;}>;
-
 export class AngularLanguageClient implements vscode.Disposable {
   private client: lsp.LanguageClient|null = null;
   private readonly disposables: vscode.Disposable[] = [];
@@ -134,7 +132,7 @@ export class AngularLanguageClient implements vscode.Disposable {
   }
 
   async getComponentsForOpenExternalTemplate(textEditor: vscode.TextEditor):
-      Promise<GetComponentsForOpenExternalTemplateResponse|undefined> {
+      Promise<vscode.Location[]|undefined> {
     if (this.client === null) {
       return undefined;
     }
@@ -148,12 +146,8 @@ export class AngularLanguageClient implements vscode.Disposable {
     }
 
     const p2cConverter = this.client.protocol2CodeConverter;
-    return response.map(v => {
-      return {
-        range: p2cConverter.asRange(v.range),
-        uri: p2cConverter.asUri(v.uri),
-      };
-    });
+    return response.map(
+        v => new vscode.Location(p2cConverter.asUri(v.uri), p2cConverter.asRange(v.range)));
   }
 
   dispose() {

--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -127,27 +127,18 @@ function goToComponentWithTemplateFile(ngClient: AngularLanguageClient): Command
     id: 'angular.goToComponentWithTemplateFile',
     isTextEditorCommand: true,
     async execute(textEditor: vscode.TextEditor) {
-      const componentLocations = await ngClient.getComponentsForOpenExternalTemplate(textEditor);
-      if (componentLocations === undefined) {
+      const locations = await ngClient.getComponentsForOpenExternalTemplate(textEditor);
+      if (locations === undefined) {
         return;
       }
 
-      const locations: vscode.Location[] =
-          componentLocations.map(location => new vscode.Location(location.uri, location.range));
-      // If there is more than one component that references the template, show them all. Otherwise
-      // go to the component immediately.
-      if (locations.length > 1) {
-        vscode.commands.executeCommand(
-            'editor.action.showReferences',
-            textEditor.document.uri,
-            new vscode.Position(
-                textEditor.selection.start.line, textEditor.selection.start.character),
-            locations,
-        );
-      } else {
-        const document = await vscode.workspace.openTextDocument(locations[0].uri);
-        await vscode.window.showTextDocument(document, {selection: locations[0].range});
-      }
+      vscode.commands.executeCommand(
+          'editor.action.goToLocations',
+          textEditor.document.uri,
+          textEditor.selection.active,
+          locations,
+          'peek', /** what to do when there are multiple results */
+      );
     },
   };
 }

--- a/common/requests.ts
+++ b/common/requests.ts
@@ -8,6 +8,17 @@
 
 import * as lsp from 'vscode-languageserver-protocol';
 
+export const GetComponentsWithTemplateFile = new lsp.RequestType<
+    GetComponentsWithTemplateFileParams, GetComponentsWithTemplateFileResponse,
+    /* error */ void>('angular/getComponentsWithTemplateFile');
+
+export interface GetComponentsWithTemplateFileParams {
+  textDocument: lsp.TextDocumentIdentifier;
+}
+
+/** An array of locations that represent component declarations. */
+export type GetComponentsWithTemplateFileResponse = Array<{uri: lsp.DocumentUri, range: lsp.Range}>;
+
 export interface GetTcbParams {
   textDocument: lsp.TextDocumentIdentifier;
   position: lsp.Position;

--- a/common/requests.ts
+++ b/common/requests.ts
@@ -9,15 +9,12 @@
 import * as lsp from 'vscode-languageserver-protocol';
 
 export const GetComponentsWithTemplateFile = new lsp.RequestType<
-    GetComponentsWithTemplateFileParams, GetComponentsWithTemplateFileResponse,
+    GetComponentsWithTemplateFileParams, lsp.Location[],
     /* error */ void>('angular/getComponentsWithTemplateFile');
 
 export interface GetComponentsWithTemplateFileParams {
   textDocument: lsp.TextDocumentIdentifier;
 }
-
-/** An array of locations that represent component declarations. */
-export type GetComponentsWithTemplateFileResponse = Array<{uri: lsp.DocumentUri, range: lsp.Range}>;
 
 export interface GetTcbParams {
   textDocument: lsp.TextDocumentIdentifier;

--- a/integration/lsp/ivy_spec.ts
+++ b/integration/lsp/ivy_spec.ts
@@ -13,7 +13,7 @@ import {URI} from 'vscode-uri';
 
 import {ProjectLanguageService, ProjectLanguageServiceParams, SuggestStrictMode, SuggestStrictModeParams} from '../../common/notifications';
 import {NgccProgress, NgccProgressToken, NgccProgressType} from '../../common/progress';
-import {GetTcbRequest} from '../../common/requests';
+import {GetComponentsWithTemplateFile, GetTcbRequest} from '../../common/requests';
 
 import {APP_COMPONENT, createConnection, createTracer, FOO_COMPONENT, FOO_TEMPLATE, initializeServer, openTextDocument, TSCONFIG} from './test_utils';
 
@@ -314,18 +314,27 @@ describe('Angular Ivy language server', () => {
     });
   });
 
-  describe('getTcb', () => {
-    it('should handle getTcb request', async () => {
-      openTextDocument(client, FOO_TEMPLATE);
-      await waitForNgcc(client);
-      const response = await client.sendRequest(GetTcbRequest, {
-        textDocument: {
-          uri: `file://${FOO_TEMPLATE}`,
-        },
-        position: {line: 0, character: 3},
-      });
-      expect(response).toBeDefined();
+  it('should handle getTcb request', async () => {
+    openTextDocument(client, FOO_TEMPLATE);
+    await waitForNgcc(client);
+    const response = await client.sendRequest(GetTcbRequest, {
+      textDocument: {
+        uri: `file://${FOO_TEMPLATE}`,
+      },
+      position: {line: 0, character: 3},
     });
+    expect(response).toBeDefined();
+  });
+
+  it('should handle goToComponent request', async () => {
+    openTextDocument(client, FOO_TEMPLATE);
+    await waitForNgcc(client);
+    const response = await client.sendRequest(GetComponentsWithTemplateFile, {
+      textDocument: {
+        uri: `file://${FOO_TEMPLATE}`,
+      }
+    });
+    expect(response).toBeDefined();
   });
 });
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,11 @@
         "command": "angular.getTemplateTcb",
         "title": "View Template Typecheck Block",
         "category": "Angular"
+      },
+      {
+        "command": "angular.goToComponentWithTemplateFile",
+        "title": "Go to component",
+        "category": "Angular"
       }
     ],
     "menus": {
@@ -39,6 +44,11 @@
         {
           "when": "resourceLangId == html || resourceLangId == typescript",
           "command": "angular.getTemplateTcb",
+          "group": "angular"
+        },
+        {
+          "when": "resourceLangId == html",
+          "command": "angular.goToComponentWithTemplateFile",
           "group": "angular"
         }
       ]

--- a/server/src/version_provider.ts
+++ b/server/src/version_provider.ts
@@ -10,7 +10,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 const MIN_TS_VERSION = '4.1';
-const MIN_NG_VERSION = '11.2';
+const MIN_NG_VERSION = '12.0';
 export const NGLANGSVC = '@angular/language-service';
 const TSSERVERLIB = 'typescript/lib/tsserverlibrary';
 


### PR DESCRIPTION
This commit adds a command to locate the components which reference a
given external template via their `templateUrl`s. If there is only one
component, immediately navigate to the component class declaration. If
there are multiple components, show them each in the same manner as
"find references" would.