### PR TITLE
feat(server): add related information to diagnostics

### DIFF
--- a/integration/lsp/ivy_spec.ts
+++ b/integration/lsp/ivy_spec.ts
@@ -99,6 +99,11 @@ describe('Angular Ivy language server', () => {
     expect(diagnostics.length).toBe(1);
     expect(diagnostics[0].message)
         .toBe(`Property 'doesnotexist' does not exist on type 'FooComponent'.`);
+    expect(diagnostics[0].relatedInformation).toBeDefined();
+    expect(diagnostics[0].relatedInformation!.length).toBe(1);
+    expect(diagnostics[0].relatedInformation![0].message)
+        .toBe(`Error occurs in the template of component FooComponent.`);
+    expect(diagnostics[0].relatedInformation![0].location.uri).toBe(FOO_COMPONENT_URI);
   });
 
   it('should support request cancellation', async () => {

--- a/server/src/diagnostic.ts
+++ b/server/src/diagnostic.ts
@@ -8,7 +8,7 @@
 
 import * as ts from 'typescript/lib/tsserverlibrary';
 import * as lsp from 'vscode-languageserver';
-import {tsTextSpanToLspRange} from './utils';
+import {tsRelatedInformationToLspRelatedInformation, tsTextSpanToLspRange} from './utils';
 
 /**
  * Convert ts.DiagnosticCategory to lsp.DiagnosticSeverity
@@ -45,5 +45,6 @@ export function tsDiagnosticToLspDiagnostic(
       tsDiagnosticCategoryToLspDiagnosticSeverity(tsDiag.category),
       tsDiag.code,
       tsDiag.source,
+      tsRelatedInformationToLspRelatedInformation(scriptInfo, tsDiag.relatedInformation),
   );
 }


### PR DESCRIPTION
Show related information in the diagnostics generated for the language
service.

Currently diagnostics we don't show related information in the language service:
![Screenshot 2021-08-25 1 54 23 PM - Display 2](https://user-images.githubusercontent.com/23410540/130849084-6f37c89f-9c7a-44ef-aedf-ad3560e4731b.png)

This PR would add them:
![Screenshot 2021-08-25 1 55 21 PM - Display 2](https://user-images.githubusercontent.com/23410540/130849120-501d81ea-b776-442c-bf3c-385efb7d70cc.png)

