### PR TITLE
fix: remove message about disabled LS if ngcc fails

### DIFF
--- a/server/src/session.ts
+++ b/server/src/session.ts
@@ -1111,9 +1111,9 @@ export class Session {
       success = true;
     } catch (e) {
       this.error(
-          `Failed to run ngcc for ${configFilePath}:\n` +
-          `    ${e.message}\n` +
-          `    Language service will remain disabled.`);
+          `Failed to run ngcc for ${
+              configFilePath}, language service may not operate correctly:\n` +
+          `    ${e.message}`);
     } finally {
       this.connection.sendProgress(NgccProgressType, NgccProgressToken, {
         done: true,


### PR DESCRIPTION
The log message is misleading because LS is enable even if ngcc fails.