### PR TITLE
fix: bad merge caused build failure

### DIFF
--- a/server/src/session.ts
+++ b/server/src/session.ts
@@ -832,7 +832,7 @@ export class Session {
       // Because we cannot ensure our extension is prioritized for renames in TS files (see
       // https://github.com/microsoft/vscode/issues/115354) we disable renaming completely so we can
       // provide consistent expectations.
-      return;
+      return null;
     }
     const project = this.getDefaultProjectForScriptInfo(scriptInfo);
     if (project === undefined || this.renameDisabledProjects.has(project)) {


### PR DESCRIPTION
Because 12.0.x and master diverged a little for renaming implementation
the change to return null instead of undefined caused a build error in
the patch branch.