### PR TITLE
fix: do not minify the client code

### DIFF
--- a/esbuild.js
+++ b/esbuild.js
@@ -21,7 +21,8 @@ const clientConfig = {
     'vscode-jsonrpc',
   ],
   format: 'cjs',
-  minify: true,
+  // Do not enable minification. It seems to break the extension on Windows (with WSL). See #1198.
+  minify: false,
 };
 
 /** @type esbuild.BuildOptions */


### PR DESCRIPTION
When switching from rollup to esbuild, we enabled minification of
the client code for the first time. This ended up breaking the
extension on Windows machines. This commit removes the minification
and should resolve the broken activation on Windows.

Fixes #1198