### PR TITLE
fix: pass watch options to watchFile and watchDirectory

### DIFF
--- a/server/src/server_host.ts
+++ b/server/src/server_host.ts
@@ -53,17 +53,19 @@ export class ServerHost implements ts.server.ServerHost {
    * @pollingInterval - this parameter is used in polling-based watchers and
    * ignored in watchers that use native OS file watching
    */
-  watchFile(path: string, callback: ts.FileWatcherCallback, pollingInterval?: number):
-      ts.FileWatcher {
-    return ts.sys.watchFile!(path, callback, pollingInterval);
+  watchFile(
+      path: string, callback: ts.FileWatcherCallback, pollingInterval?: number,
+      options?: ts.WatchOptions): ts.FileWatcher {
+    return ts.sys.watchFile!(path, callback, pollingInterval, options);
   }
 
-  watchDirectory(path: string, callback: ts.DirectoryWatcherCallback, recursive?: boolean):
-      ts.FileWatcher {
+  watchDirectory(
+      path: string, callback: ts.DirectoryWatcherCallback, recursive?: boolean,
+      options?: ts.WatchOptions): ts.FileWatcher {
     if (this.isG3 && path.startsWith('/google/src')) {
       return NOOP_WATCHER;
     }
-    return ts.sys.watchDirectory!(path, callback, recursive);
+    return ts.sys.watchDirectory!(path, callback, recursive, options);
   }
 
   resolvePath(path: string): string {


### PR DESCRIPTION
The options are needed so that the server respects the `WatchOptions`
provided by users in their tsconfig.json.

```ts
    export interface WatchOptions {
        watchFile?: WatchFileKind;
        watchDirectory?: WatchDirectoryKind;
        fallbackPolling?: PollingWatchKind;
        synchronousWatchDirectory?: boolean;
        excludeDirectories?: string[];
        excludeFiles?: string[];
        [option: string]: CompilerOptionsValue | undefined;
    }
```

Without this fix, the server falls back to file polling, which consumes considerable CPU cycles in large projects.

fix https://github.com/angular/vscode-ng-language-service/issues/636