### PR TITLE
refactor: run `ngcc --typings-only` if version >= 11.2.4

### DIFF
--- a/server/src/ngcc.ts
+++ b/server/src/ngcc.ts
@@ -8,16 +8,7 @@
 
 import {fork} from 'child_process';
 import {dirname, resolve} from 'path';
-
-function resolveNgccFrom(directory: string): string|null {
-  try {
-    return require.resolve(`@angular/compiler-cli/ngcc/main-ngcc.js`, {
-      paths: [directory],
-    });
-  } catch {
-    return null;
-  }
-}
+import {resolveNgcc, Version} from './version_provider';
 
 interface Progress {
   report(msg: string): void;
@@ -29,27 +20,29 @@ interface Progress {
  */
 export async function resolveAndRunNgcc(tsconfig: string, progress: Progress): Promise<void> {
   const directory = dirname(tsconfig);
-  const ngcc = resolveNgccFrom(directory);
+  const ngcc = resolveNgcc(directory);
   if (!ngcc) {
     throw new Error(`Failed to resolve ngcc from ${directory}`);
   }
-  const index = ngcc.lastIndexOf('node_modules');
+  const index = ngcc.resolvedPath.lastIndexOf('node_modules');
   // By default, ngcc assumes the node_modules directory that it needs to process
   // is in the cwd. In our case, we should set cwd to the directory where ngcc
   // is resolved to, not the directory where tsconfig.json is located. See
   // https://github.com/angular/angular/blob/e23fd1f38205410e0ecb601ec73847cea2dea2a8/packages/compiler-cli/ngcc/src/command_line_options.ts#L18-L24
-  const cwd = index > 0 ? ngcc.slice(0, index) : process.cwd();
-  const childProcess = fork(
-      ngcc,
-      [
-        '--tsconfig',
-        tsconfig,
-      ],
-      {
-        cwd: resolve(cwd),
-        silent: true,  // pipe stderr and stdout so that we can report progress
-        execArgv: [],  // do not inherit flags like --inspect from parent process
-      });
+  const cwd = index > 0 ? ngcc.resolvedPath.slice(0, index) : process.cwd();
+  const args: string[] = [
+    '--tsconfig',
+    tsconfig,
+  ];
+  if (ngcc.version.greaterThanOrEqual(new Version('11.2.4'))) {
+    // See https://github.com/angular/angular/commit/241784bde8582bcbc00b8a95acdeb3b0d38fbec6
+    args.push('--typings-only');
+  }
+  const childProcess = fork(ngcc.resolvedPath, args, {
+    cwd: resolve(cwd),
+    silent: true,  // pipe stderr and stdout so that we can report progress
+    execArgv: [],  // do not inherit flags like --inspect from parent process
+  });
 
   let stderr = '';
   childProcess.stderr?.on('data', (data: Buffer) => {

--- a/server/src/version_provider.ts
+++ b/server/src/version_provider.ts
@@ -122,6 +122,10 @@ export function resolveNgLangSvc(probeLocations: string[]): NodeModule {
   return resolveWithMinVersion(ngls, MIN_NG_VERSION, probeLocations, ngls);
 }
 
+export function resolveNgcc(directory: string): NodeModule|undefined {
+  return resolve('@angular/compiler-cli/ngcc/main-ngcc.js', directory, '@angular/compiler-cli');
+}
+
 /**
  * Converts the specified string `a` to non-negative integer.
  * Returns -1 if the result is NaN.


### PR DESCRIPTION
ngcc v11.2.4 and above supports `--typings-only` mode, which updates the
TypeScript declaration files but keep Javascript files unmodified.
This will speed up ngcc operation in the extension.

cc: @petebacondarwin