### PR TITLE
Create node.js.yml for E2E test on GitHub Actions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,0 +1,30 @@
+# This workflow will do a clean install of node dependencies, build the source code and run the E2E tests.
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: E2E Test
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: 12.x
+    - run: yarn install
+    - run: yarn install --cwd integration/project
+    - run: scripts/build.sh
+    - run: xvfb-run -a yarn run test:e2e
+      if: runner.os == 'Linux'
+    - run: yarn run test:e2e
+      if: runner.os != 'Linux'

--- a/integration/e2e/definition_spec.ts
+++ b/integration/e2e/definition_spec.ts
@@ -3,22 +3,22 @@ import {APP_COMPONENT} from '../test_constants';
 import {activate} from './helper';
 
 const DEFINITION_COMMAND = 'vscode.executeDefinitionProvider';
+const APP_COMPONENT_URI = vscode.Uri.file(APP_COMPONENT);
 
-describe('Angular LS', () => {
+describe('Angular Ivy LS', () => {
+  beforeAll(async () => {
+    await activate(APP_COMPONENT_URI);
+  }, 25000 /* 25 seconds */);
+
   it(`returns definition for variable in template`, async () => {
-    const docUri = vscode.Uri.file(APP_COMPONENT);
-
     // vscode Position is zero-based
     //   template: `<h1>Hello {{name}}</h1>`,
     //                          ^-------- here
     const position = new vscode.Position(4, 25);
-
-    await activate(docUri);
-
     // For a complete list of standard commands, see
     // https://code.visualstudio.com/api/references/commands
     const definitions = await vscode.commands.executeCommand<vscode.LocationLink[]>(
-        DEFINITION_COMMAND, docUri, position);
+        DEFINITION_COMMAND, APP_COMPONENT_URI, position);
     expect(definitions?.length).toBe(1);
     const def = definitions![0];
     expect(def.targetUri.fsPath).toBe(APP_COMPONENT);  // in the same document

--- a/integration/e2e/helper.ts
+++ b/integration/e2e/helper.ts
@@ -6,5 +6,5 @@ function sleep(ms: number) {
 
 export async function activate(uri: vscode.Uri) {
   await vscode.window.showTextDocument(uri);
-  await sleep(3 * 1000);  // Wait for server activation
+  await sleep(20 * 1000);  // Wait for server activation, including ngcc run
 }

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-set -ex -o pipefail
-
-export NG_DEBUG="true"
-export CODE_TESTS_PATH="$(pwd)/integration/out/e2e"
-export CODE_TESTS_WORKSPACE="$(pwd)/integration/project"
-
-node "$(pwd)/node_modules/vscode/bin/test"


### PR DESCRIPTION
Run E2E test on Linux and MacOS.
(Test currently fails on Windows, further debugging required).

Ref https://code.visualstudio.com/api/working-with-extensions/continuous-integration