### PR TITLE
fix: force enable Ivy and strictTemplates in google3

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -39,6 +39,7 @@ const session = new Session({
   // TypeScript allows only package names as plugin names.
   ngPlugin: '@angular/language-service',
   resolvedNgLsPath: ng.resolvedPath,
+  resolvedTsLsPath: ts.resolvedPath,
   ivy: options.ivy,
   logToConsole: options.logToConsole,
 });


### PR DESCRIPTION
This commit checks if `typescript` is resolved to the tsdk in google3,
and if so set `ivy` and `strictTemplates` to true. Both settings are
required for the Angular extension to work in google3.