### PR TITLE
build: disable other extensions while testing

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,6 +8,7 @@
       "name": "Launch Client",
       "runtimeExecutable": "${execPath}",
       "args": [
+        "--disable-extensions",
         "--extensionDevelopmentPath=${workspaceFolder}"
       ],
       "outFiles": [


### PR DESCRIPTION
Disable all non-native extensions when bringing up the dev instance.