### PR TITLE
feat: Add codelens with a link to go to the component from a template

### DIFF
--- a/integration/lsp/ivy_spec.ts
+++ b/integration/lsp/ivy_spec.ts
@@ -363,6 +363,24 @@ describe('Angular Ivy language server', () => {
     });
     expect(response).toBeDefined();
   });
+
+  it('should provide a "go to component" codelens', async () => {
+    openTextDocument(client, FOO_TEMPLATE);
+    await waitForNgcc(client);
+    const codeLensResponse = await client.sendRequest(lsp.CodeLensRequest.type, {
+      textDocument: {
+        uri: `file://${FOO_TEMPLATE}`,
+      }
+    });
+    expect(codeLensResponse).toBeDefined();
+    const [codeLens] = codeLensResponse!;
+    expect(codeLens.data.uri).toEqual(`file://${FOO_TEMPLATE}`);
+
+    const codeLensResolveResponse =
+        await client.sendRequest(lsp.CodeLensResolveRequest.type, codeLensResponse![0]);
+    expect(codeLensResolveResponse).toBeDefined();
+    expect(codeLensResolveResponse?.command?.title).toEqual('Go to component');
+  });
 });
 
 function onNgccProgress(client: MessageConnection): Promise<string> {

--- a/server/src/session.ts
+++ b/server/src/session.ts
@@ -144,6 +144,8 @@ export class Session {
     conn.onCompletionResolve(p => this.onCompletionResolve(p));
     conn.onRequest(GetComponentsWithTemplateFile, p => this.onGetComponentsWithTemplateFile(p));
     conn.onRequest(GetTcbRequest, p => this.onGetTcb(p));
+    conn.onCodeLens(p => this.onCodeLens(p));
+    conn.onCodeLensResolve(p => this.onCodeLensResolve(p));
   }
 
   private onGetTcb(params: GetTcbParams): GetTcbResponse|undefined {
@@ -186,6 +188,34 @@ export class Session {
       results.push(lsp.Location.create(filePathToUri(documentSpan.fileName), range));
     }
     return results;
+  }
+
+  private onCodeLens(params: lsp.CodeLensParams): lsp.CodeLens[]|undefined {
+    if (!params.textDocument.uri.endsWith('.html')) {
+      return undefined;
+    }
+    const position = lsp.Position.create(0, 0);
+    const topOfDocument = lsp.Range.create(position, position);
+
+
+    const codeLens: lsp.CodeLens = {
+      range: topOfDocument,
+      data: params.textDocument,
+    };
+
+    return [codeLens];
+  }
+
+  private onCodeLensResolve(params: lsp.CodeLens): lsp.CodeLens {
+    const components = this.onGetComponentsWithTemplateFile({textDocument: params.data});
+    if (components !== undefined && components.length > 0) {
+      params.command = {
+        command: 'angular.goToComponentWithTemplateFile',
+        title: components.length > 1 ? `Used as templateUrl in ${components.length} components` :
+                                       'Go to component',
+      };
+    }
+    return params;
   }
 
   private enableLanguageServiceForProject(project: ts.server.Project, angularCore: string) {
@@ -376,6 +406,7 @@ export class Session {
     };
     return {
       capabilities: {
+        codeLensProvider: this.ivy ? {resolveProvider: true} : undefined,
         textDocumentSync: lsp.TextDocumentSyncKind.Incremental,
         completionProvider: {
           // Only the Ivy LS provides support for additional completion resolution.


### PR DESCRIPTION
This commit adds a codelens which provides a link to the component(s) of
an external template.

![image](https://user-images.githubusercontent.com/479713/109551502-7eb59300-7a85-11eb-8cfc-cd85c56f6ffb.png)
