### PR TITLE
feat: add command to run ngcc manually

### DIFF
--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -12,7 +12,7 @@ import * as vscode from 'vscode';
 import * as lsp from 'vscode-languageclient/node';
 
 import {OpenOutputChannel, ProjectLoadingFinish, ProjectLoadingStart, SuggestStrictMode, SuggestStrictModeParams} from '../common/notifications';
-import {GetComponentsWithTemplateFile, GetTcbRequest, GetTemplateLocationForComponent, IsInAngularProject} from '../common/requests';
+import {GetComponentsWithTemplateFile, GetTcbRequest, GetTemplateLocationForComponent, IsInAngularProject, RunNgccRequest} from '../common/requests';
 import {resolve, Version} from '../common/resolver';
 
 import {isInsideComponentDecorator, isInsideInlineTemplateRegion, isInsideStringLiteral} from './embedded_support';
@@ -255,6 +255,16 @@ export class AngularLanguageClient implements vscode.Disposable {
     };
   }
 
+  runNgcc(textEditor: vscode.TextEditor): void {
+    if (this.client === null) {
+      return;
+    }
+    this.client.sendRequest(RunNgccRequest, {
+      textDocument:
+          this.client.code2ProtocolConverter.asTextDocumentIdentifier(textEditor.document),
+    });
+  }
+
   get initializeResult(): lsp.InitializeResult|undefined {
     return this.client?.initializeResult;
   }
@@ -410,9 +420,9 @@ function constructArgs(ctx: vscode.ExtensionContext, viewEngine: boolean): strin
     args.push('--includeCompletionsWithSnippetText');
   }
 
-  const disableNgcc = config.get<boolean>('angular.disableNgcc');
-  if (disableNgcc) {
-    args.push('--disableNgcc');
+  const disableAutomaticNgcc = config.get<boolean>('angular.disableAutomaticNgcc');
+  if (disableAutomaticNgcc) {
+    args.push('--disableAutomaticNgcc');
   }
 
   const tsdk: string|null = config.get('typescript.tsdk', null);

--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -115,6 +115,15 @@ function getTemplateTcb(
     }
   };
 }
+function runNgcc(ngClient: AngularLanguageClient): Command {
+  return {
+    id: 'angular.runNgcc',
+    isTextEditorCommand: true,
+    async execute(textEditor: vscode.TextEditor) {
+      ngClient.runNgcc(textEditor);
+    }
+  };
+}
 
 /**
  * Command goToComponentWithTemplateFile finds components which reference an external template in
@@ -180,6 +189,7 @@ export function registerCommands(
     restartNgServer(client),
     openLogFile(client),
     getTemplateTcb(client, context),
+    runNgcc(client),
     goToComponentWithTemplateFile(client),
     goToTemplateForComponent(client),
   ];

--- a/common/requests.ts
+++ b/common/requests.ts
@@ -30,8 +30,15 @@ export interface GetTcbParams {
   position: lsp.Position;
 }
 
+export interface RunNgccParams {
+  textDocument: lsp.TextDocumentIdentifier;
+}
+
 export const GetTcbRequest =
     new lsp.RequestType<GetTcbParams, GetTcbResponse|null, /* error */ void>('angular/getTcb');
+
+export const RunNgccRequest =
+    new lsp.RequestType<RunNgccParams, void, /* error */ void>('angular/runNgcc');
 
 export interface GetTcbResponse {
   uri: lsp.DocumentUri;

--- a/package.json
+++ b/package.json
@@ -48,6 +48,11 @@
         "command": "angular.goToTemplateForComponent",
         "title": "Go to template",
         "category": "Angular"
+      },
+      {
+        "command": "angular.runNgcc",
+        "title": "Run ngcc",
+        "category": "Angular"
       }
     ],
     "menus": {
@@ -124,10 +129,10 @@
           "default": true,
           "markdownDescription": "Enable/disable snippet completions from Angular language server. Requires using TypeScript 4.3+ in the workspace and the `legacy View Engine` option to be disabled."
         },
-        "angular.disableNgcc": {
+        "angular.disableAutomaticNgcc": {
           "type": "boolean",
           "default": false,
-          "markdownDescription": "Manually disable the step to run ngcc. [ngcc](https://github.com/angular/angular/blob/master/packages/compiler/design/architecture.md#high-level-proposal) is required to run and gather metadata from libraries not published with Ivy instructions. This can be run outside of VSCode instead (for example, as part of the build/rebuild in the CLI). Note that ngcc needs to run not only at startup, but also whenever the dependencies change. Failing to run ngcc when required can result in incomplete information and spurious errors reported by the language service."
+          "markdownDescription": "Disable the step to automatically run ngcc. [ngcc](https://github.com/angular/angular/blob/master/packages/compiler/design/architecture.md#high-level-proposal) is required to run and gather metadata from libraries not published with Ivy instructions. This can be run outside of VSCode instead (for example, as part of the build/rebuild in the CLI). Note that ngcc needs to run not only at startup, but also whenever the dependencies change. Failing to run ngcc when required can result in incomplete information and spurious errors reported by the language service."
         }
       }
     },

--- a/server/src/cmdline_utils.ts
+++ b/server/src/cmdline_utils.ts
@@ -35,7 +35,7 @@ interface CommandLineOptions {
   /**
    * If true, skips the running ngcc when using Ivy LS.
    */
-  disableNgcc: boolean;
+  disableAutomaticNgcc: boolean;
   logFile?: string;
   logVerbosity?: string;
   logToConsole: boolean;
@@ -49,7 +49,7 @@ export function parseCommandLine(argv: string[]): CommandLineOptions {
   return {
     help: hasArgument(argv, '--help'),
     ivy: !hasArgument(argv, '--viewEngine'),
-    disableNgcc: hasArgument(argv, '--disableNgcc'),
+    disableAutomaticNgcc: hasArgument(argv, '--disableAutomaticNgcc'),
     logFile: findArgument(argv, '--logFile'),
     logVerbosity: findArgument(argv, '--logVerbosity'),
     logToConsole: hasArgument(argv, '--logToConsole'),

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -43,7 +43,7 @@ function main() {
     ngPlugin: '@angular/language-service',
     resolvedNgLsPath: ng.resolvedPath,
     ivy: isG3 ? true : options.ivy,
-    disableNgcc: options.disableNgcc,
+    disableAutomaticNgcc: options.disableAutomaticNgcc,
     logToConsole: options.logToConsole,
     includeAutomaticOptionalChainCompletions: options.includeAutomaticOptionalChainCompletions,
     includeCompletionsWithSnippetText: options.includeCompletionsWithSnippetText,


### PR DESCRIPTION
Adds a command to manually run ngcc for a given file. This commit also
refactors the `disableNgcc` option to indicate that it's disabling the
_automatic_ `ngcc` run but it can still be triggered manually with the
new command.

The `disableAutomaticNgcc` option and new command to manually run ngcc
are complementary. We have found that the extension can be overzealous
in automatically running ngcc, especially with solution-style project
configurations (common practice in Nx projects). If a dev server is not
active to rerun ngcc when needed, then the new command gives an easy way
to do that when the `disableAutomaticNgcc` option is set.

Fixes #991