### PR TITLE
docs: clarify how to override ivy opt-in in a workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,9 +53,11 @@
           "description": "Enables logging of the Angular server to a file. This log can be used to diagnose Angular Server issues. The log may contain file paths, source code, and other potentially sensitive information from your project."
         },
         "angular.experimental-ivy": {
-          "type": "boolean",
+          "type": [
+            "boolean"
+          ],
           "default": false,
-          "description": "This is an experimental feature that enables the Ivy language service."
+          "description": "Opt-in to the Ivy language service. Note: To disable the Ivy language service in a workspace when it is enabled in the user settings, open the settings.json file and set the angular.experiment-ivy to false."
         },
         "angular.enable-experimental-ivy-prompt": {
           "type": "boolean",


### PR DESCRIPTION
Add a clarifying not about how to specifically override the global user
setting in a workspace for the ivy opt in.

fixes #1108