### PR TITLE
refactor: ivy flag no longer needed with single entry point

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -27,7 +27,7 @@ const logger = createLogger({
 });
 
 const ts = resolveTsServer(options.tsProbeLocations);
-const ng = resolveNgLangSvc(options.ngProbeLocations, options.ivy);
+const ng = resolveNgLangSvc(options.ngProbeLocations);
 
 const isG3 = ts.resolvedPath.includes('/google3/');
 

--- a/server/src/tests/version_provider_spec.ts
+++ b/server/src/tests/version_provider_spec.ts
@@ -28,16 +28,8 @@ describe('Node Module Resolver', () => {
   });
 
   it('should be able to resolve Angular language service', () => {
-    const result = resolveNgLangSvc(probeLocations, false /* ivy */);
+    const result = resolveNgLangSvc(probeLocations);
     expect(result).toBeDefined();
-    expect(result.resolvedPath.endsWith('@angular/language-service/index.js')).toBeTrue();
-  });
-
-  it('should be able to resolve Ivy version of Angular language service', () => {
-    const result = resolveNgLangSvc(probeLocations, true /* ivy */);
-    expect(result).toBeDefined();
-    // Starting from v12.0.0-next.3 @angular/language-service provides a single
-    // entry point
     expect(result.resolvedPath.endsWith('@angular/language-service/index.js')).toBeTrue();
   });
 });

--- a/server/src/version_provider.ts
+++ b/server/src/version_provider.ts
@@ -116,9 +116,8 @@ function resolveTsServerFromTsdk(tsdk: string): NodeModule|undefined {
 /**
  * Resolve `@angular/language-service` from the given locations.
  * @param probeLocations locations from which resolution is attempted
- * @param ivy true if Ivy language service is requested
  */
-export function resolveNgLangSvc(probeLocations: string[], ivy: boolean): NodeModule {
+export function resolveNgLangSvc(probeLocations: string[]): NodeModule {
   const ngls = '@angular/language-service';
   return resolveWithMinVersion(ngls, MIN_NG_VERSION, probeLocations, ngls);
 }


### PR DESCRIPTION
Starting from v12.0.0-next.3 `@angular/language-service` provides a single
point, so the `ivy` flag is no longer needed when resolving the package.