### PR TITLE
feat: add configuration for workspace trust

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,12 @@
   "engines": {
     "vscode": "^1.56.0"
   },
+  "capabilities": {
+    "untrustedWorkspaces": {
+      "supported": false,
+      "description": "This extension requires workspace trust because it needs to execute ngcc from the node_modules in the workspace."
+    }
+  },
   "categories": [
     "Programming Languages"
   ],


### PR DESCRIPTION
Our extension does not support untrusted workspaces because it executes
`ngcc` from `node_modules`.

See https://github.com/microsoft/vscode/issues/120251 for a description
of workspace trust and how to determine if an extension should support
untrusted workspaces.

Fixes #1322