### PR TITLE
fix: do not resolve CodeLens command until LS is enabled

### DIFF
--- a/server/src/session.ts
+++ b/server/src/session.ts
@@ -228,6 +228,16 @@ export class Session {
   }
 
   private onCodeLensResolve(params: lsp.CodeLens): lsp.CodeLens {
+    const lsInfo = this.getLSAndScriptInfo(params.data);
+    if (lsInfo === undefined) {
+      return params;
+    }
+    const project = this.getDefaultProjectForScriptInfo(lsInfo.scriptInfo);
+    // If the language service is disabled, the angular command will not be available.
+    if (!project?.languageServiceEnabled) {
+      return params;
+    }
+
     const components = this.onGetComponentsWithTemplateFile({textDocument: params.data});
     if (components !== undefined && components.length > 0) {
       params.command = {


### PR DESCRIPTION
CodeLens will show "!!MISSING: command!!" on startup while ngcc is
running (because the language service gets disabled). Fortunately, the
CodeLensResolve gets called periodically so we can simply wait until the
language service is re-enabled before returning the resolved command.

Fixes #1253