### PR TITLE
Revert "fix: remove TSC_NONPOLLING_WATCHER env variable"

### DIFF
--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -358,7 +358,10 @@ function constructArgs(ctx: vscode.ExtensionContext): string[] {
 
 function getServerOptions(ctx: vscode.ExtensionContext, debug: boolean): lsp.NodeModule {
   // Environment variables for server process
-  const prodEnv = {};
+  const prodEnv = {
+    // Force TypeScript to use the non-polling version of the file watchers.
+    TSC_NONPOLLING_WATCHER: true,
+  };
   const devEnv = {
     ...prodEnv,
     NG_DEBUG: true,

--- a/integration/lsp/test_utils.ts
+++ b/integration/lsp/test_utils.ts
@@ -37,6 +37,9 @@ export function createConnection(serverOptions: ServerOptions): MessageConnectio
   }
   const server = fork(SERVER_PATH, argv, {
     cwd: PROJECT_PATH,
+    env: {
+      TSC_NONPOLLING_WATCHER: 'true',
+    },
     // uncomment to debug server process
     // execArgv: ['--inspect-brk=9330']
   });

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -56,5 +56,8 @@ if (logger.loggingEnabled()) {
 if (process.env.NG_DEBUG === 'true') {
   session.info('Angular Language Service is running under DEBUG mode');
 }
+if (process.env.TSC_NONPOLLING_WATCHER !== 'true') {
+  session.warn(`Using less efficient polling watcher. Set TSC_NONPOLLING_WATCHER to true.`);
+}
 
 session.listen();


### PR DESCRIPTION
This reverts commit 17708d44c062bab28028ec94442e87baf31e9b83.

Fixes #1310

We need to do more investigation into the default watch options and
setting them in the `ProjectService` host configuration.