### PR TITLE
perf: optimizations to reduce and prioritize getSemanticDiagnostics for open files

### DIFF
--- a/integration/lsp/ivy_spec.ts
+++ b/integration/lsp/ivy_spec.ts
@@ -75,7 +75,15 @@ describe('Angular Ivy language server', () => {
     });
   });
 
-  it('should show existing diagnostics on external template', async () => {
+  it('should show diagnostics for inline template on open', async () => {
+    openTextDocument(client, APP_COMPONENT);
+    const languageServiceEnabled = await waitForNgcc(client);
+    expect(languageServiceEnabled).toBeTrue();
+    const diagnostics = await getDiagnosticsForFile(client, APP_COMPONENT);
+    expect(diagnostics.length).toBe(0);
+  });
+
+  it('should show diagnostics for external template on open', async () => {
     client.sendNotification(lsp.DidOpenTextDocumentNotification.type, {
       textDocument: {
         uri: `file://${FOO_TEMPLATE}`,

--- a/integration/lsp/viewengine_spec.ts
+++ b/integration/lsp/viewengine_spec.ts
@@ -94,7 +94,7 @@ describe('Angular language server', () => {
     client.sendNotification(lsp.DidOpenTextDocumentNotification.type, {
       textDocument: {
         uri: `file://${FOO_TEMPLATE}`,
-        languageId: 'typescript',
+        languageId: 'html',
         version: 1,
         text: `{{ doesnotexist }}`,
       },

--- a/server/src/session.ts
+++ b/server/src/session.ts
@@ -21,7 +21,7 @@ import {readNgCompletionData, tsCompletionEntryToLspCompletionItem} from './comp
 import {tsDiagnosticToLspDiagnostic} from './diagnostic';
 import {resolveAndRunNgcc} from './ngcc';
 import {ServerHost} from './server_host';
-import {filePathToUri, isConfiguredProject, isDebugMode, lspPositionToTsPosition, lspRangeToTsPositions, tsTextSpanToLspRange, uriToFilePath} from './utils';
+import {filePathToUri, isConfiguredProject, isDebugMode, lspPositionToTsPosition, lspRangeToTsPositions, MruTracker, tsTextSpanToLspRange, uriToFilePath} from './utils';
 import {resolve, Version} from './version_provider';
 
 export interface SessionOptions {
@@ -54,6 +54,7 @@ export class Session {
   private readonly ivy: boolean;
   private readonly configuredProjToExternalProj = new Map<string, string>();
   private readonly logToConsole: boolean;
+  private readonly openFiles = new MruTracker();
   private diagnosticsTimeout: NodeJS.Timeout|null = null;
   private isProjectLoading = false;
   /**
@@ -328,12 +329,9 @@ export class Session {
       // not affect other files because it is local to the Component.
       files.push(file);
     } else {
-      // Get all open files. Cast is needed because the key of the map is
-      // actually ts.Path. See
-      // https://github.com/microsoft/TypeScript/blob/496a1d3caa21c762daa95b1ac1b75823f8774575/src/server/editorServices.ts#L978
-      const openFiles = toArray(this.projectService.openFiles.keys()) as ts.Path[];
-      for (const openFile of openFiles) {
-        const scriptInfo = this.projectService.getScriptInfoForPath(openFile);
+      // Get all open files, most recently used first.
+      for (const openFile of this.openFiles.getAll()) {
+        const scriptInfo = this.projectService.getScriptInfo(openFile);
         if (scriptInfo) {
           files.push(scriptInfo.fileName);
         }
@@ -480,6 +478,7 @@ export class Session {
     if (!filePath) {
       return;
     }
+    this.openFiles.update(filePath);
     // External templates (HTML files) should be tagged as ScriptKind.Unknown
     // so that they don't get parsed as TS files. See
     // https://github.com/microsoft/TypeScript/blob/b217f22e798c781f55d17da72ed099a9dee5c650/src/compiler/program.ts#L1897-L1899
@@ -541,6 +540,7 @@ export class Session {
     if (!filePath) {
       return;
     }
+    this.openFiles.delete(filePath);
     this.projectService.closeClientFile(filePath);
   }
 
@@ -577,6 +577,7 @@ export class Session {
     if (!filePath) {
       return;
     }
+    this.openFiles.update(filePath);
     const scriptInfo = this.projectService.getScriptInfo(filePath);
     if (!scriptInfo) {
       this.error(`Failed to get script info for ${filePath}`);
@@ -602,6 +603,10 @@ export class Session {
   private onDidSaveTextDocument(params: lsp.DidSaveTextDocumentParams) {
     const {text, textDocument} = params;
     const filePath = uriToFilePath(textDocument.uri);
+    if (!filePath) {
+      return;
+    }
+    this.openFiles.update(filePath);
     const scriptInfo = this.projectService.getScriptInfo(filePath);
     if (!scriptInfo) {
       return;

--- a/server/src/session.ts
+++ b/server/src/session.ts
@@ -230,7 +230,6 @@ export class Session {
     // (because language service was disabled while waiting for ngcc).
     // First, make sure the Angular project is complete.
     this.runGlobalAnalysisForNewlyLoadedProject(project);
-    project.refreshDiagnostics();  // Show initial diagnostics
   }
 
   /**
@@ -242,8 +241,15 @@ export class Session {
       return;
     }
     const fileName = project.getRootScriptInfos()[0].fileName;
+    const label = `Global analysis - getSemanticDiagnostics for ${fileName}`;
+    if (isDebugMode) {
+      console.time(label);
+    }
     // Getting semantic diagnostics will trigger a global analysis.
     project.getLanguageService().getSemanticDiagnostics(fileName);
+    if (isDebugMode) {
+      console.timeEnd(label);
+    }
   }
 
   private handleCompilerOptionsDiagnostics(project: ts.server.Project) {
@@ -299,7 +305,7 @@ export class Session {
       case ts.server.ProjectsUpdatedInBackgroundEvent:
         // ProjectsUpdatedInBackgroundEvent is sent whenever diagnostics are
         // requested via project.refreshDiagnostics()
-        this.triggerDiagnostics(event.data.openFiles);
+        this.triggerDiagnostics(event.data.openFiles, event.eventName);
         break;
       case ts.server.ProjectLanguageServiceStateEvent:
         this.connection.sendNotification(ProjectLanguageService, {
@@ -310,12 +316,40 @@ export class Session {
   }
 
   /**
-   * Retrieve Angular diagnostics for the specified `openFiles` after a specific
+   * Request diagnostics to be computed due to the specified `file` being opened
+   * or changed.
+   * @param file File opened / changed
+   * @param reason Trace to explain why diagnostics are requested
+   */
+  private requestDiagnosticsOnOpenOrChangeFile(file: string, reason: string): void {
+    const files: string[] = [];
+    if (isExternalTemplate(file)) {
+      // If only external template is opened / changed, we know for sure it will
+      // not affect other files because it is local to the Component.
+      files.push(file);
+    } else {
+      // Get all open files. Cast is needed because the key of the map is
+      // actually ts.Path. See
+      // https://github.com/microsoft/TypeScript/blob/496a1d3caa21c762daa95b1ac1b75823f8774575/src/server/editorServices.ts#L978
+      const openFiles = toArray(this.projectService.openFiles.keys()) as ts.Path[];
+      for (const openFile of openFiles) {
+        const scriptInfo = this.projectService.getScriptInfoForPath(openFile);
+        if (scriptInfo) {
+          files.push(scriptInfo.fileName);
+        }
+      }
+    }
+    this.triggerDiagnostics(files, reason);
+  }
+
+  /**
+   * Retrieve Angular diagnostics for the specified `files` after a specific
    * `delay`, or renew the request if there's already a pending one.
-   * @param openFiles
+   * @param files files to be checked
+   * @param reason Trace to explain why diagnostics are triggered
    * @param delay time to wait before sending request (milliseconds)
    */
-  private triggerDiagnostics(openFiles: string[], delay: number = 300) {
+  private triggerDiagnostics(files: string[], reason: string, delay: number = 300) {
     // Do not immediately send a diagnostics request. Send only after user has
     // stopped typing after the specified delay.
     if (this.diagnosticsTimeout) {
@@ -325,24 +359,25 @@ export class Session {
     // Set a new timeout
     this.diagnosticsTimeout = setTimeout(() => {
       this.diagnosticsTimeout = null;  // clear the timeout
-      this.sendPendingDiagnostics(openFiles);
+      this.sendPendingDiagnostics(files, reason);
       // Default delay is 200ms, consistent with TypeScript. See
       // https://github.com/microsoft/vscode/blob/7b944a16f52843b44cede123dd43ae36c0405dfd/extensions/typescript-language-features/src/features/bufferSyncSupport.ts#L493)
     }, delay);
   }
 
   /**
-   * Execute diagnostics request for each of the specified `openFiles`.
-   * @param openFiles
+   * Execute diagnostics request for each of the specified `files`.
+   * @param files files to be checked
+   * @param reason Trace to explain why diagnostics is triggered
    */
-  private async sendPendingDiagnostics(openFiles: string[]) {
-    for (let i = 0; i < openFiles.length; ++i) {
-      const fileName = openFiles[i];
+  private async sendPendingDiagnostics(files: string[], reason: string) {
+    for (let i = 0; i < files.length; ++i) {
+      const fileName = files[i];
       const result = this.getLSAndScriptInfo(fileName);
       if (!result) {
         continue;
       }
-      const label = `getSemanticDiagnostics - ${fileName}`;
+      const label = `${reason} - getSemanticDiagnostics for ${fileName}`;
       if (isDebugMode) {
         console.time(label);
       }
@@ -361,7 +396,7 @@ export class Session {
         // so stop this one immediately.
         return;
       }
-      if (i < openFiles.length - 1) {
+      if (i < files.length - 1) {
         // If this is not the last file, yield so that pending I/O events get a
         // chance to run. This will open an opportunity for the server to process
         // incoming requests. The next file will be checked in the next iteration
@@ -467,7 +502,8 @@ export class Session {
         return;
       }
       if (project.languageServiceEnabled) {
-        project.refreshDiagnostics();  // Show initial diagnostics
+        // Show initial diagnostics
+        this.requestDiagnosticsOnOpenOrChangeFile(filePath, `Opening ${filePath}`);
       }
     } catch (error) {
       if (this.isProjectLoading) {
@@ -560,7 +596,7 @@ export class Session {
     if (!project || !project.languageServiceEnabled) {
       return;
     }
-    project.refreshDiagnostics();
+    this.requestDiagnosticsOnOpenOrChangeFile(scriptInfo.fileName, `Changing ${filePath}`);
   }
 
   private onDidSaveTextDocument(params: lsp.DidSaveTextDocumentParams) {
@@ -1007,4 +1043,12 @@ function isExternalAngularCore(path: string): boolean {
 
 function isInternalAngularCore(path: string): boolean {
   return path.endsWith('angular2/rc/packages/core/index.d.ts');
+}
+
+function isTypeScriptFile(path: string): boolean {
+  return path.endsWith('.ts');
+}
+
+function isExternalTemplate(path: string): boolean {
+  return !isTypeScriptFile(path);
 }

--- a/server/src/tests/utils_spec.ts
+++ b/server/src/tests/utils_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {filePathToUri, uriToFilePath} from '../utils';
+import {filePathToUri, MruTracker, uriToFilePath} from '../utils';
 
 describe('filePathToUri', () => {
   it('should return URI with File scheme', () => {
@@ -51,4 +51,41 @@ describe('uriToFilePath', () => {
       expect(filePath).toBe('//project/main.ts');
     });
   }
+});
+
+
+describe('MruTracker', () => {
+  it('should track new items', () => {
+    const tracker = new MruTracker();
+    tracker.update('a');
+    expect(tracker.getAll()).toEqual(['a']);
+  });
+
+  it('should delete existing items', () => {
+    const tracker = new MruTracker();
+    tracker.update('a');
+    tracker.delete('a');
+    expect(tracker.getAll()).toEqual([]);
+  });
+
+  it('should allow deletion of item that does not exist', () => {
+    const tracker = new MruTracker();
+    tracker.delete('a');
+    expect(tracker.getAll()).toEqual([]);
+  });
+
+  it('should return items in most recently used order', () => {
+    const tracker = new MruTracker();
+    tracker.update('a');
+    tracker.update('b');
+    expect(tracker.getAll()).toEqual(['b', 'a']);
+  });
+
+  it('should update existing item', () => {
+    const tracker = new MruTracker();
+    tracker.update('a');
+    tracker.update('b');
+    tracker.update('a');
+    expect(tracker.getAll()).toEqual(['a', 'b']);
+  });
 });

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -81,3 +81,32 @@ export function isConfiguredProject(project: ts.server.Project):
     project is ts.server.ConfiguredProject {
   return project.projectKind === ts.server.ProjectKind.Configured;
 }
+
+/**
+ * A class that tracks items in most recently used order.
+ */
+export class MruTracker {
+  private readonly set = new Set<string>();
+
+  update(item: string) {
+    if (this.set.has(item)) {
+      this.set.delete(item);
+    }
+    this.set.add(item);
+  }
+
+  delete(item: string) {
+    this.set.delete(item);
+  }
+
+  /**
+   * Returns all items sorted by most recently used.
+   */
+  getAll(): string[] {
+    // Javascript Set maintains insertion order, see
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set
+    // Since items are sorted from least recently used to most recently used,
+    // we reverse the result.
+    return [...this.set].reverse();
+  }
+}


### PR DESCRIPTION
This commit reduces the number of `getSemanticDiagnostics` calls the server
makes by looking at the file type when a file is opened /changed.

If the file is an external template, we know it has to be local to a
particular component, so checking that one file is sufficient.

If the file is TypeScript, then we compute diagnostics for all open files.

(idea: If we can detect that changes are made only to inline template, then
we could skip checking other open files altogether).