### PR TITLE
fix(server): return the right range for the original source file of DTS

### DIFF
--- a/server/src/session.ts
+++ b/server/src/session.ts
@@ -930,7 +930,10 @@ export class Session {
       if (scriptInfo) {
         const project = this.getDefaultProjectForScriptInfo(scriptInfo);
         mappedInfo = project ? getMappedDefinitionInfo(d, project) : mappedInfo;
-        range = tsTextSpanToLspRange(scriptInfo, mappedInfo.textSpan);
+        // After the DTS file maps to original source file, the `scriptInfo` should be updated.
+        const originalScriptInfo =
+            this.projectService.getScriptInfo(mappedInfo.fileName) ?? scriptInfo;
+        range = tsTextSpanToLspRange(originalScriptInfo, mappedInfo.textSpan);
       }
 
       const targetUri = filePathToUri(mappedInfo.fileName);


### PR DESCRIPTION
When the user tries to go to the definition that is in the DTS file,
the Angular LS will map it to the original source file. Because of
not updating the `scriptInfo`, the Angular LS returns the wrong range
of the definition.