### PR TITLE
fix: make Ivy LS the default

### DIFF
--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -296,28 +296,6 @@ function registerNotificationHandlers(client: lsp.LanguageClient): vscode.Dispos
     }
   }));
 
-  disposables.push(client.onNotification(
-      SuggestIvyLanguageService, async (params: SuggestIvyLanguageServiceParams) => {
-        const config = vscode.workspace.getConfiguration();
-        if (config.get('angular.enable-experimental-ivy-prompt') === false) {
-          return;
-        }
-
-        const enableIvy = 'Enable';
-        const doNotPromptAgain = 'Do not show this again';
-        const selection = await vscode.window.showInformationMessage(
-            params.message,
-            enableIvy,
-            doNotPromptAgain,
-        );
-        if (selection === enableIvy) {
-          config.update('angular.experimental-ivy', true, vscode.ConfigurationTarget.Global);
-        } else if (selection === doNotPromptAgain) {
-          config.update(
-              'angular.enable-experimental-ivy-prompt', false, vscode.ConfigurationTarget.Global);
-        }
-      }));
-
   return vscode.Disposable.from(...disposables);
 }
 
@@ -401,9 +379,9 @@ function constructArgs(ctx: vscode.ExtensionContext): string[] {
   const ngProbeLocations = getProbeLocations(ngdk, ctx.extensionPath);
   args.push('--ngProbeLocations', ngProbeLocations.join(','));
 
-  const experimentalIvy: boolean = config.get('angular.experimental-ivy', false);
-  if (experimentalIvy) {
-    args.push('--experimental-ivy');
+  const viewEngine: boolean = config.get('angular.view-engine', false);
+  if (viewEngine) {
+    args.push('--viewEngine');
   }
 
   const tsdk: string|null = config.get('typescript.tsdk', null);

--- a/integration/lsp/test_utils.ts
+++ b/integration/lsp/test_utils.ts
@@ -25,8 +25,8 @@ export function createConnection(serverOptions: ServerOptions): MessageConnectio
     '--ngProbeLocations',
     [SERVER_PATH, PROJECT_PATH].join(','),
   ];
-  if (serverOptions.ivy) {
-    argv.push('--experimental-ivy');
+  if (!serverOptions.ivy) {
+    argv.push('--viewEngine');
   }
   const server = fork(SERVER_PATH, argv, {
     cwd: PROJECT_PATH,

--- a/integration/project/.vscode/settings.json
+++ b/integration/project/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "angular.experimental-ivy": true
-}

--- a/package.json
+++ b/package.json
@@ -82,15 +82,10 @@
           "default": "off",
           "description": "Enables logging of the Angular server to a file. This log can be used to diagnose Angular Server issues. The log may contain file paths, source code, and other potentially sensitive information from your project."
         },
-        "angular.experimental-ivy": {
+        "angular.view-engine": {
           "type": "boolean",
           "default": false,
-          "description": "Opt-in to the Ivy language service. Note: To disable the Ivy language service in a workspace when it is enabled in the user settings, open the settings.json file and set the angular.experiment-ivy to false."
-        },
-        "angular.enable-experimental-ivy-prompt": {
-          "type": "boolean",
-          "default": true,
-          "description": "Prompt to enable the Ivy language service for the workspace when View Engine is in use."
+          "description": "Use legacy View Engine language service."
         },
         "angular.enable-strict-mode-prompt": {
           "type": "boolean",

--- a/server/src/cmdline_utils.ts
+++ b/server/src/cmdline_utils.ts
@@ -29,8 +29,7 @@ function hasArgument(argv: string[], argName: string): boolean {
 interface CommandLineOptions {
   help: boolean;
   /**
-   * If true, use the Ivy version of Angular LS. For now this is only used for
-   * development.
+   * If true, use Ivy LS, otherwise use legacy View Engine LS.
    */
   ivy: boolean;
   logFile?: string;
@@ -43,7 +42,7 @@ interface CommandLineOptions {
 export function parseCommandLine(argv: string[]): CommandLineOptions {
   return {
     help: hasArgument(argv, '--help'),
-    ivy: hasArgument(argv, '--experimental-ivy'),
+    ivy: !hasArgument(argv, '--viewEngine'),
     logFile: findArgument(argv, '--logFile'),
     logVerbosity: findArgument(argv, '--logVerbosity'),
     logToConsole: hasArgument(argv, '--logToConsole'),
@@ -59,7 +58,7 @@ export function generateHelpMessage(argv: string[]) {
 
   Options:
     --help: Prints help message.
-    --experimental-ivy: Enables the Ivy language service. Defaults to false.
+    --viewEngine: Use legacy View Engine language service. Defaults to false.
     --logFile: Location to log messages. Logging to file is disabled if not provided.
     --logVerbosity: terse|normal|verbose|requestTime. See ts.server.LogLevel.
     --logToConsole: Enables logging to console via 'window/logMessage'. Defaults to false.


### PR DESCRIPTION
Ivy LS will be the default in Angular v12.

To revert to legacy View Engine LS, enable the `view-engine` option:

<img width="1904" alt="Screen Shot 2021-04-12 at 2 12 26 PM" src="https://user-images.githubusercontent.com/2941178/114463395-39fb3c80-9b99-11eb-9079-08d9ef25c5e3.png">
