### PR TITLE
fix: remove angular.ngdk configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Download the extension from [Visual Studio Marketplace](https://marketplace.visu
 
 ## Configuring compiler options for the Angular Language Service
 
-The Angular Language Service uses the same set of options that are used to compile the application. 
+The Angular Language Service uses the same set of options that are used to compile the application.
 To get the most complete information in the editor, set the `strictTemplates` option in `tsconfig.json`,
 as shown in the following example:
 
@@ -33,15 +33,16 @@ For more information, see the [Angular compiler options](https://angular.io/guid
 ## Versioning
 
 The language service extension relies on the `@angular/language-service` and `typescript` packages
-for its backend. These packages are loaded, in order of priority, from:
+for its backend. `@angular/language-service` is always bundled with the extension, and is always
+the latest version at the time of the release.
+`typescript` is loaded, in order of priority, from:
 
-1. The path specified by `angular.ngdk` and `typescript.tsdk`, respectively, in project or global
-   settings.
-2. _(Recommended)_ The version of these packages bundled with the Angular Language Service extension.
-3. The version of these packages present in the current workspace's node_modules.
+1. The path specified by `typescript.tsdk` in project or global settings.
+2. _(Recommended)_ The version of `typescript` bundled with the Angular Language Service extension.
+3. The version of `typescript` present in the current workspace's node_modules.
 
-We suggest **not** specifying neither `angular.ngdk` nor `typescript.tsdk` in your VSCode settings
-per method (1) above. If the `@angular/language-service` and `typescript` packages are loaded by
+We suggest **not** specifying `typescript.tsdk` in your VSCode settings
+per method (1) above. If the `typescript` package is loaded by
 methods (1) or (3), there is a potential for a mismatch between
 the API expected by `@angular/language-service` and the API provided by `typescript`. This could
 lead to a failure of the language service extension.

--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -184,8 +184,8 @@ export class AngularLanguageClient implements vscode.Disposable {
     // Create the language client and start the client.
     const forceDebug = process.env['NG_DEBUG'] === 'true';
     this.client = new lsp.LanguageClient(
-        // This is the ID for Angular-specific configurations, like angular.log,
-        // angular.ngdk, etc. See contributes.configuration in package.json.
+        // This is the ID for Angular-specific configurations, like "angular.log".
+        // See contributes.configuration in package.json.
         'angular',
         this.name,
         serverOptions,
@@ -390,8 +390,7 @@ function constructArgs(ctx: vscode.ExtensionContext): string[] {
     args.push('--logVerbosity', ngLog);
   }
 
-  const ngdk: string|null = config.get('angular.ngdk', null);
-  const ngProbeLocations = getProbeLocations(ngdk, ctx.extensionPath);
+  const ngProbeLocations = getProbeLocations(null, ctx.extensionPath);
   args.push('--ngProbeLocations', ngProbeLocations.join(','));
 
   // Because the configuration is typed as "boolean" in package.json, vscode

--- a/package.json
+++ b/package.json
@@ -62,15 +62,6 @@
     "configuration": {
       "title": "Angular Language Service",
       "properties": {
-        "angular.ngdk": {
-          "type": [
-            "string",
-            "null"
-          ],
-          "default": null,
-          "description": "Specifies the folder path to @angular/language-service.",
-          "scope": "machine"
-        },
         "angular.log": {
           "type": "string",
           "enum": [


### PR DESCRIPTION
This configuration does not work well in practice because we cannot guarantee
the compatibility between the extension and an older version of
`@angular/language-service`.

If users have to revert to an older version for any reason, they should
download an older extension from the VSCode marketplace.

Close #1325