### PR TITLE
build: fix compound target in launch.json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -84,9 +84,9 @@
   ],
   "compounds": [
     {
-      "name": "Client + Server",
+      "name": "Dev Client + Server",
       "configurations": [
-        "Launch Client",
+        "Launch Dev Client",
         "Attach to Server"
       ]
     }


### PR DESCRIPTION
`Launch Client` has been renamed to `Launch Dev Client`.