### PR TITLE
test: fix syntax tests so they work when testing against builds repo

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -21,7 +21,11 @@ yarn run test:lsp
 
 # Syntaxes tests
 yarn run test:syntaxes
-if [[ -n "$(git status --porcelain)" ]]; then
+# Check git status to see if there are modified files
+STATUS="$(git status --porcelain)"
+echo $STATUS
+# If the status contains modified files in the syntaxes folder, they are out of date
+if [[ "$STATUS" == *"syntaxes"* ]]; then
   echo 'Syntax files are out-of-sync with source. Please run "yarn run build:syntaxes".'
   exit 1
 fi


### PR DESCRIPTION
When running tests against the builds repo, the package.json and yarn.lock files get updated.
The syntax check only really cares about modifications to files in the syntaxes folder.