### PR TITLE
fix: turn off logging by default

### DIFF
--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -60,9 +60,7 @@ function openLogFile(client: AngularLanguageClient): Command {
           const isGlobalConfig = false;
           await vscode.workspace.getConfiguration().update(
               'angular.log', 'verbose', isGlobalConfig);
-          // Restart the server
-          await client.stop();
-          await client.start();
+          // Server will automatically restart because the config is changed
         }
         return;
       }

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
             "normal",
             "verbose"
           ],
-          "default": "terse",
+          "default": "off",
           "description": "Enables logging of the Angular server to a file. This log can be used to diagnose Angular Server issues. The log may contain file paths, source code, and other potentially sensitive information from your project."
         },
         "angular.experimental-ivy": {

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -49,7 +49,11 @@ const session = new Session({
 session.info(`Angular language server process ID: ${process.pid}`);
 session.info(`Using ${ts.name} v${ts.version} from ${ts.resolvedPath}`);
 session.info(`Using ${ng.name} v${ng.version} from ${ng.resolvedPath}`);
-session.info(`Log file: ${logger.getLogFileName()}`);
+if (logger.loggingEnabled()) {
+  session.info(`Log file: ${logger.getLogFileName()}`);
+} else {
+  session.info(`Logging is turned off. To enable, run command 'Open Angular server log'.`);
+}
 if (process.env.NG_DEBUG === 'true') {
   session.info('Angular Language Service is running under DEBUG mode');
 }


### PR DESCRIPTION
For large projects (especially projects in google3), logging to file with
will slow down the language service because it prints all the filenames in
the project. This is true even when the logging verbosity is `terse` (the
old default).

This PR turns off logging by default. If users want to inspect the logs,
they can run the `Open Angular server log` command, which will automatically
set the log verbosity to `verbose` and restart the server.

<img width="1792" alt="Screen Shot 2021-03-04 at 9 06 11 AM" src="https://user-images.githubusercontent.com/2941178/110005088-f6293380-7ccc-11eb-90b6-af1192ac57e7.png">
