### PR TITLE
refactor: move version resolver to common

### DIFF
--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -14,7 +14,6 @@ import * as lsp from 'vscode-languageclient/node';
 import {ProjectLoadingFinish, ProjectLoadingStart, SuggestStrictMode, SuggestStrictModeParams} from '../common/notifications';
 import {NgccProgress, NgccProgressToken, NgccProgressType} from '../common/progress';
 import {GetComponentsWithTemplateFile, GetTcbRequest, IsInAngularProject} from '../common/requests';
-import {resolve, Version} from '../common/resolver';
 
 import {isInsideComponentDecorator, isInsideInlineTemplateRegion} from './embedded_support';
 import {ProgressReporter} from './progress-reporter';
@@ -315,8 +314,7 @@ function registerProgressHandlers(client: lsp.LanguageClient) {
       client.onProgress(NgccProgressType, NgccProgressToken, async (params: NgccProgress) => {
         const {configFilePath} = params;
         if (!progressReporters.has(configFilePath)) {
-          const reporter = new ProgressReporter();
-          progressReporters.set(configFilePath, reporter);
+          progressReporters.set(configFilePath, new ProgressReporter());
         }
         const reporter = progressReporters.get(configFilePath)!;
         if (params.done) {
@@ -390,8 +388,7 @@ function constructArgs(ctx: vscode.ExtensionContext): string[] {
   const ngProbeLocations = getProbeLocations(ngdk, ctx.extensionPath);
   args.push('--ngProbeLocations', ngProbeLocations.join(','));
 
-  console.error(vscode.workspace.workspaceFolders);
-  const viewEngine: boolean = config.get('angular.view-engine', !allProjectsSupportIvy());
+  const viewEngine: boolean = config.get('angular.view-engine', false);
   if (viewEngine) {
     args.push('--viewEngine');
   }
@@ -435,15 +432,4 @@ function getServerOptions(ctx: vscode.ExtensionContext, debug: boolean): lsp.Nod
       execArgv: debug ? devExecArgv : prodExecArgv,
     },
   };
-}
-
-function allProjectsSupportIvy() {
-  const workspaceFolders = vscode.workspace.workspaceFolders || [];
-  for (const workspaceFolder of workspaceFolders) {
-    const angularCore = resolve('@angular/core', workspaceFolder.uri.fsPath);
-    if (angularCore?.version.greaterThanOrEqual(new Version('9')) === false) {
-      return false;
-    }
-  }
-  return true;
 }

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -15,7 +15,7 @@
     }
   ],
   "include": [
-    "src"
+    "src/*.ts"
   ],
   "exclude": [
     "node_modules"

--- a/common/resolver.ts
+++ b/common/resolver.ts
@@ -1,0 +1,100 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as fs from 'fs';
+
+/**
+ * Represents a valid node module that has been successfully resolved.
+ */
+export interface NodeModule {
+  name: string;
+  resolvedPath: string;
+  version: Version;
+}
+
+export function resolve(packageName: string, location: string, rootPackage?: string): NodeModule|
+    undefined {
+  rootPackage = rootPackage || packageName;
+  try {
+    const packageJsonPath = require.resolve(`${rootPackage}/package.json`, {
+      paths: [location],
+    });
+    // Do not use require() to read JSON files since it's a potential security
+    // vulnerability.
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+    const resolvedPath = require.resolve(packageName, {
+      paths: [location],
+    });
+    return {
+      name: packageName,
+      resolvedPath,
+      version: new Version(packageJson.version),
+    };
+  } catch {
+  }
+}
+
+export class Version {
+  readonly major: number;
+  readonly minor: number;
+  readonly patch: number;
+
+  constructor(private readonly versionStr: string) {
+    const [major, minor, patch] = Version.parseVersionStr(versionStr);
+    this.major = major;
+    this.minor = minor;
+    this.patch = patch;
+  }
+
+  greaterThanOrEqual(other: Version): boolean {
+    if (this.major < other.major) {
+      return false;
+    }
+    if (this.major > other.major) {
+      return true;
+    }
+    if (this.minor < other.minor) {
+      return false;
+    }
+    if (this.minor > other.minor) {
+      return true;
+    }
+    return this.patch >= other.patch;
+  }
+
+  toString(): string {
+    return this.versionStr;
+  }
+
+  /**
+   * Converts the specified `versionStr` to its number constituents. Invalid
+   * number value is represented as negative number.
+   * @param versionStr
+   */
+  static parseVersionStr(versionStr: string): [number, number, number] {
+    const [major, minor, patch] = versionStr.split('.').map(parseNonNegativeInt);
+    return [
+      major === undefined ? 0 : major,
+      minor === undefined ? 0 : minor,
+      patch === undefined ? 0 : patch,
+    ];
+  }
+}
+
+/**
+ * Converts the specified string `a` to non-negative integer.
+ * Returns -1 if the result is NaN.
+ * @param a
+ */
+function parseNonNegativeInt(a: string): number {
+  // parseInt() will try to convert as many as possible leading characters that
+  // are digits. This means a string like "123abc" will be converted to 123.
+  // For our use case, this is sufficient.
+  const i = parseInt(a, 10 /* radix */);
+  return isNaN(i) ? -1 : i;
+}

--- a/common/tests/resolver_spec.ts
+++ b/common/tests/resolver_spec.ts
@@ -1,0 +1,58 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Version} from '../resolver';
+
+describe('Version', () => {
+  it('should parse version string correctly', () => {
+    const cases: Array<[string, number, number, number]> = [
+      // version string | major | minor | patch
+      ['1', 1, 0, 0],
+      ['1.2', 1, 2, 0],
+      ['1.2.3', 1, 2, 3],
+      ['9.0.0-rc.1+126.sha-0c38aae.with-local-changes', 9, 0, 0],
+    ];
+    for (const [versionStr, major, minor, patch] of cases) {
+      const v = new Version(versionStr);
+      expect(v.major).toBe(major);
+      expect(v.minor).toBe(minor);
+      expect(v.patch).toBe(patch);
+    }
+  });
+
+  it('should compare versions correctly', () => {
+    const cases: Array<[string, string, boolean]> = [
+      // lhs | rhs | result
+      ['1', '1', true],
+      ['1', '2', false],
+      ['2', '2.0', true],
+      ['2', '2.1', false],
+      ['2', '2.0.0', true],
+      ['2', '2.0.1', false],
+
+      ['1.2', '1', true],
+      ['1.2', '2', false],
+      ['2.2', '2.1', true],
+      ['2.2', '2.7', false],
+      ['3.2', '3.2.0', true],
+      ['3.2', '3.2.1', false],
+
+      ['1.2.3', '1', true],
+      ['1.2.3', '2', false],
+      ['2.2.3', '2.1', true],
+      ['2.2.3', '2.3', false],
+      ['3.2.3', '3.2.2', true],
+      ['3.2.3', '3.2.4', false],
+    ];
+    for (const [s1, s2, result] of cases) {
+      const v1 = new Version(s1);
+      const v2 = new Version(s2);
+      expect(v1.greaterThanOrEqual(v2)).toBe(result, `Expect ${v1} >= ${v2}`);
+    }
+  });
+});

