### PR TITLE
fix: dispose reporters and notification handlers; fix: restart only on angular config change

### DIFF
--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -155,8 +155,8 @@ export class AngularLanguageClient implements vscode.Disposable {
     await this.client.onReady();
     // Must wait for the client to be ready before registering notification
     // handlers.
-    registerNotificationHandlers(this.client, this.context);
-    registerProgressHandlers(this.client, this.context);
+    this.disposables.push(registerNotificationHandlers(this.client));
+    this.disposables.push(registerProgressHandlers(this.client));
   }
 
   /**
@@ -229,8 +229,7 @@ export class AngularLanguageClient implements vscode.Disposable {
   }
 }
 
-function registerNotificationHandlers(
-    client: lsp.LanguageClient, context: vscode.ExtensionContext) {
+function registerNotificationHandlers(client: lsp.LanguageClient): vscode.Disposable {
   const disposable1 = client.onNotification(ProjectLoadingStart, () => {
     vscode.window.withProgress(
         {
@@ -293,10 +292,10 @@ function registerNotificationHandlers(
         }
       });
 
-  context.subscriptions.push(disposable1, disposable2, disposable3);
+  return vscode.Disposable.from(disposable1, disposable2, disposable3);
 }
 
-function registerProgressHandlers(client: lsp.LanguageClient, context: vscode.ExtensionContext) {
+function registerProgressHandlers(client: lsp.LanguageClient) {
   const progressReporters = new Map<string, ProgressReporter>();
   const disposable =
       client.onProgress(NgccProgressType, NgccProgressToken, async (params: NgccProgress) => {
@@ -323,8 +322,15 @@ function registerProgressHandlers(client: lsp.LanguageClient, context: vscode.Ex
           reporter.report(params.message);
         }
       });
-  // Dispose the progress handler on exit
-  context.subscriptions.push(disposable);
+  const reporterDisposer = vscode.Disposable.from({
+    dispose() {
+      for (const reporter of progressReporters.values()) {
+        reporter.finish();
+      }
+      disposable.dispose();
+    }
+  });
+  return reporterDisposer;
 }
 
 /**

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -19,10 +19,14 @@ export function activate(context: vscode.ExtensionContext) {
   registerCommands(client, context);
 
   // Restart the server on configuration change.
-  const disposable = vscode.workspace.onDidChangeConfiguration(async () => {
-    await client.stop();
-    await client.start();
-  });
+  const disposable =
+      vscode.workspace.onDidChangeConfiguration(async (e: vscode.ConfigurationChangeEvent) => {
+        if (!e.affectsConfiguration('angular')) {
+          return;
+        }
+        await client.stop();
+        await client.start();
+      });
   context.subscriptions.push(client, disposable);
 
   client.start();


### PR DESCRIPTION
fix: only restart language server on angular configuration change
Currently, we stop and start the client on _any_ configuration change.
With this commit, we will only do that when the changed configuration
affects the `angular` section.

fix: dispose reporters and notification handlers when client is stopped
The "restart Angular Language server" command as well as the restart
that happens when a configuration changes stops and starts the client.
We should track and clean up the notification and progress handlers for
the client at this time rather than continually pushing new ones to the
vscode context, which is only cleaned up when the window reloads/closes.


Fixes #1232