### PR TITLE
perf: Avoid making Angular-related decisions for files not in an Angu…

### DIFF
--- a/common/requests.ts
+++ b/common/requests.ts
@@ -29,3 +29,11 @@ export interface GetTcbResponse {
   content: string;
   selections: lsp.Range[]
 }
+
+export const IsInAngularProject =
+    new lsp.RequestType<IsInAngularProjectParams, boolean, /* error */ void>(
+        'angular/isAngularCoreInOwningProject');
+
+export interface IsInAngularProjectParams {
+  textDocument: lsp.TextDocumentIdentifier;
+}

--- a/integration/lsp/ivy_spec.ts
+++ b/integration/lsp/ivy_spec.ts
@@ -14,7 +14,7 @@ import {URI} from 'vscode-uri';
 
 import {ProjectLanguageService, ProjectLanguageServiceParams, SuggestStrictMode, SuggestStrictModeParams} from '../../common/notifications';
 import {NgccProgress, NgccProgressToken, NgccProgressType} from '../../common/progress';
-import {GetComponentsWithTemplateFile, GetTcbRequest} from '../../common/requests';
+import {GetComponentsWithTemplateFile, GetTcbRequest, IsInAngularProject} from '../../common/requests';
 import {APP_COMPONENT, FOO_COMPONENT, FOO_TEMPLATE, PROJECT_PATH, TSCONFIG} from '../test_constants';
 
 import {createConnection, createTracer, initializeServer, openTextDocument} from './test_utils';
@@ -408,6 +408,23 @@ describe('Angular Ivy language server', () => {
     expect(codeLensResolveResponse).toBeDefined();
     expect(codeLensResolveResponse?.command?.title).toEqual('Go to component');
   });
+
+  it('detects an Angular project', async () => {
+    openTextDocument(client, FOO_TEMPLATE);
+    await waitForNgcc(client);
+    const templateResponse = await client.sendRequest(IsInAngularProject, {
+      textDocument: {
+        uri: `file://${FOO_TEMPLATE}`,
+      }
+    });
+    expect(templateResponse).toBe(true);
+    const componentResponse = await client.sendRequest(IsInAngularProject, {
+      textDocument: {
+        uri: `file://${FOO_COMPONENT}`,
+      }
+    });
+    expect(componentResponse).toBe(true);
+  })
 });
 
 function onNgccProgress(client: MessageConnection): Promise<string> {

--- a/server/src/session.ts
+++ b/server/src/session.ts
@@ -15,7 +15,7 @@ import * as lsp from 'vscode-languageserver/node';
 import {ServerOptions} from '../common/initialize';
 import {ProjectLanguageService, ProjectLoadingFinish, ProjectLoadingStart, SuggestIvyLanguageService, SuggestStrictMode} from '../common/notifications';
 import {NgccProgressToken, NgccProgressType} from '../common/progress';
-import {GetComponentsWithTemplateFile, GetTcbParams, GetTcbRequest, GetTcbResponse} from '../common/requests';
+import {GetComponentsWithTemplateFile, GetTcbParams, GetTcbRequest, GetTcbResponse, IsInAngularProject, IsInAngularProjectParams} from '../common/requests';
 
 import {readNgCompletionData, tsCompletionEntryToLspCompletionItem} from './completion';
 import {tsDiagnosticToLspDiagnostic} from './diagnostic';
@@ -165,8 +165,29 @@ export class Session {
     conn.onCompletionResolve(p => this.onCompletionResolve(p));
     conn.onRequest(GetComponentsWithTemplateFile, p => this.onGetComponentsWithTemplateFile(p));
     conn.onRequest(GetTcbRequest, p => this.onGetTcb(p));
+    conn.onRequest(IsInAngularProject, p => this.isInAngularProject(p));
     conn.onCodeLens(p => this.onCodeLens(p));
     conn.onCodeLensResolve(p => this.onCodeLensResolve(p));
+  }
+
+  private isInAngularProject(params: IsInAngularProjectParams): boolean {
+    const filePath = uriToFilePath(params.textDocument.uri);
+    if (!filePath) {
+      return false;
+    }
+    const scriptInfo = this.projectService.getScriptInfo(filePath);
+    if (!scriptInfo) {
+      return false;
+    }
+    const project = this.projectService.getDefaultProjectForFile(
+        scriptInfo.fileName,
+        false  // ensureProject
+    );
+    if (!project) {
+      return false;
+    }
+    const angularCore = project.getFileNames().find(isAngularCore);
+    return angularCore !== undefined;
   }
 
   private onGetTcb(params: GetTcbParams): GetTcbResponse|undefined {


### PR DESCRIPTION
…lar project

This commit updates our client-side short-circuit logic to provide an
additiona short circuit that avoids tokenizing typescript files when
they are not within a project that uses Angular.

fixes #1237