### PR TITLE
docs: update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,20 +1,44 @@
 ---
-name: Bug report
-about: Create a report to help us improve
+name: "\U0001F41E Bug report"
+about: Report a bug in the Angular Language Service extension, or in the language server.
 title: ''
 labels: bug
 assignees: ''
 
 ---
 
-**Describe the bug**
+<!--🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅
 
-A clear and concise description of what the bug is.
+Oh hi there! 😄
+
+To expedite issue processing please search open and closed issues before submitting a new one.
+Existing issues often contain information about workarounds, resolution, or progress updates.
+
+🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅-->
+
+# 🐞 bug report
+
+### Is this a regression?
+
+<!-- Did this behavior use to work in the previous version? -->
+<!-- ✍️--> Yes, the previous version in which this bug was not present was: ....
+
+### Description
+
+<!-- ✍️--> A clear and concise description of the problem...
 
 If the bug is caused or experienced by a particular source code, please provide a minimal
 reproduction of that source code.
 
-**To Reproduce**
+## Bug Type
+What does this bug affect
+
+<!-- Please check the one that applies to this bug report using "x". -->
+
+- [ ] Angular Language Service VSCode extension
+- [ ] Angular Language Service server
+
+## Reproduction
 
 Steps to reproduce the behavior:
 1. Go to '...'
@@ -26,22 +50,60 @@ Steps to reproduce the behavior:
 
 A clear and concise description of what you expected to happen.
 
-**Logs**
+### **Logs**
 
-Log file gives us deep insight into the behavior and performance of the extension, so we strongly
-recommend you upload it.
-
-Go to the command palette (Cmd+Shift+P on Mac, Ctrl+Shift+P on Windows), search `Open Angular Server log`
+Log file gives us deep insight into the behavior and performance of the extension. If the issue is a performance
+problem or an error occured, please provide the output of the log file below.
 
 Set Angular Log level to verbose.
-Open settings (File/Preferences/Settings on Windows, Code/Preferences/Settings on Mac), go to Extensions/Angular Language Service, set `angular.log` to `verbose`.
 
-**Screenshots**
+<pre><code>
+<!-- If the issue is accompanied by log file output, please share it below.
+
+Set the Angular Log level to verbose by opening settings (File/Preferences/Settings on Windows, Code/Preferences/Settings on Mac), go to Extensions/Angular Language Service, set `angular.log` to `verbose`.
+
+To open the log file, go to the command palette (Cmd+Shift+P on Mac, Ctrl+Shift+P on Windows), search `Open Angular Server log`.
+
+Alternatively, if the log file is long, it can be uploaded instead of pasting below. -->
+<!-- ✍️-->
+
+</code></pre>
+
+### **Screenshots**
 
 If applicable, add screenshots to help explain your problem.
 
 ![Example Screenshot](./output.png)
 
-**Additional context**
+## 🌍  Your Environment
+**Angular Version:**
+<pre><code>
+<!-- run `ng version` and paste output below -->
+<!-- ✍️-->
 
-Add any other context about the problem here.
+</code></pre>
+
+Extension Version:
+<pre><code>
+<!-- Enter the version of 'Angular Language Service'. Example: v11.2.11 -->
+<!-- ✍️-->
+
+</code></pre>
+
+VSCode Version:
+<pre><code>
+<!-- Open 'About Visual Studio Code' and paste output below -->
+<!-- ✍️-->
+
+</code></pre>
+
+Operating System:
+<pre><code>
+<!-- Example: Windows 10 Version 1703 OS Build 15063.483  -->
+<!-- ✍️-->
+
+</code></pre>
+
+**Anything else relevant?**
+<!-- ✍️Do any of these matter hardware, other extensions installed, build environment, ...? If so, please mention it below. -->
+

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,6 @@
 ---
-name: Feature request
-about: Suggest an idea for this project
+name: "\U0001F680 Feature request"
+about: Suggest a feature for the Angular Language Service extension, or in the language server.
 title: ''
 labels: feature
 assignees: ''
@@ -8,17 +8,38 @@ assignees: ''
 ---
 
 **Is your feature request related to a problem? Please describe.**
+<!--🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅
 
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+Oh hi there! 😄
 
-**Describe the solution you'd like**
+To expedite issue processing please search open and closed issues before submitting a new one.
+Existing issues often contain information about workarounds, resolution, or progress updates.
 
-A clear and concise description of what you want to happen.
+🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅-->
 
-**Describe alternatives you've considered**
 
-A clear and concise description of any alternative solutions or features you've considered.
+# 🚀 feature request
 
-**Additional context**
+### Description
+<!-- ✍️--> A clear and concise description of the problem or missing capability...
 
-Add any other context or screenshots about the feature request here.
+### Feature Type
+What does this bug affect
+
+<!-- Please check the one that applies to this bug report using "x". -->
+
+- [ ] Angular Language Service VSCode extension
+- [ ] Angular Language Service server
+
+### Describe the solution you'd like
+<!-- ✍️--> If you have a solution in mind, please describe it.
+
+
+### Describe alternatives you've considered
+<!-- ✍️--> Have you considered any alternative solutions or workarounds?
+
+
+### Anything else relevant?
+
+<!-- ✍️Aare screenshots or any other information needed to prvoide context? If so, please mention it below. --> 
+


### PR DESCRIPTION
Updates the bug report and feature request issue templates to give the
community more direction on how to fill them out. Most of the
boilerplate is copied from angular/angular, and this aligns our tone and
organizational style with angular/angular.