### PR TITLE
feat: Allow renaming from string literals in TS files

### DIFF
--- a/server/src/session.ts
+++ b/server/src/session.ts
@@ -787,12 +787,6 @@ export class Session {
       return;
     }
     const {languageService, scriptInfo} = lsInfo;
-    if (scriptInfo.scriptKind === ts.ScriptKind.TS) {
-      // Because we cannot ensure our extension is prioritized for renames in TS files (see
-      // https://github.com/microsoft/vscode/issues/115354) we disable renaming completely so we can
-      // provide consistent expectations.
-      return;
-    }
     const project = this.getDefaultProjectForScriptInfo(scriptInfo);
     if (project === undefined || this.renameDisabledProjects.has(project)) {
       return;
@@ -830,12 +824,6 @@ export class Session {
       return;
     }
     const {languageService, scriptInfo} = lsInfo;
-    if (scriptInfo.scriptKind === ts.ScriptKind.TS) {
-      // Because we cannot ensure our extension is prioritized for renames in TS files (see
-      // https://github.com/microsoft/vscode/issues/115354) we disable renaming completely so we can
-      // provide consistent expectations.
-      return;
-    }
     const project = this.getDefaultProjectForScriptInfo(scriptInfo);
     if (project === undefined || this.renameDisabledProjects.has(project)) {
       return;


### PR DESCRIPTION
Previously we had decided to disable renaming in TypeScript files
because of a limitation in VSCode
(https://github.com/microsoft/vscode/issues/115354). This meant that we
could give consistent expectations for Angular renames: they only work
in external templates.

This change updates that expectation by providing the ability to rename
from strings in TypeScript files. Because TypeScript would not
provide any rename results for most strings (see note below), we can be sure that
Angular will be asked to provide its rename results for these cases.

Additionally, this moves the logic for determining if we should provide
renames outside the server. The benefit of this is that potential
consumers of the @angular/language-server for other editors would be
able to provide renames if they do not have the limitation that vscode
does (mentioned above).

Note that TS _can_ actually provide renames for some string literals so
we still have to be more specific than allowing renames for all string
literals (ex: `type MyType = 'a'|'b'` - TSLS can rename the string union and
assignments to it). 
If there were an assignment in a template to an value with the string
union type, we would not be guaranteed to pick this up if the rename were done
from a TypeScript file.
A similar situation would occur for keyed property reads (`x['prop']`) and string enums.

fixes #1319