### PR TITLE
fix: remove TSC_NONPOLLING_WATCHER env variable and provide default w…

### DIFF
--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -403,10 +403,7 @@ function constructArgs(ctx: vscode.ExtensionContext): string[] {
 
 function getServerOptions(ctx: vscode.ExtensionContext, debug: boolean): lsp.NodeModule {
   // Environment variables for server process
-  const prodEnv = {
-    // Force TypeScript to use the non-polling version of the file watchers.
-    TSC_NONPOLLING_WATCHER: true,
-  };
+  const prodEnv = {};
   const devEnv = {
     ...prodEnv,
     NG_DEBUG: true,

--- a/integration/lsp/test_utils.ts
+++ b/integration/lsp/test_utils.ts
@@ -30,9 +30,6 @@ export function createConnection(serverOptions: ServerOptions): MessageConnectio
   }
   const server = fork(SERVER_PATH, argv, {
     cwd: PROJECT_PATH,
-    env: {
-      TSC_NONPOLLING_WATCHER: 'true',
-    },
     // uncomment to debug server process
     // execArgv: ['--inspect-brk=9330']
   });

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -59,10 +59,6 @@ function main() {
     session.info('Angular Language Service is running under DEBUG mode');
   }
 
-  if (process.env.TSC_NONPOLLING_WATCHER !== 'true') {
-    session.warn(`Using less efficient polling watcher. Set TSC_NONPOLLING_WATCHER to true.`);
-  }
-
   session.listen();
 }
 

--- a/server/src/session.ts
+++ b/server/src/session.ts
@@ -129,6 +129,12 @@ export class Session {
         // https://devblogs.microsoft.com/typescript/announcing-typescript-4-0/#smarter-auto-imports
         includePackageJsonAutoImports: 'off',
       },
+      watchOptions: {
+        // Used as watch options when not specified by user's `tsconfig`.
+        watchFile: ts.WatchFileKind.UseFsEvents,
+        watchDirectory: ts.WatchDirectoryKind.UseFsEvents,
+        fallbackPolling: ts.PollingWatchKind.DynamicPriority,
+      }
     });
 
     const pluginConfig: PluginConfig = {


### PR DESCRIPTION
…atchOptions

`TSC_NONPOLLING_WATCHER` was used back in the early days to improve
file watcher performance, but it prevents files / directories from
being moved / renamed.
Since TS now provides built-in option to configure file watcher, this
environment variable is no longer needed.

See https://www.typescriptlang.org/docs/handbook/configuring-watch.html

The watch options used are derived from the user defined options in
their `tsconfig` combined with the default options provided to the
project service via `setHostConfiguration`
([code reference](https://github.com/microsoft/TypeScript/blob/f7ef1540d3c10fb282d1d433d9f2850b28391169/src/server/editorServices.ts#L2985-L2989)).

As noted in the documentation for configuration watch options, the
default when no watch options are provided falls back to `fs.watchFile`
with `250ms` for any file. This would cause the performance issues as
seen in #1310.

Fixes #750