### PR TITLE
refactor: remove suggest Ivy LS notification

### DIFF
--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -11,7 +11,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import * as lsp from 'vscode-languageclient/node';
 
-import {ProjectLoadingFinish, ProjectLoadingStart, SuggestIvyLanguageService, SuggestIvyLanguageServiceParams, SuggestStrictMode, SuggestStrictModeParams} from '../common/notifications';
+import {ProjectLoadingFinish, ProjectLoadingStart, SuggestStrictMode, SuggestStrictModeParams} from '../common/notifications';
 import {NgccProgress, NgccProgressToken, NgccProgressType} from '../common/progress';
 import {GetComponentsWithTemplateFile, GetTcbRequest, IsInAngularProject} from '../common/requests';
 

--- a/common/notifications.ts
+++ b/common/notifications.ts
@@ -26,10 +26,3 @@ export interface SuggestStrictModeParams {
 
 export const SuggestStrictMode =
     new NotificationType<SuggestStrictModeParams>('angular/suggestStrictMode');
-
-export interface SuggestIvyLanguageServiceParams {
-  message: string;
-}
-
-export const SuggestIvyLanguageService =
-    new NotificationType<SuggestIvyLanguageServiceParams>('angular/suggestIvyLanguageServiceMode');

--- a/integration/lsp/viewengine_spec.ts
+++ b/integration/lsp/viewengine_spec.ts
@@ -9,7 +9,6 @@
 import {MessageConnection} from 'vscode-jsonrpc';
 import * as lsp from 'vscode-languageserver-protocol';
 
-import {SuggestIvyLanguageService, SuggestIvyLanguageServiceParams} from '../../common/notifications';
 import {APP_COMPONENT, FOO_TEMPLATE} from '../test_constants';
 
 import {createConnection, initializeServer, openTextDocument} from './test_utils';
@@ -111,12 +110,6 @@ describe('Angular language server', () => {
     expect(diagnostics.length).toBe(1);
     expect(diagnostics[0].message).toContain(`Identifier 'doesnotexist' is not defined.`);
   });
-
-  it('should prompt to enable Ivy Language Service', async () => {
-    openTextDocument(client, APP_COMPONENT);
-    const message = await onSuggestIvyLanguageService(client);
-    expect(message).toContain('Would you like to enable the new Ivy-native language service');
-  });
 });
 
 describe('initialization', () => {
@@ -148,11 +141,3 @@ describe('initialization', () => {
     client.dispose();
   });
 });
-
-function onSuggestIvyLanguageService(client: MessageConnection): Promise<string> {
-  return new Promise(resolve => {
-    client.onNotification(SuggestIvyLanguageService, (params: SuggestIvyLanguageServiceParams) => {
-      resolve(params.message);
-    });
-  });
-}


### PR DESCRIPTION
Now that Ivy LS is the default in version 12, `SuggestIvyLanguageService` notification
is no longer needed.