### PR TITLE
fix: use single entry point for @angular/language-service

### DIFF
--- a/package.json
+++ b/package.json
@@ -168,7 +168,7 @@
     "test:syntaxes": "yarn compile:syntaxes-test && yarn build:syntaxes && jasmine dist/syntaxes/test/driver.js"
   },
   "dependencies": {
-    "@angular/language-service": "12.0.0-next.2",
+    "@angular/language-service": "12.0.0-next.3",
     "typescript": "4.1.5",
     "vscode-jsonrpc": "6.0.0",
     "vscode-languageclient": "7.0.0",

--- a/server/package.json
+++ b/server/package.json
@@ -15,7 +15,7 @@
     "ngserver": "./bin/ngserver"
   },
   "dependencies": {
-    "@angular/language-service": "12.0.0-next.2",
+    "@angular/language-service": "12.0.0-next.3",
     "vscode-jsonrpc": "6.0.0",
     "vscode-languageserver": "7.0.0",
     "vscode-uri": "3.0.2"

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -10,7 +10,7 @@ import {generateHelpMessage, parseCommandLine} from './cmdline_utils';
 import {createLogger} from './logger';
 import {ServerHost} from './server_host';
 import {Session} from './session';
-import {NGLANGSVC, resolveNgLangSvc, resolveTsServer} from './version_provider';
+import {resolveNgLangSvc, resolveTsServer} from './version_provider';
 
 // Parse command line arguments
 const options = parseCommandLine(process.argv);
@@ -30,13 +30,14 @@ const ts = resolveTsServer(options.tsProbeLocations);
 const ng = resolveNgLangSvc(options.ngProbeLocations, options.ivy);
 
 // ServerHost provides native OS functionality
-const host = new ServerHost(options.ivy);
+const host = new ServerHost();
 
 // Establish a new server session that encapsulates lsp connection.
 const session = new Session({
   host,
   logger,
-  ngPlugin: NGLANGSVC,  // TypeScript allows only package names as plugin names.
+  // TypeScript allows only package names as plugin names.
+  ngPlugin: '@angular/language-service',
   resolvedNgLsPath: ng.resolvedPath,
   ivy: options.ivy,
   logToConsole: options.logToConsole,

--- a/server/src/server_host.ts
+++ b/server/src/server_host.ts
@@ -7,7 +7,6 @@
  */
 
 import * as ts from 'typescript/lib/tsserverlibrary';
-import {NGLANGSVC} from './version_provider';
 
 /**
  * `ServerHost` is a wrapper around `ts.sys` for the Node system. In Node, all
@@ -20,7 +19,7 @@ export class ServerHost implements ts.server.ServerHost {
   readonly newLine: string;
   readonly useCaseSensitiveFileNames: boolean;
 
-  constructor(private ivy: boolean) {
+  constructor() {
     this.args = ts.sys.args;
     this.newLine = ts.sys.newLine;
     this.useCaseSensitiveFileNames = ts.sys.useCaseSensitiveFileNames;
@@ -172,13 +171,9 @@ export class ServerHost implements ts.server.ServerHost {
 
   require(initialPath: string, moduleName: string) {
     try {
-      let modulePath = require.resolve(moduleName, {
+      const modulePath = require.resolve(moduleName, {
         paths: [initialPath],
       });
-      // TypeScript allows only package names as plugin names.
-      if (this.ivy && moduleName === NGLANGSVC) {
-        modulePath = this.resolvePath(modulePath + '/../ivy.js');
-      }
       return {
         module: require(modulePath),
         error: undefined,

--- a/server/src/session.ts
+++ b/server/src/session.ts
@@ -114,6 +114,7 @@ export class Session {
       pluginName: options.ngPlugin,
       configuration: {
         angularOnly: true,
+        ivy: options.ivy,
       },
     });
 

--- a/server/src/tests/version_provider_spec.ts
+++ b/server/src/tests/version_provider_spec.ts
@@ -30,13 +30,15 @@ describe('Node Module Resolver', () => {
   it('should be able to resolve Angular language service', () => {
     const result = resolveNgLangSvc(probeLocations, false /* ivy */);
     expect(result).toBeDefined();
-    expect(result.resolvedPath).toMatch(/language-service.js$/);
+    expect(result.resolvedPath.endsWith('@angular/language-service/index.js')).toBeTrue();
   });
 
   it('should be able to resolve Ivy version of Angular language service', () => {
     const result = resolveNgLangSvc(probeLocations, true /* ivy */);
     expect(result).toBeDefined();
-    expect(result.resolvedPath).toMatch(/ivy.js$/);
+    // Starting from v12.0.0-next.3 @angular/language-service provides a single
+    // entry point
+    expect(result.resolvedPath.endsWith('@angular/language-service/index.js')).toBeTrue();
   });
 });
 

--- a/server/src/version_provider.ts
+++ b/server/src/version_provider.ts
@@ -11,7 +11,6 @@ import * as path from 'path';
 
 const MIN_TS_VERSION = '4.1';
 const MIN_NG_VERSION = '12.0';
-export const NGLANGSVC = '@angular/language-service';
 const TSSERVERLIB = 'typescript/lib/tsserverlibrary';
 
 /**
@@ -120,8 +119,8 @@ function resolveTsServerFromTsdk(tsdk: string): NodeModule|undefined {
  * @param ivy true if Ivy language service is requested
  */
 export function resolveNgLangSvc(probeLocations: string[], ivy: boolean): NodeModule {
-  const packageName = ivy ? `${NGLANGSVC}/bundles/ivy` : NGLANGSVC;
-  return resolveWithMinVersion(packageName, MIN_NG_VERSION, probeLocations, NGLANGSVC);
+  const ngls = '@angular/language-service';
+  return resolveWithMinVersion(ngls, MIN_NG_VERSION, probeLocations, ngls);
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@angular/language-service@12.0.0-next.2":
-  version "12.0.0-next.2"
-  resolved "https://registry.yarnpkg.com/@angular/language-service/-/language-service-12.0.0-next.2.tgz#83e499e2dc907deaad81da8c9f6dca0f366a7612"
-  integrity sha512-XnKVCHz3d7kQGBq0JRunmxdVWi+CcXzozNd82Hbi1kFVYwJ4mOZfpl6Uvlof9os/XeKqP3Xclfm+KmXROk8DZg==
+"@angular/language-service@12.0.0-next.3":
+  version "12.0.0-next.3"
+  resolved "https://registry.yarnpkg.com/@angular/language-service/-/language-service-12.0.0-next.3.tgz#6cb919e856e6e53b6eaf9484afee950f6883caae"
+  integrity sha512-isrLGNZ/AutKI6xgX3pk65E3CZwRmfnXCeD7NwYkKUB49Ld4QuNu8VwHfk1CGjE21bBw++ja4l2AcTuphBm87g==
 
 "@babel/code-frame@^7.0.0":
   version "7.10.4"


### PR DESCRIPTION
Starting from `@angular/language-service` v12.0.0-next.3, the package
will dynamically load View Engine or Ivy LS based on the config passed
to the plugin.

This reverts https://github.com/angular/vscode-ng-language-service/pull/1111