### PR TITLE
feat(extension): Support renaming from TypeScript files

### DIFF
--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -65,16 +65,7 @@ export class AngularLanguageClient implements vscode.Disposable {
         prepareRename: async (
             document: vscode.TextDocument, position: vscode.Position,
             token: vscode.CancellationToken, next: lsp.PrepareRenameSignature) => {
-          // We are able to provide renames for many types of string literals: template strings,
-          // pipe names, and hopefully in the future selectors and input/output aliases. Because
-          // TypeScript isn't able to provide renames for these, we can more or less
-          // guarantee that the Angular Language service will be called for the rename as the
-          // fallback. We specifically do not provide renames outside of string literals
-          // because we cannot ensure our extension is prioritized for renames in TS files (see
-          // https://github.com/microsoft/vscode/issues/115354) we disable renaming completely so we
-          // can provide consistent expectations.
-          if (await this.isInAngularProject(document) &&
-              isInsideStringLiteral(document, position)) {
+          if (await this.isInAngularProject(document)) {
             return next(document, position, token);
           }
         },

--- a/override_rename_ts_plugin/README.md
+++ b/override_rename_ts_plugin/README.md
@@ -1,0 +1,6 @@
+This package is applied to the built-in TS extension by the config [`typescriptServerPlugins`][1] and is used to disable rename provider of the built-in TS extension so VSCode asks the Angular Language Service for the answer instead.
+
+Detail about this package is [here][2].
+
+[1]: https://code.visualstudio.com/api/references/contribution-points#contributes.typescriptServerPlugins
+[2]: https://github.com/angular/angular/blob/master/packages/language-service/README.md#override-rename-ts-plugin

--- a/override_rename_ts_plugin/index.js
+++ b/override_rename_ts_plugin/index.js
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+module.exports = require("@angular/language-service/override_rename_ts_plugin").factory;

--- a/override_rename_ts_plugin/package.json
+++ b/override_rename_ts_plugin/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@angular/override-rename-ts-plugin",
+  "version": "0.0.1",
+  "main": "./index.js",
+  "private": "true"
+}

--- a/package.json
+++ b/package.json
@@ -165,6 +165,12 @@
         "path": "./syntaxes/expression.json",
         "scopeName": "expression.ng"
       }
+    ],
+    "typescriptServerPlugins": [
+      {
+        "name": "@angular/override-rename-ts-plugin",
+        "enableForWorkspaceTypeScriptVersions": true
+      }
     ]
   },
   "activationEvents": [
@@ -188,6 +194,7 @@
     "test:syntaxes": "yarn compile:syntaxes-test && yarn build:syntaxes && jasmine dist/syntaxes/test/driver.js"
   },
   "dependencies": {
+    "@angular/override-rename-ts-plugin": "file:override_rename_ts_plugin",
     "@angular/language-service": "14.0.0-next.0",
     "typescript": "4.5.4",
     "vscode-jsonrpc": "6.0.0",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -53,6 +53,7 @@ cp package.json angular.png CHANGELOG.md README.md dist/npm
 # Copy files to server directory
 cp -r server/package.json server/README.md server/bin dist/npm/server
 cp -r v12_language_service dist/npm/v12_language_service
+cp -r override_rename_ts_plugin dist/npm/override_rename_ts_plugin
 # Build and copy files to syntaxes directory
 yarn run build:syntaxes
 mkdir dist/npm/syntaxes

--- a/yarn.lock
+++ b/yarn.lock
@@ -57,6 +57,9 @@
   resolved "https://registry.yarnpkg.com/@angular/language-service/-/language-service-14.0.0-next.0.tgz#644e73e03810559079c29192c0eb1f59c2dfbd11"
   integrity sha512-jiN1XQQI4sFWUIsDpBQtWNLDCoYfAYwDG/LQqjmgR1yAgDEKQDZRHEbbccDVgcWp7jI3H0QRv9mUE9XlfjJZPg==
 
+"@angular/override-rename-ts-plugin@file:override_rename_ts_plugin":
+  version "0.0.1"
+
 "@babel/code-frame@^7.0.0":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.13.tgz#dcfc826beef65e75c50e21d3837d7d95798dd658"


### PR DESCRIPTION
This PR will add a new package that is applied to the built-in TS
extension by the config [`typescriptServerPlugins`][1] and is used
to disable rename provider of the built-in TS extension so VSCode
asks the Angular Language Service for the answer instead.

Detail about this package is [here][2].

[1]: https://code.visualstudio.com/api/references/contribution-points#contributes.typescriptServerPlugins
[2]: https://github.com/angular/angular/blob/master/packages/language-service/README.md#override-rename-ts-plugin