### PR TITLE
refactor: wrap server script in main() to avoid polluting globals

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -12,50 +12,54 @@ import {ServerHost} from './server_host';
 import {Session} from './session';
 import {resolveNgLangSvc, resolveTsServer} from './version_provider';
 
-// Parse command line arguments
-const options = parseCommandLine(process.argv);
+function main() {
+  // Parse command line arguments
+  const options = parseCommandLine(process.argv);
 
-if (options.help) {
-  console.error(generateHelpMessage(process.argv));
-  process.exit(0);
+  if (options.help) {
+    console.error(generateHelpMessage(process.argv));
+    process.exit(0);
+  }
+
+  // Create a logger that logs to file. OK to emit verbose entries.
+  const logger = createLogger({
+    logFile: options.logFile,
+    logVerbosity: options.logVerbosity,
+  });
+
+  const ts = resolveTsServer(options.tsProbeLocations);
+  const ng = resolveNgLangSvc(options.ngProbeLocations);
+
+  const isG3 = ts.resolvedPath.includes('/google3/');
+
+  // ServerHost provides native OS functionality
+  const host = new ServerHost(isG3);
+
+  // Establish a new server session that encapsulates lsp connection.
+  const session = new Session({
+    host,
+    logger,
+    // TypeScript allows only package names as plugin names.
+    ngPlugin: '@angular/language-service',
+    resolvedNgLsPath: ng.resolvedPath,
+    ivy: isG3 ? true : options.ivy,
+    logToConsole: options.logToConsole,
+  });
+
+  // Log initialization info
+  session.info(`Angular language server process ID: ${process.pid}`);
+  session.info(`Using ${ts.name} v${ts.version} from ${ts.resolvedPath}`);
+  session.info(`Using ${ng.name} v${ng.version} from ${ng.resolvedPath}`);
+  if (logger.loggingEnabled()) {
+    session.info(`Log file: ${logger.getLogFileName()}`);
+  } else {
+    session.info(`Logging is turned off. To enable, run command 'Open Angular server log'.`);
+  }
+  if (process.env.NG_DEBUG === 'true') {
+    session.info('Angular Language Service is running under DEBUG mode');
+  }
+
+  session.listen();
 }
 
-// Create a logger that logs to file. OK to emit verbose entries.
-const logger = createLogger({
-  logFile: options.logFile,
-  logVerbosity: options.logVerbosity,
-});
-
-const ts = resolveTsServer(options.tsProbeLocations);
-const ng = resolveNgLangSvc(options.ngProbeLocations);
-
-const isG3 = ts.resolvedPath.includes('/google3/');
-
-// ServerHost provides native OS functionality
-const host = new ServerHost(isG3);
-
-// Establish a new server session that encapsulates lsp connection.
-const session = new Session({
-  host,
-  logger,
-  // TypeScript allows only package names as plugin names.
-  ngPlugin: '@angular/language-service',
-  resolvedNgLsPath: ng.resolvedPath,
-  ivy: isG3 ? true : options.ivy,
-  logToConsole: options.logToConsole,
-});
-
-// Log initialization info
-session.info(`Angular language server process ID: ${process.pid}`);
-session.info(`Using ${ts.name} v${ts.version} from ${ts.resolvedPath}`);
-session.info(`Using ${ng.name} v${ng.version} from ${ng.resolvedPath}`);
-if (logger.loggingEnabled()) {
-  session.info(`Log file: ${logger.getLogFileName()}`);
-} else {
-  session.info(`Logging is turned off. To enable, run command 'Open Angular server log'.`);
-}
-if (process.env.NG_DEBUG === 'true') {
-  session.info('Angular Language Service is running under DEBUG mode');
-}
-
-session.listen();
+main();


### PR DESCRIPTION
`server.js` is a script, which means when it's bundled all symbols defined
in the root scope of the file show up as globals.
Wrap them in main() function to avoid polluting the scope.