### PR TITLE
fix: retain typecheck files after project reload

### DIFF
--- a/integration/lsp/test_utils.ts
+++ b/integration/lsp/test_utils.ts
@@ -14,7 +14,7 @@ import * as lsp from 'vscode-languageserver-protocol';
 
 const SERVER_PATH = resolve(__dirname, '../../../dist/npm/server/index.js');
 const PACKAGE_ROOT = resolve(__dirname, '../../..');
-const PROJECT_PATH = `${PACKAGE_ROOT}/integration/project`;
+export const PROJECT_PATH = `${PACKAGE_ROOT}/integration/project`;
 export const APP_COMPONENT = `${PROJECT_PATH}/app/app.component.ts`;
 export const FOO_TEMPLATE = `${PROJECT_PATH}/app/foo.component.html`;
 export const FOO_COMPONENT = `${PROJECT_PATH}/app/foo.component.ts`;
@@ -40,7 +40,11 @@ export function createConnection(serverOptions: ServerOptions): MessageConnectio
     // uncomment to debug server process
     // execArgv: ['--inspect-brk=9330']
   });
-
+  server.on('close', (code: number) => {
+    if (code !== null && code !== 0) {
+      throw new Error(`Server exited with code: ${code}`);
+    }
+  });
   const connection = createMessageConnection(
       new IPCMessageReader(server),
       new IPCMessageWriter(server),

--- a/server/src/server_host.ts
+++ b/server/src/server_host.ts
@@ -65,6 +65,11 @@ export class ServerHost implements ts.server.ServerHost {
   }
 
   fileExists(path: string): boolean {
+    // When a project is reloaded (due to changes in node_modules for example),
+    // the typecheck files ought to be retained. However, if they do not exist
+    // on disk, tsserver will remove them from project. See
+    // https://github.com/microsoft/TypeScript/blob/3c32f6e154ead6749b76ec9c19cbfdd2acad97d6/src/server/editorServices.ts#L2188-L2193
+    // To fix this, we fake the existence of the typecheck files.
     if (path.endsWith('.ngtypecheck.ts')) {
       return true;
     }

--- a/server/src/server_host.ts
+++ b/server/src/server_host.ts
@@ -65,6 +65,9 @@ export class ServerHost implements ts.server.ServerHost {
   }
 
   fileExists(path: string): boolean {
+    if (path.endsWith('.ngtypecheck.ts')) {
+      return true;
+    }
     return ts.sys.fileExists(path);
   }
 


### PR DESCRIPTION
It turns out typecheck files are not retained even after the fix in
https://github.com/angular/angular/pull/40162.

For a complete explanation of the situation, see prior issue:
https://github.com/angular/vscode-ng-language-service/issues/1030

This is because even after adding the typecheck files to the list of
files to retain, tsserver will still remove them from a project if they
do not exist on disk:
https://github.com/microsoft/TypeScript/blob/3c32f6e154ead6749b76ec9c19cbfdd2acad97d6/src/server/editorServices.ts#L2188-L2193

In order to force tsserver to retain the files, we need to fake their
existence. This is done in the `ServerHost`.

Admittedly, this is not a great fix because it relies on the knowledge
of the typecheck file suffix, which is an implementation detail in the compiler.

The alternative is to explore the concept of "dynamic files", which are
files that exist only in memory and not on disk. This would require
changes to the Ivy compiler and `@angular/language-service`.
Ideally, the compiler should ask `@angular/language-service` how to name the
typecheck files, so that the behavior is dictated by LS rather than
the compiler.

fix https://github.com/angular/vscode-ng-language-service/issues/1090