### PR TITLE
fix: ensure project language service is the Angular LS

### DIFF
--- a/server/src/session.ts
+++ b/server/src/session.ts
@@ -708,8 +708,12 @@ export class Session {
       this.logger.info(`Failed to get language service for closed project ${project.projectName}.`);
       return undefined;
     }
+    const languageService = project.getLanguageService();
+    if (!isNgLs(languageService)) {
+      return undefined;
+    }
     return {
-      languageService: project.getLanguageService() as NgLanguageService,
+      languageService,
       scriptInfo,
     };
   }
@@ -936,4 +940,8 @@ function toArray<T>(it: ts.Iterator<T>): T[] {
     results.push(itResult.value);
   }
   return results;
+}
+
+function isNgLs(ls: ts.LanguageService|NgLanguageService): ls is NgLanguageService {
+  return 'getTcb' in ls;
 }


### PR DESCRIPTION
Add check to ensure the returned language service for the project is the Angular
Language Service. This removes the need for a type assertion and also prevents
the native TS LS from taking the place of ours if there is an issue with the
plugin registration (which would result in duplicate results in TS files).

Fixes #1110.