### PR TITLE
fix: files incorrectly determined as not being in an Angular project

### DIFF
--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -134,23 +134,12 @@ export class AngularLanguageClient implements vscode.Disposable {
   }
 
   private async isInAngularProject(doc: vscode.TextDocument): Promise<boolean> {
-    if (this.client === null) {
-      return false;
-    }
-    const uri = doc.uri.toString();
-    if (this.fileToIsInAngularProjectMap.has(uri)) {
-      return this.fileToIsInAngularProjectMap.get(uri)!;
-    }
-
-    try {
-      const response = await this.client.sendRequest(IsInAngularProject, {
-        textDocument: this.client.code2ProtocolConverter.asTextDocumentIdentifier(doc),
-      });
-      this.fileToIsInAngularProjectMap.set(uri, response);
-      return response;
-    } catch {
-      return false;
-    }
+    // TODO(#1330): The logic below has been found to have some race conditions. It appears that
+    // when trying to do operations in an external while the language service is still initializing
+    // will result in this function determining that the file is not in an Angular project.
+    // We should disable this check (by always returning assuming the document is inside an Angular
+    // project) until a solution is found.
+    return true;
   }
 
   private createVirtualHtmlDoc(document: vscode.TextDocument): vscode.Uri {


### PR DESCRIPTION
I have observed that the performance enhancement introduced in #1272 does not
work in some situations. It appears that if I attempt to do operations in an
external template before the language service is initialized, the template will
be identified as not being inside an Angular project.

The result of this incorrect determination is that we will not service
requests for that file. This commit disables the check by always returning
`true`, effectively marking every TS and HTML file as being inside an
Angular project.

There may be some performance degradation in non-Angular projects as a
result due to additional file tokenization of TypeScript files. However,
we do still expect this tokenization to be very fast and there should be
no observable performance issues.

https://github.com/angular/vscode-ng-language-service/issues/1330