### PR TITLE
fix: do not load plugins except @angular/language-service

### DIFF
--- a/server/src/server_host.ts
+++ b/server/src/server_host.ts
@@ -176,7 +176,13 @@ export class ServerHost implements ts.server.ServerHost {
     return clearImmediate(timeoutId);
   }
 
-  require(initialPath: string, moduleName: string) {
+  require(initialPath: string, moduleName: string): ts.server.RequireResult {
+    if (moduleName !== '@angular/language-service') {
+      return {
+        module: undefined,
+        error: new Error(`Angular server will not load plugin '${moduleName}'.`),
+      };
+    }
     try {
       const modulePath = require.resolve(moduleName, {
         paths: [initialPath],

--- a/server/src/session.ts
+++ b/server/src/session.ts
@@ -89,7 +89,8 @@ export class Session {
       eventHandler: (e) => this.handleProjectServiceEvent(e),
       globalPlugins: [options.ngPlugin],
       pluginProbeLocations: [options.resolvedNgLsPath],
-      allowLocalPluginLoads: false,  // do not load plugins from tsconfig.json
+      // do not resolve plugins from the directory where tsconfig.json is located
+      allowLocalPluginLoads: false,
     });
 
     projSvc.setHostConfiguration({


### PR DESCRIPTION
Users can specify any arbitrary plugins in their `tsconfig.json`, and
tsserver will load all of them by default. In Angular server, we do not
want this behavior since other plugins can slow down the server
considerably. Angular server should only load
`@angular/language-service`.

In google3, `@bazel/tsetse` and `ide_performance` plugins are automatically
added by the `ts_config` rule.