### PR TITLE
fix: Prevent legacy VE from being used with v13 projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
         "angular.view-engine": {
           "type": "boolean",
           "default": false,
-          "description": "Use legacy View Engine language service."
+          "description": "Use legacy View Engine language service. This option is incompatible with projects using Angular v13 and above."
         },
         "angular.enable-strict-mode-prompt": {
           "type": "boolean",


### PR DESCRIPTION
Angular v13+ projects do not support VE. If the client detects a v13+ project in the workspace,
it now sets legacy VE to false, regardless of the extension options or incompatible legacy projects
in the workspace.