### PR TITLE
test: update e2e test wait condition to wait for definitions

### DIFF
--- a/integration/e2e/helper.ts
+++ b/integration/e2e/helper.ts
@@ -13,5 +13,21 @@ function sleep(ms: number) {
 
 export async function activate(uri: vscode.Uri) {
   await vscode.window.showTextDocument(uri);
-  await sleep(20 * 1000);  // Wait for server activation, including ngcc run
+  await waitForDefinitionsToBeAvailable(20);
+}
+
+async function waitForDefinitionsToBeAvailable(maxSeconds: number) {
+  let tries = 0
+  while (tries < maxSeconds) {
+    const position = new vscode.Position(4, 25);
+    // For a complete list of standard commands, see
+    // https://code.visualstudio.com/api/references/commands
+    const definitions = await vscode.commands.executeCommand<vscode.LocationLink[]>(
+        DEFINITION_COMMAND, APP_COMPONENT_URI, position);
+    if (definitions && definitions.length > 0) {
+      return;
+    }
+    tries++;
+    await sleep(1000);
+  }
 }


### PR DESCRIPTION
Rather than waiting a set 20 seconds for ngcc to finish, this updates the tests to
instead wait for definitions to be available in the template. This change was intended
to be in #1367 but accidentally was reverted before merging