### PR TITLE
test: update default timeout inteval to 30 seconds

### DIFF
--- a/integration/e2e/helper.ts
+++ b/integration/e2e/helper.ts
@@ -12,6 +12,8 @@ function sleep(ms: number) {
 }
 
 export async function activate(uri: vscode.Uri) {
+  // set default timeout to 30 seconds
+  jasmine.DEFAULT_TIMEOUT_INTERVAL = 30_000;
   await vscode.window.showTextDocument(uri);
   await waitForDefinitionsToBeAvailable(20);
 }


### PR DESCRIPTION
This change is an effort to reduce the flakiness of the e2e tests on macos.
If those e2e tests are still still flaky after this change, we should consider them for macos.

example failure due to timeout: https://github.com/angular/vscode-ng-language-service/runs/3186857720