### PR TITLE
build: changes for primary branch rename to main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ workflows:
             filters:
               branches:
                 only:
-                  - master
+                  - main
             # Runs monitoring jobs at 10:00AM every day.
             cron: '0 10 * * *'
-    
+

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -5,9 +5,9 @@ name: E2E Test
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: '0 5 * * 0'
   push:
-    branches: [master]
+    branches: [main]
   workflow_dispatch:
 
 # Declare default permissions as read only.


### PR DESCRIPTION
Applies changes for the `DIRECT` phase of the renaming
master to main planning doc.

cc. @josephperrott 