### PR TITLE
perf: yield after checking diagnostics for an open file

### DIFF
--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -10,6 +10,8 @@ import * as ts from 'typescript/lib/tsserverlibrary';
 import * as lsp from 'vscode-languageserver';
 import {URI} from 'vscode-uri';
 
+export const isDebugMode = process.env['NG_DEBUG'] === 'true';
+
 enum Scheme {
   File = 'file',
 }


### PR DESCRIPTION
This commit contains a few perf improvements:

1. Increase debounce time from 200ms to 300ms
   This increases the likelihood of consolidating diagnostics requests, but
   should have little impact on user perception.
2. While in the middle of a diagnositc check, stop the operation if there is
   another pending diagnostic request.
3. After checking a file, yield the execution thread so that the server gets
   a chance to process incoming requests.