### PR TITLE
perf: Avoid making Angular-related decisions for files not in an Angu…

### DIFF
--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -150,12 +150,28 @@ export class AngularLanguageClient implements vscode.Disposable {
   }
 
   private async isInAngularProject(doc: vscode.TextDocument): Promise<boolean> {
-    // TODO(#1330): The logic below has been found to have some race conditions. It appears that
-    // when trying to do operations in an external while the language service is still initializing
-    // will result in this function determining that the file is not in an Angular project.
-    // We should disable this check (by always returning assuming the document is inside an Angular
-    // project) until a solution is found.
-    return true;
+    if (this.client === null) {
+      return false;
+    }
+    const uri = doc.uri.toString();
+    if (this.fileToIsInAngularProjectMap.has(uri)) {
+      return this.fileToIsInAngularProjectMap.get(uri)!;
+    }
+
+    try {
+      const response = await this.client.sendRequest(IsInAngularProject, {
+        textDocument: this.client.code2ProtocolConverter.asTextDocumentIdentifier(doc),
+      });
+      if (response === undefined) {
+        // If the response indicates the answer can't be determined at the moment, return `false`
+        // but do not cache the result so we can try to get the real answer on follow-up requests.
+        return false;
+      }
+      this.fileToIsInAngularProjectMap.set(uri, response);
+      return response;
+    } catch {
+      return false;
+    }
   }
 
   private createVirtualHtmlDoc(document: vscode.TextDocument): vscode.Uri {

--- a/common/requests.ts
+++ b/common/requests.ts
@@ -31,7 +31,7 @@ export interface GetTcbResponse {
 }
 
 export const IsInAngularProject =
-    new lsp.RequestType<IsInAngularProjectParams, boolean, /* error */ void>(
+    new lsp.RequestType<IsInAngularProjectParams, boolean|undefined, /* error */ void>(
         'angular/isAngularCoreInOwningProject');
 
 export interface IsInAngularProjectParams {

--- a/server/src/session.ts
+++ b/server/src/session.ts
@@ -175,21 +175,22 @@ export class Session {
     conn.onSignatureHelp(p => this.onSignatureHelp(p));
   }
 
-  private isInAngularProject(params: IsInAngularProjectParams): boolean {
+  private isInAngularProject(params: IsInAngularProjectParams): boolean|undefined {
     const filePath = uriToFilePath(params.textDocument.uri);
     if (!filePath) {
       return false;
     }
-    const scriptInfo = this.projectService.getScriptInfo(filePath);
-    if (!scriptInfo) {
-      return false;
+    const lsAndScriptInfo = this.getLSAndScriptInfo(params.textDocument);
+    if (!lsAndScriptInfo) {
+      // If we cannot get language service / script info, return undefined to indicate we don't know
+      // the answer definitively.
+      return undefined;
     }
-    const project = this.projectService.getDefaultProjectForFile(
-        scriptInfo.fileName,
-        false  // ensureProject
-    );
+    const project = this.getDefaultProjectForScriptInfo(lsAndScriptInfo.scriptInfo);
     if (!project) {
-      return false;
+      // If we cannot get project, return undefined to indicate we don't know
+      // the answer definitively.
+      return undefined;
     }
     const angularCore = project.getFileNames().find(isAngularCore);
     return angularCore !== undefined;


### PR DESCRIPTION
…lar project

This commit updates our client-side short-circuit logic to provide an
additiona short circuit that avoids tokenizing typescript files when
they are not within a project that uses Angular.

fixes #1330