### PR TITLE
fix: remove TSC_NONPOLLING_WATCHER env variable

### DIFF
--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -283,10 +283,7 @@ function constructArgs(ctx: vscode.ExtensionContext, debug: boolean): string[] {
 
 function getServerOptions(ctx: vscode.ExtensionContext, debug: boolean): lsp.NodeModule {
   // Environment variables for server process
-  const prodEnv = {
-    // Force TypeScript to use the non-polling version of the file watchers.
-    TSC_NONPOLLING_WATCHER: true,
-  };
+  const prodEnv = {};
   const devEnv = {
     ...prodEnv,
     NG_DEBUG: true,

--- a/integration/lsp/test_utils.ts
+++ b/integration/lsp/test_utils.ts
@@ -37,9 +37,6 @@ export function createConnection(serverOptions: ServerOptions): MessageConnectio
   }
   const server = fork(SERVER_PATH, argv, {
     cwd: PROJECT_PATH,
-    env: {
-      TSC_NONPOLLING_WATCHER: 'true',
-    },
     // uncomment to debug server process
     // execArgv: ['--inspect-brk=9330']
   });

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -50,8 +50,5 @@ session.info(`Log file: ${logger.getLogFileName()}`);
 if (process.env.NG_DEBUG === 'true') {
   session.info('Angular Language Service is running under DEBUG mode');
 }
-if (process.env.TSC_NONPOLLING_WATCHER !== 'true') {
-  session.warn(`Using less efficient polling watcher. Set TSC_NONPOLLING_WATCHER to true.`);
-}
 
 session.listen();


### PR DESCRIPTION
`TSC_NONPOLLING_WATCHER` was used back in the early days to improve
file watcher performance, but it prevents files / directories from
being moved / renamed.
Since TS now provides built-in option to configure file watcher, this
environment variable is no longer needed.

See https://www.typescriptlang.org/docs/handbook/configuring-watch.html

Fix https://github.com/angular/vscode-ng-language-service/issues/750