### PR TITLE
fix(language-server): Only enable language service on open projects

### DIFF
--- a/server/src/session.ts
+++ b/server/src/session.ts
@@ -330,6 +330,10 @@ export class Session {
 
   private enableLanguageServiceForProject(project: ts.server.Project) {
     const {projectName} = project;
+    if (project.isClosed()) {
+      this.info(`Cannot enable language service for closed project ${projectName}.`);
+      return;
+    }
     if (!project.languageServiceEnabled) {
       project.enableLanguageService();
       // When the language service got disabled, the program was discarded via


### PR DESCRIPTION
After `ngcc` finishes, only enable language service for projects that
are open. This avoids an error that would otherwise be thrown by TypeScript.

It's not entirely clear what causes the project to close immediately
after opening, but it appears to be triggered by having files open from
multiple projects. The files not actively being displayed in the editor
have their projects closed, but this also only appears to happen after
having the editor open for a long time.

Fixes #1438
Fixes #1399 - Not entirely sure this fixes the issue there, but it may
and we don't currently have any other indicators for what the issue
there might be if the cause is different.