--- a/common/tests/tsconfig.json
+++ b/common/tests/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/common/tests",
+  },
+  "references": [
+    { "path": "../tsconfig.json" }
+  ],
+  "include": ["*.ts"]
+}

--- a/jasmine.json
+++ b/jasmine.json
@@ -2,6 +2,7 @@
   "spec_dir": "dist",
   "spec_files": [
     "client/tests/*_spec.js",
+    "common/tests/*_spec.js",
     "server/tests/*_spec.js"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -152,8 +152,8 @@
   ],
   "main": "./dist/client/extension",
   "scripts": {
-    "compile": "tsc -p server/banner.tsconfig.json && tsc -b && node esbuild.js",
-    "compile:test": "tsc -b server/src/tests && tsc -b client/src/tests",
+    "compile": "tsc -b server/banner.tsconfig.json && tsc -b && node esbuild.js",
+    "compile:test": "tsc -b test.tsconfig.json",
     "compile:integration": "tsc -b integration",
     "compile:syntaxes-test": "tsc -b syntaxes/test",
     "build:syntaxes": "tsc -b syntaxes && node dist/syntaxes/build.js",

--- a/server/banner.tsconfig.json
+++ b/server/banner.tsconfig.json
@@ -1,13 +1,16 @@
 {
+  "extends": "../tsconfig.json",
   "compilerOptions": {
-    "target": "es2015",
-    "module": "es2015",
-    "moduleResolution": "node",
-    "sourceMap": false,
-    "strict": true,
-    "outDir": "../dist/banner"
+    "outDir": "../dist/banner",
+    "rootDir": "src",
+    "rootDirs": [".", "../dist"]
   },
+  "references": [
+    {"path": "../common"}
+  ],
   "files": [
-    "src/banner.ts"
+    "src/banner.ts",
+    "src/cmdline_utils.ts",
+    "src/version_provider.ts"
   ]
 }

--- a/server/src/ngcc.ts
+++ b/server/src/ngcc.ts
@@ -8,7 +8,10 @@
 
 import {fork} from 'child_process';
 import {dirname, resolve} from 'path';
-import {resolveNgcc, Version} from './version_provider';
+
+import {Version} from '../common/resolver';
+
+import {resolveNgcc} from './version_provider';
 
 interface Progress {
   report(msg: string): void;

--- a/server/src/tests/version_provider_spec.ts
+++ b/server/src/tests/version_provider_spec.ts
@@ -8,7 +8,7 @@
 
 import {isAbsolute, resolve} from 'path';
 
-import {resolveNgLangSvc, resolveTsServer, Version} from '../version_provider';
+import {resolveNgLangSvc, resolveTsServer} from '../version_provider';
 
 describe('Node Module Resolver', () => {
   const probeLocations = [__dirname];
@@ -31,54 +31,5 @@ describe('Node Module Resolver', () => {
     const result = resolveNgLangSvc(probeLocations);
     expect(result).toBeDefined();
     expect(result.resolvedPath.endsWith('@angular/language-service/index.js')).toBeTrue();
-  });
-});
-
-describe('Version', () => {
-  it('should parse version string correctly', () => {
-    const cases: Array<[string, number, number, number]> = [
-      // version string | major | minor | patch
-      ['1', 1, 0, 0],
-      ['1.2', 1, 2, 0],
-      ['1.2.3', 1, 2, 3],
-      ['9.0.0-rc.1+126.sha-0c38aae.with-local-changes', 9, 0, 0],
-    ];
-    for (const [versionStr, major, minor, patch] of cases) {
-      const v = new Version(versionStr);
-      expect(v.major).toBe(major);
-      expect(v.minor).toBe(minor);
-      expect(v.patch).toBe(patch);
-    }
-  });
-
-  it('should compare versions correctly', () => {
-    const cases: Array<[string, string, boolean]> = [
-      // lhs | rhs | result
-      ['1', '1', true],
-      ['1', '2', false],
-      ['2', '2.0', true],
-      ['2', '2.1', false],
-      ['2', '2.0.0', true],
-      ['2', '2.0.1', false],
-
-      ['1.2', '1', true],
-      ['1.2', '2', false],
-      ['2.2', '2.1', true],
-      ['2.2', '2.7', false],
-      ['3.2', '3.2.0', true],
-      ['3.2', '3.2.1', false],
-
-      ['1.2.3', '1', true],
-      ['1.2.3', '2', false],
-      ['2.2.3', '2.1', true],
-      ['2.2.3', '2.3', false],
-      ['3.2.3', '3.2.2', true],
-      ['3.2.3', '3.2.4', false],
-    ];
-    for (const [s1, s2, result] of cases) {
-      const v1 = new Version(s1);
-      const v2 = new Version(s2);
-      expect(v1.greaterThanOrEqual(v2)).toBe(result, `Expect ${v1} >= ${v2}`);
-    }
   });
 });

--- a/test.tsconfig.json
+++ b/test.tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "references": [
+    {"path": "./client/src/tests"},
+    {"path": "./server/src/tests"},
+    {"path": "./common/tests"}
+  ]
+}


### PR DESCRIPTION
Move the version resolver code to `common` directory so that it can be shared with client code.