### PR TITLE
test: use TS dep installed for production

### DIFF
--- a/integration/lsp/test_utils.ts
+++ b/integration/lsp/test_utils.ts
@@ -28,7 +28,7 @@ export function createConnection(serverOptions: ServerOptions): MessageConnectio
   const argv: string[] = [
     '--node-ipc',
     '--tsProbeLocations',
-    PACKAGE_ROOT,
+    SERVER_PATH,
     '--ngProbeLocations',
     [SERVER_PATH, PROJECT_PATH].join(','),
   ];


### PR DESCRIPTION
When the `.vsix` file is built, prod dependencies are installed in `dist/npm`.
The LSP tests should resolve `typescript` from `node_modules` in that
directory instead of package root to make sure prod build is tested with
prod dependencies.