### PR TITLE
fix: show Go to component in HTML files only

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,12 @@
       }
     ],
     "menus": {
+      "commandPalette": [
+        {
+          "command": "angular.goToComponentWithTemplateFile",
+          "when": "editorLangId == html"
+        }
+      ],
       "editor/context": [
         {
           "when": "resourceLangId == html || resourceLangId == typescript",


### PR DESCRIPTION
Go to component should not be shown in TypeScript files.