### PR TITLE
fix: unable to load ivy native plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
   },
   "dependencies": {
     "@angular/language-service": "11.2.0",
-    "typescript": "~4.1.0",
+    "typescript": "4.1.5",
     "vscode-jsonrpc": "6.0.0",
     "vscode-languageclient": "7.0.0",
     "vscode-languageserver": "7.0.0",

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -10,7 +10,7 @@ import {generateHelpMessage, parseCommandLine} from './cmdline_utils';
 import {createLogger} from './logger';
 import {ServerHost} from './server_host';
 import {Session} from './session';
-import {resolveNgLangSvc, resolveTsServer} from './version_provider';
+import {NGLANGSVC, resolveNgLangSvc, resolveTsServer} from './version_provider';
 
 // Parse command line arguments
 const options = parseCommandLine(process.argv);
@@ -30,13 +30,13 @@ const ts = resolveTsServer(options.tsProbeLocations);
 const ng = resolveNgLangSvc(options.ngProbeLocations, options.ivy);
 
 // ServerHost provides native OS functionality
-const host = new ServerHost();
+const host = new ServerHost(options.ivy);
 
 // Establish a new server session that encapsulates lsp connection.
 const session = new Session({
   host,
   logger,
-  ngPlugin: ng.name,
+  ngPlugin: NGLANGSVC,  // TypeScript allows only package names as plugin names.
   resolvedNgLsPath: ng.resolvedPath,
   ivy: options.ivy,
   logToConsole: options.logToConsole,

--- a/server/src/server_host.ts
+++ b/server/src/server_host.ts
@@ -7,6 +7,7 @@
  */
 
 import * as ts from 'typescript/lib/tsserverlibrary';
+import {NGLANGSVC} from './version_provider';
 
 /**
  * `ServerHost` is a wrapper around `ts.sys` for the Node system. In Node, all
@@ -19,7 +20,7 @@ export class ServerHost implements ts.server.ServerHost {
   readonly newLine: string;
   readonly useCaseSensitiveFileNames: boolean;
 
-  constructor() {
+  constructor(private ivy: boolean) {
     this.args = ts.sys.args;
     this.newLine = ts.sys.newLine;
     this.useCaseSensitiveFileNames = ts.sys.useCaseSensitiveFileNames;
@@ -163,9 +164,13 @@ export class ServerHost implements ts.server.ServerHost {
 
   require(initialPath: string, moduleName: string) {
     try {
-      const modulePath = require.resolve(moduleName, {
+      let modulePath = require.resolve(moduleName, {
         paths: [initialPath],
       });
+      // TypeScript allows only package names as plugin names.
+      if (this.ivy && moduleName === NGLANGSVC) {
+        modulePath = this.resolvePath(modulePath + '/../ivy.js');
+      }
       return {
         module: require(modulePath),
         error: undefined,

--- a/server/src/version_provider.ts
+++ b/server/src/version_provider.ts
@@ -10,6 +10,7 @@ import * as fs from 'fs';
 
 const MIN_TS_VERSION = '4.1';
 const MIN_NG_VERSION = '11.2';
+export const NGLANGSVC = '@angular/language-service';
 
 /**
  * Represents a valid node module that has been successfully resolved.
@@ -84,9 +85,8 @@ export function resolveTsServer(probeLocations: string[]): NodeModule {
  * @param ivy true if Ivy language service is requested
  */
 export function resolveNgLangSvc(probeLocations: string[], ivy: boolean): NodeModule {
-  const nglangsvc = '@angular/language-service';
-  const packageName = ivy ? `${nglangsvc}/bundles/ivy` : nglangsvc;
-  return resolveWithMinVersion(packageName, MIN_NG_VERSION, probeLocations, nglangsvc);
+  const packageName = ivy ? `${NGLANGSVC}/bundles/ivy` : NGLANGSVC;
+  return resolveWithMinVersion(packageName, MIN_NG_VERSION, probeLocations, NGLANGSVC);
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -907,10 +907,10 @@ typed-rest-client@1.2.0:
     tunnel "0.0.4"
     underscore "1.8.3"
 
-typescript@~4.1.0:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.3.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
-  integrity sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==
+typescript@4.1.5:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.5.tgz#123a3b214aaff3be32926f0d8f1f6e704eb89a72"
+  integrity sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==
 
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"


### PR DESCRIPTION
In typescript 4.1.4, ts allows only package names as plugin names,
so `@angular/language-service/bundles/ivy` is disabled by ts. This
PR will resolve `@angular/language-service` to path `./bundles/ivy.js`
when the user enables the Ivy-native language service.

fixed #1109