### PR TITLE
ci: cache node_modules in test project and test workspace

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,12 @@ jobs:
       - checkout
       - node/install-packages:
           pkg-manager: yarn
+      - node/install-packages:
+          app-dir: integration/project
+          pkg-manager: yarn
+      - node/install-packages:
+          app-dir: integration/workspace
+          pkg-manager: yarn
       - run: scripts/lint.sh
       - run: scripts/format.sh
       - run: scripts/build.sh

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -3,14 +3,15 @@
 set -ex -o pipefail
 
 # Install test project dependencies
+if [[ -z "${CI}" ]]; then
+  (cd integration/project && yarn)
+  (cd integration/workspace && yarn)
+fi
+
+# Run ngcc before test starts
 (
   cd integration/project
-  yarn
   yarn ngcc
-)
-(
-  cd integration/workspace
-  yarn
 )
 
 # Server unit tests
@@ -20,7 +21,7 @@ yarn run test
 yarn run test:lsp
 
 # E2E test that brings up full vscode
-# TODO: Disabled for now because it cannot be run on Travis
+# TODO: Disabled for now because it cannot be run on CircleCI
 # yarn run test:e2e
 
 # Syntaxes tests


### PR DESCRIPTION
Use CircleCI config to install node_modules in `integration/project` and
`integration/workspace` so that they are cached.