### PR TITLE
ci: fix flaky e2e test

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -23,6 +23,7 @@ jobs:
         node-version: 12.x
     - run: yarn install
     - run: yarn install --cwd integration/project
+    - run: cd integration/project && yarn ngcc
     - run: scripts/build.sh
     - run: xvfb-run -a yarn run test:e2e
       if: runner.os == 'Linux'


### PR DESCRIPTION
Run `ngcc` prior to starting vscode instance