### PR TITLE
fix: attempt to resolve tsdk using fs path

### DIFF
--- a/server/src/tests/version_provider_spec.ts
+++ b/server/src/tests/version_provider_spec.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {isAbsolute, resolve} from 'path';
+
 import {resolveNgLangSvc, resolveTsServer, Version} from '../version_provider';
 
 describe('Node Module Resolver', () => {
@@ -15,6 +17,14 @@ describe('Node Module Resolver', () => {
     const result = resolveTsServer(probeLocations);
     expect(result).toBeDefined();
     expect(result.resolvedPath).toMatch(/typescript\/lib\/tsserverlibrary.js$/);
+  });
+
+  it('should resolve tsserver from typescript.tsdk provided as fs path', () => {
+    // Resolve relative to cwd.
+    const absPath = resolve('node_modules/typescript/lib');
+    expect(isAbsolute(absPath)).toBeTrue();
+    const result = resolveTsServer([absPath]);
+    expect(result.resolvedPath.endsWith('typescript/lib/tsserverlibrary.js')).toBeTrue();
   });
 
   it('should be able to resolve Angular language service', () => {


### PR DESCRIPTION
This commit fixes an inconsistency in resolving `typescript.tsdk` in the
Angular extension compared to native TypeScript extension.

In Angular, `require.resolve` is used to resolve `typescript.tsdk`, but
this does not work in environment that does not support node module
resolution (where `node_modules` directory does not exist).

The documentation for `typescript.tsdk` explicitly mentions the support
of providing the value as a fs path:
```
Specifies the folder path to the tsserver and lib*.d.ts files under a
TypeScript install to use for IntelliSense, for example:
./node_modules/typescript/lib.
```