### PR TITLE
chore: add vim swap files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ dist/
 .vscode/settings.json
 .vimrc
 .nvimrc
+*.swo
+*.swp
 
 
 # Ignore files log and local only files related to ng-dev


### PR DESCRIPTION
adds *.swp and *.swo files to .gitignore to avoid versioning temorary
files created by vim. This aligns this repo with angular/angular.

See implementation in angular/angular: https://github.com/angular/angular/blob/master/.gitignore#L21