### PR TITLE
fix: check Angular version if angular.view-engine is false

### DIFF
--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -394,7 +394,10 @@ function constructArgs(ctx: vscode.ExtensionContext): string[] {
   const ngProbeLocations = getProbeLocations(ngdk, ctx.extensionPath);
   args.push('--ngProbeLocations', ngProbeLocations.join(','));
 
-  const viewEngine: boolean = config.get('angular.view-engine', !allProjectsSupportIvy());
+  // Because the configuration is typed as "boolean" in package.json, vscode
+  // will return false even when the value is not set. If value is false, then
+  // we need to check if all projects support Ivy language service.
+  const viewEngine: boolean = config.get('angular.view-engine') || !allProjectsSupportIvy();
   if (viewEngine) {
     args.push('--viewEngine');
   }


### PR DESCRIPTION
This commit fixes a bug where View Engine is not launched even though
the Angular version is resolved correctly. This is because the configuration
value is typed as "boolean", and defaults to `false` when the value is not set.

Fix #1350 