### PR TITLE
refactor: clear client caches on stop request

### DIFF
--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -227,6 +227,8 @@ export class AngularLanguageClient implements vscode.Disposable {
     this.outputChannel.clear();
     this.dispose();
     this.client = null;
+    this.fileToIsInAngularProjectMap.clear();
+    this.virtualDocumentContents.clear();
   }
 
   /**


### PR DESCRIPTION
The command to restart the language server calls `client.stop` followed
by `client.start`. We should clear the caches so that the restart
command starts with a clean state.