### PR TITLE
build: update the lock closed sha to the latest sha

### DIFF
--- a/.github/workflows/lock-closed.yml
+++ b/.github/workflows/lock-closed.yml
@@ -7,8 +7,9 @@ on:
 
 jobs:
   lock_closed:
+    if: github.repository == 'angular/vscode-ng-language-service'
     runs-on: ubuntu-latest
     steps:
-      - uses: angular/dev-infra/github-actions/lock-closed@0fc6f4d839e93312ed0dd9a2be88d4c11e947a0b
+      - uses: angular/dev-infra/github-actions/lock-closed@7679cff885633cd33bf5ac7922a5304e8971a5a6
         with:
           lock-bot-key: ${{ secrets.LOCK_BOT_PRIVATE_KEY }}


### PR DESCRIPTION
Update to use the latest lock closed sha, additionally use the full length sha for
referencing the exact version to use.