### PR TITLE
fix: do not pass execArgv to ngcc process

### DIFF
--- a/server/src/ngcc.ts
+++ b/server/src/ngcc.ts
@@ -48,6 +48,7 @@ export async function resolveAndRunNgcc(tsconfig: string, progress: Progress): P
       {
         cwd: resolve(cwd),
         silent: true,  // pipe stderr and stdout so that we can report progress
+        execArgv: [], // do not inherit flags like --inspect from parent process
       });
 
   let stderr = '';

--- a/server/src/ngcc.ts
+++ b/server/src/ngcc.ts
@@ -48,7 +48,7 @@ export async function resolveAndRunNgcc(tsconfig: string, progress: Progress): P
       {
         cwd: resolve(cwd),
         silent: true,  // pipe stderr and stdout so that we can report progress
-        execArgv: [], // do not inherit flags like --inspect from parent process
+        execArgv: [],  // do not inherit flags like --inspect from parent process
       });
 
   let stderr = '';


### PR DESCRIPTION
ngcc process will fail if the debugger is already attached to the main
process because it inherits `execArgv` from the parent process by
default.