### PR TITLE
build: clean up references to old `master` branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ This release upgrades `@angular/language-service` to v13.1.0.
 
 This release upgrades `@angular/language-service` to v13.0.0.
 For a complete change log see
-[here](https://github.com/angular/angular/blob/master/CHANGELOG.md#1300-2021-11-03).
+[here](https://github.com/angular/angular/blob/main/CHANGELOG.md#1300-2021-11-03).
 
 1. feat: provide snippets for attribute (#1509) (0428c31fa)
 1. feat: Add support for going to template from component  (#1491) (3014713e1)
@@ -69,7 +69,7 @@ This release contains various internal refactorings and dependency updates.
 
 This release upgrades `@angular/language-service` to v12.2.0.
 For a complete change log see
-[here](https://github.com/angular/angular/blob/master/CHANGELOG.md#1220-2021-08-04).
+[here](https://github.com/angular/angular/blob/main/CHANGELOG.md#1220-2021-08-04).
 
 1. fix(language-service): provide literal completions as well as context completions (https://github.com/angular/angular/pull/42729)
 
@@ -78,7 +78,7 @@ For a complete change log see
 
 This release upgrades `@angular/language-service` to v12.1.4.
 For a complete change log see
-[here](https://github.com/angular/angular/blob/master/CHANGELOG.md#1214-2021-07-28).
+[here](https://github.com/angular/angular/blob/main/CHANGELOG.md#1214-2021-07-28).
 
 1. fix(language-server): rename response should use URI instead of file name (#1462) (49d81aa4a)
 1. fix(language-server): Only enable language service on open projects (#1461) (26f6fcf1b)
@@ -88,14 +88,14 @@ For a complete change log see
 
 This release upgrades `@angular/language-service` to v12.1.3.
 For a complete change log see
-[here](https://github.com/angular/angular/blob/master/CHANGELOG.md#1213-2021-07-21).
+[here](https://github.com/angular/angular/blob/main/CHANGELOG.md#1213-2021-07-21).
 
 1. fix(server): Only provide InsertReplaceEdit when the client supports it (#1452) (7c22c4c3a)
 
 # v12.1.2
 
 This release upgrades `@angular/language-service` to v12.1.2.
-For a complete change log see [here](https://github.com/angular/angular/blob/master/CHANGELOG.md#1212-2021-07-14).
+For a complete change log see [here](https://github.com/angular/angular/blob/main/CHANGELOG.md#1212-2021-07-14).
 
 1. fix(language-server): Ensure LS is enabled in same order as project initialization for solution-style projects (#1447) (68ee8344e)
 1. fix(compiler-cli): return directives for an element on a microsyntax template (https://github.com/angular/angular/pull/42640)
@@ -103,7 +103,7 @@ For a complete change log see [here](https://github.com/angular/angular/blob/mas
 # v12.1.1
 
 This release upgrades `@angular/language-service` to v12.1.1.
-For a complete change log see [here](https://github.com/angular/angular/blob/master/CHANGELOG.md#1211-2021-06-30).
+For a complete change log see [here](https://github.com/angular/angular/blob/main/CHANGELOG.md#1211-2021-06-30).
 
 * update to TS 4.3.4 (#1428) (fb6681ee6)
 
@@ -111,7 +111,7 @@ For a complete change log see [here](https://github.com/angular/angular/blob/mas
 
 
 This release upgrades `@angular/language-service` to v12.1.0.
-For a complete change log see [here](https://github.com/angular/angular/blob/master/CHANGELOG.md#1210-2021-06-24).
+For a complete change log see [here](https://github.com/angular/angular/blob/main/CHANGELOG.md#1210-2021-06-24).
 
 Features:
 1. feat: Allow renaming from string literals in TS files (#1337) (9dba839b3)
@@ -155,7 +155,7 @@ This is because the configuration value is typed as `boolean`, and defaults to
 # v12.0.0
 
 This release upgrades `@angular/language-service` to v12.0.0.
-For a complete change log see [here](https://github.com/angular/angular/blob/master/CHANGELOG.md#1200-2021-05-12).
+For a complete change log see [here](https://github.com/angular/angular/blob/main/CHANGELOG.md#1200-2021-05-12).
 
 New features:
 1. add support for signature help (#1277) (ec148073f)
@@ -215,7 +215,7 @@ Bug fixes:
 
 # v11.2.12
 This release upgrades `@angular/language-service` to v11.2.11.
-For a complete change log see [here](https://github.com/angular/angular/blob/master/CHANGELOG.md#11211-2021-04-21).
+For a complete change log see [here](https://github.com/angular/angular/blob/main/CHANGELOG.md#11211-2021-04-21).
 
 Bug fixes:
 1. compiler-cli: autocomplete literal types in templates (296f887)
@@ -224,7 +224,7 @@ Bug fixes:
 # v11.2.11
 
 This release upgrades `@angular/language-service` to v11.2.10.
-For a complete change log see [here](https://github.com/angular/angular/blob/master/CHANGELOG.md#11210-2021-04-14).
+For a complete change log see [here](https://github.com/angular/angular/blob/main/CHANGELOG.md#11210-2021-04-14).
 
 Bug fixes:
 1. language-service: bound attributes should not break directive matching (#41597) (3dbcc7f)
@@ -238,7 +238,7 @@ Performance improvements:
 # v11.2.10
 
 This release upgrades `@angular/language-service` to v11.2.9.
-For a complete change log see [here](https://github.com/angular/angular/blob/master/CHANGELOG.md#1129-2021-04-07).
+For a complete change log see [here](https://github.com/angular/angular/blob/main/CHANGELOG.md#1129-2021-04-07).
 
 Bug fixes:
 1. Allow analysis to continue with invalid style url (#41403) (#41489) (07131fa)
@@ -250,7 +250,7 @@ Performance improvements:
 
 # v11.2.9
 This release upgrades `@angular/language-service` to v11.2.7.
-For a complete change log see [here](https://github.com/angular/angular/blob/master/CHANGELOG.md#1127-2021-03-24).
+For a complete change log see [here](https://github.com/angular/angular/blob/main/CHANGELOG.md#1127-2021-03-24).
 
 bug fixes in `@angular/language-service`:
 * **compiler-cli:** add `useInlining` option to type check config ([#41268](https://github.com/angular/angular/issues/41268)) ([57644e9](https://github.com/angular/angular/commit/57644e95aadbfe9c8f336be77a22f7a5e1859758)), closes [#40963](https://github.com/angular/angular/issues/40963)
@@ -274,7 +274,7 @@ This release reverts the following commits due to [#1198](https://github.com/ang
 # v11.2.6
 
 This release upgrades `@angular/language-service` to v11.2.5.
-For a complete change log see [here](https://github.com/angular/angular/blob/master/CHANGELOG.md#1125-2021-03-10).
+For a complete change log see [here](https://github.com/angular/angular/blob/main/CHANGELOG.md#1125-2021-03-10).
 
 This release contains various performance improvements.
 
@@ -290,7 +290,7 @@ Bug fixes:
 # v11.2.4
 
 This release upgrades `@angular/language-service` to v11.2.4.
-For a complete change log see [here](https://github.com/angular/angular/blob/master/CHANGELOG.md#1124-2021-03-03).
+For a complete change log see [here](https://github.com/angular/angular/blob/main/CHANGELOG.md#1124-2021-03-03).
 
 Bug fixes in `@angular/language-service`:
 - Add plugin option to force strictTemplates (#41063) (95f748c)
@@ -313,7 +313,7 @@ Bug fixes in `@angular/language-server`:
 # v11.2.3
 
 This release upgrades `@angular/language-service` to v11.2.2.
-For a complete change log see [here](https://github.com/angular/angular/blob/master/CHANGELOG.md#1110-2021-01-20).
+For a complete change log see [here](https://github.com/angular/angular/blob/main/CHANGELOG.md#1110-2021-01-20).
 
 Performance improvements:
 - The Ivy Language Service no longer slows down the operation of plain TS language service features when editing TS code outside of a template.
@@ -321,7 +321,7 @@ Performance improvements:
 # v11.2.2
 
 This release upgrades `@angular/language-service` to v11.2.1.
-For a complete change log see [here](https://github.com/angular/angular/blob/master/CHANGELOG.md#1200-next1-2021-02-17).
+For a complete change log see [here](https://github.com/angular/angular/blob/main/CHANGELOG.md#1200-next1-2021-02-17).
 
 # v11.2.1
 
@@ -332,7 +332,7 @@ See https://github.com/angular/vscode-ng-language-service/issues/1109
 # v11.2.0
 
 This release upgrades `@angular/language-service` to v11.2.0.
-For a complete change log see [here](https://github.com/angular/angular/blob/master/CHANGELOG.md#1120-2021-02-10).
+For a complete change log see [here](https://github.com/angular/angular/blob/main/CHANGELOG.md#1120-2021-02-10).
 
 Bug fixes:
 - disable rename feature when strictTemplates is disabled
@@ -347,7 +347,7 @@ Features:
 # v11.1.3
 
 This release upgrades `@angular/language-service` to v11.1.2.
-For a complete change log see [here](https://github.com/angular/angular/blob/master/CHANGELOG.md#1112-2021-02-03).
+For a complete change log see [here](https://github.com/angular/angular/blob/main/CHANGELOG.md#1112-2021-02-03).
 
 # v11.1.2
 
@@ -356,7 +356,7 @@ No major updates in this release.
 # v11.1.1
 
 This release upgrades `@angular/language-service` to v11.1.1.
-For a complete change log see [here](https://github.com/angular/angular/blob/master/CHANGELOG.md#1111-2021-01-27).
+For a complete change log see [here](https://github.com/angular/angular/blob/main/CHANGELOG.md#1111-2021-01-27).
 
 # v11.1.0
 
@@ -364,7 +364,7 @@ Ivy-native language service is officially available for preview!
 To try it, go to Preferences > Settings > Angular > check experimental-ivy.
 
 This release upgrades `@angular/language-service` to v11.1.0.
-For a complete change log see [here](https://github.com/angular/angular/blob/master/CHANGELOG.md#1110-2021-01-20).
+For a complete change log see [here](https://github.com/angular/angular/blob/main/CHANGELOG.md#1110-2021-01-20).
 
 # 0.1101.0-rc.1
 
@@ -376,7 +376,7 @@ Bug fixes:
 
 This release upgrades `@angular/language-service` to v11.1.0-rc.0.
 
-For a complete change log see [here](https://github.com/angular/angular/blob/master/CHANGELOG.md#1110-rc0-2021-01-13).
+For a complete change log see [here](https://github.com/angular/angular/blob/main/CHANGELOG.md#1110-rc0-2021-01-13).
 
 Bug fixes:
 - prevent project from closing when only a template file is open
@@ -388,19 +388,19 @@ Features:
 
 This release upgrades `@angular/language-service` to v11.1.0-next.4.
 
-For a complete change log see [here](https://github.com/angular/angular/blob/master/CHANGELOG.md#1110-next4-2021-01-06).
+For a complete change log see [here](https://github.com/angular/angular/blob/main/CHANGELOG.md#1110-next4-2021-01-06).
 
 # v0.1101.0-next.1
 
 This release upgrades `@angular/language-service` to v11.1.0-next.3.
 
-For a complete change log see [here](https://github.com/angular/angular/blob/master/CHANGELOG.md#1110-next3-2020-12-16).
+For a complete change log see [here](https://github.com/angular/angular/blob/main/CHANGELOG.md#1110-next3-2020-12-16).
 
 # v0.1101.0-next.0
 
 This release upgrades `@angular/language-service` to v11.1.0-next.2.
 
-For a complete change log see [here](https://github.com/angular/angular/blob/master/CHANGELOG.md#1110-next2-2020-12-09).
+For a complete change log see [here](https://github.com/angular/angular/blob/main/CHANGELOG.md#1110-next2-2020-12-09).
 
 Bug fixes:
 - `require.resolve` not working in vscode, resulting in ngcc failure.
@@ -419,22 +419,22 @@ Bug fixes:
 
 This release upgrades `@angular/language-service` to v11.0.0-rc.3.
 
-For a complete change log see [here](https://github.com/angular/angular/blob/master/CHANGELOG.md#1100-rc3-2020-11-09).
+For a complete change log see [here](https://github.com/angular/angular/blob/main/CHANGELOG.md#1100-rc3-2020-11-09).
 
 # v0.1100.0-rc.0
 
 This release upgrades `@angular/language-service` to v11.0.0-rc.1.
-For a complete change log see [here](https://github.com/angular/angular/blob/master/CHANGELOG.md#1100-rc1-2020-10-28).
+For a complete change log see [here](https://github.com/angular/angular/blob/main/CHANGELOG.md#1100-rc1-2020-10-28).
 
 # v0.1000.8
 
 This release upgrades `@angular/language-service` to v10.0.14.
-For a complete change log see [here](https://github.com/angular/angular/blob/master/CHANGELOG.md#10014-2020-08-26).
+For a complete change log see [here](https://github.com/angular/angular/blob/main/CHANGELOG.md#10014-2020-08-26).
 
 # v0.1000.7
 
 This release upgrades `@angular/language-service` to v10.0.7.
-For a complete change log see [here](https://github.com/angular/angular/blob/master/CHANGELOG.md#1007-2020-07-30).
+For a complete change log see [here](https://github.com/angular/angular/blob/main/CHANGELOG.md#1007-2020-07-30).
 
 This release fixes a bug caused by the upgrade of bundle format from ES5 to
 ES2015.
@@ -445,19 +445,19 @@ Bug fixes:
 # v0.1000.6
 
 This release upgrades `@angular/language-service` to v10.0.6.
-For a complete change log see [here](https://github.com/angular/angular/blob/master/CHANGELOG.md#1006-2020-07-28).
+For a complete change log see [here](https://github.com/angular/angular/blob/main/CHANGELOG.md#1006-2020-07-28).
 
 # v0.1000.5
 
 This release upgrades `@angular/language-service` to v10.0.5.
-For a complete change log see [here](https://github.com/angular/angular/blob/master/CHANGELOG.md#1005-2020-07-22).
+For a complete change log see [here](https://github.com/angular/angular/blob/main/CHANGELOG.md#1005-2020-07-22).
 
 The `.umd` suffix has been removed from the bundle filename.
 
 # v0.1000.4
 
 This release upgrades `@angular/language-service` to v10.0.4.
-For a complete change log see [here](https://github.com/angular/angular/blob/master/CHANGELOG.md#1004-2020-07-15).
+For a complete change log see [here](https://github.com/angular/angular/blob/main/CHANGELOG.md#1004-2020-07-15).
 
 Features:
 - Upgrade bundle format to ES2015.
@@ -468,7 +468,7 @@ Bug fixes:
 # v0.1000.3
 
 This release upgrades `@angular/language-service` to v10.0.3.
-For a complete change log see [here](https://github.com/angular/angular/blob/master/CHANGELOG.md#1003-2020-07-08).
+For a complete change log see [here](https://github.com/angular/angular/blob/main/CHANGELOG.md#1003-2020-07-08).
 
 Bug fixes:
 - Do not match inline template grammars inside a template itself (#839)
@@ -476,7 +476,7 @@ Bug fixes:
 # v0.1000.2
 
 This release upgrades `@angular/language-service` to v10.0.2.
-For a complete change log see [here](https://github.com/angular/angular/blob/master/CHANGELOG.md#1002-2020-06-30).
+For a complete change log see [here](https://github.com/angular/angular/blob/main/CHANGELOG.md#1002-2020-06-30).
 
 Bug fixes:
 - incorrect autocomplete results on unknown symbol (#37518) (7c0b25f)
@@ -484,7 +484,7 @@ Bug fixes:
 # v0.1000.1
 
 This release upgrades `@angular/language-service` to v10.0.1.
-For a complete change log see [here](https://github.com/angular/angular/blob/master/CHANGELOG.md#1001-2020-06-26).
+For a complete change log see [here](https://github.com/angular/angular/blob/main/CHANGELOG.md#1001-2020-06-26).
 
 This release fixes support for ["solution-style"](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-9.html#support-for-solution-style-tsconfigjson-files) tsconfig.
 
@@ -494,7 +494,7 @@ Bug fixes:
 # v0.1000.0
 
 This release upgrades `@angular/language-service` to v10.0.0 and `typescript` to v3.9.5.
-For a complete change log see [here](https://github.com/angular/angular/blob/master/CHANGELOG.md#1000-2020-06-24).
+For a complete change log see [here](https://github.com/angular/angular/blob/main/CHANGELOG.md#1000-2020-06-24).
 
 Known issues:
 - This release does not yet support ["solution-style"](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-9.html#support-for-solution-style-tsconfigjson-files) tsconfig.
@@ -516,42 +516,42 @@ Deprecations:
 # v0.1000.0-rc.1
 
 This release upgrades `@angular/language-service` to v10.0.0-rc.2.
-For a complete change log see [here](https://github.com/angular/angular/blob/master/CHANGELOG.md#1000-rc2-2020-06-01).
+For a complete change log see [here](https://github.com/angular/angular/blob/main/CHANGELOG.md#1000-rc2-2020-06-01).
 
 # v0.1000.0-rc.0
 
 This release upgrades `@angular/language-service` to v10.0.0-rc.0.
-For a complete change log see [here](https://github.com/angular/angular/blob/master/CHANGELOG.md#1000-rc0-2020-05-21).
+For a complete change log see [here](https://github.com/angular/angular/blob/main/CHANGELOG.md#1000-rc0-2020-05-21).
 
 # v0.901.9
 
 This release upgrades `@angular/language-service` to v9.1.9.
-For a complete change log see [here](https://github.com/angular/angular/blob/master/CHANGELOG.md#919-2020-05-20).
+For a complete change log see [here](https://github.com/angular/angular/blob/main/CHANGELOG.md#919-2020-05-20).
 
 # v0.901.8
 
 This release upgrades `@angular/language-service` to v9.1.8.
-For a complete change log see [here](https://github.com/angular/angular/blob/master/CHANGELOG.md#918-2020-05-20).
+For a complete change log see [here](https://github.com/angular/angular/blob/main/CHANGELOG.md#918-2020-05-20).
 
 # v0.901.7
 
 This release upgrades `@angular/language-service` to v9.1.7.
-For a complete change log see [here](https://github.com/angular/angular/blob/master/CHANGELOG.md#917-2020-05-13).
+For a complete change log see [here](https://github.com/angular/angular/blob/main/CHANGELOG.md#917-2020-05-13).
 
 # v0.901.6
 
 This release upgrades `@angular/language-service` to v9.1.6.
-For a complete change log see [here](https://github.com/angular/angular/blob/master/CHANGELOG.md#916-2020-05-08).
+For a complete change log see [here](https://github.com/angular/angular/blob/main/CHANGELOG.md#916-2020-05-08).
 
 # v0.901.5
 
 This release upgrades `@angular/language-service` to v9.1.5.
-For a complete change log see [here](https://github.com/angular/angular/blob/master/CHANGELOG.md#915-2020-05-07).
+For a complete change log see [here](https://github.com/angular/angular/blob/main/CHANGELOG.md#915-2020-05-07).
 
 # v0.901.4
 
 This release upgrades `@angular/language-service` to v9.1.4.
-For a complete change log see [here](https://github.com/angular/angular/blob/master/CHANGELOG.md#914-2020-04-29).
+For a complete change log see [here](https://github.com/angular/angular/blob/main/CHANGELOG.md#914-2020-04-29).
 
 Bug fixes:
 - do not invalidate `@angular/core` module (#36783) (d3a77ea)
@@ -559,7 +559,7 @@ Bug fixes:
 # v0.901.3
 
 This release upgrades `@angular/language-service` to v9.1.3.
-For a complete change log see [here](https://github.com/angular/angular/blob/master/CHANGELOG.md#913-2020-04-22).
+For a complete change log see [here](https://github.com/angular/angular/blob/main/CHANGELOG.md#913-2020-04-22).
 
 Bug fixes:
 - properly evaluate types in comparable expressions (#36529) (5bab498)
@@ -567,12 +567,12 @@ Bug fixes:
 # v0.901.2
 
 This release upgrades `@angular/language-service` to v9.1.2.
-For a complete change log see [here](https://github.com/angular/angular/blob/master/CHANGELOG.md#912-2020-04-15).
+For a complete change log see [here](https://github.com/angular/angular/blob/main/CHANGELOG.md#912-2020-04-15).
 
 # v0.901.1
 
 This release upgrades `@angular/language-service` to v9.1.1.
-For a complete change log see [here](https://github.com/angular/angular/blob/master/CHANGELOG.md#911-2020-04-07).
+For a complete change log see [here](https://github.com/angular/angular/blob/main/CHANGELOG.md#911-2020-04-07).
 
 Bug fixes:
 - infer type of elements of array-like objects (#36312) (ff523c9), closes #36191
@@ -582,7 +582,7 @@ Bug fixes:
 # v0.901.0
 
 This release upgrades `@angular/language-service` to v9.1.0.
-For a complete change log see [here](https://github.com/angular/angular/blob/master/CHANGELOG.md#910-2020-03-25).
+For a complete change log see [here](https://github.com/angular/angular/blob/main/CHANGELOG.md#910-2020-03-25).
 
 New features:
 - improve non-callable error message (#35271) (acc483e)
@@ -603,7 +603,7 @@ Bug fixes:
 # v0.900.18
 
 This release upgrades `@angular/language-service` to v9.0.7.
-For a complete change log see [here](https://github.com/angular/angular/blob/master/CHANGELOG.md#907-2020-03-18).
+For a complete change log see [here](https://github.com/angular/angular/blob/main/CHANGELOG.md#907-2020-03-18).
 
 Bug fixes:
 - infer $implicit value for ngIf template contexts (#35941) (f5e4410)
@@ -611,7 +611,7 @@ Bug fixes:
 # v0.900.17
 
 This release upgrades `@angular/language-service` to v9.0.6.
-For a complete change log see [here](https://github.com/angular/angular/blob/master/CHANGELOG.md#906-2020-03-10).
+For a complete change log see [here](https://github.com/angular/angular/blob/main/CHANGELOG.md#906-2020-03-10).
 
 Bug fixes:
 - resolve the variable from the template context first (#35982) (f882ff0)
@@ -620,7 +620,7 @@ Bug fixes:
 # v0.900.16
 
 This release upgrades `@angular/language-service` to v9.0.5.
-For a complete change log see [here](https://github.com/angular/angular/blob/master/CHANGELOG.md#905-2020-03-04).
+For a complete change log see [here](https://github.com/angular/angular/blob/main/CHANGELOG.md#905-2020-03-04).
 
 New features:
 - modularize error messages (#35678) (bcff873)
@@ -631,7 +631,7 @@ Bug fixes:
 # v0.900.15
 
 This release upgrades `@angular/language-service` to v9.0.4.
-For a complete change log see [here](https://github.com/angular/angular/blob/master/CHANGELOG.md#904-2020-02-27).
+For a complete change log see [here](https://github.com/angular/angular/blob/main/CHANGELOG.md#904-2020-02-27).
 
 Bug fixes:
 - get the right 'ElementAst' in the nested HTML tag (#35317) (7403ba1)
@@ -646,7 +646,7 @@ Special thanks to @ghaschel, @ayazhafiz, and @dannymcgee.
 # v0.900.13
 
 This release upgrades `@angular/language-service` to v9.0.2.
-For a complete change log see [here](https://github.com/angular/angular/blob/master/CHANGELOG.md#902-2020-02-19).
+For a complete change log see [here](https://github.com/angular/angular/blob/main/CHANGELOG.md#902-2020-02-19).
 
 New features:
 - Trigger autocomplete on pipe
@@ -657,7 +657,7 @@ Bug fixes:
 # v0.900.12
 
 This release upgrades `@angular/language-service` to v9.0.1.
-For a complete change log see [here](https://github.com/angular/angular/blob/master/CHANGELOG.md#901-2020-02-12).
+For a complete change log see [here](https://github.com/angular/angular/blob/main/CHANGELOG.md#901-2020-02-12).
 
 Bug fixes:
 - Suggest ? and ! operator on nullable receiver (#35200) (3cc24a9)
@@ -665,17 +665,17 @@ Bug fixes:
 # v0.900.11
 
 This release upgrades `@angular/language-service` to v9.0.0.
-For a complete change log see [here](https://github.com/angular/angular/blob/master/CHANGELOG.md#900-2020-02-06).
+For a complete change log see [here](https://github.com/angular/angular/blob/main/CHANGELOG.md#900-2020-02-06).
 
 # v0.900.10
 
 This release upgrades `@angular/language-service` to v9.0.0-rc.14.
-For a complete change log see [here](https://github.com/angular/angular/blob/master/CHANGELOG.md#900-rc14-2020-02-03).
+For a complete change log see [here](https://github.com/angular/angular/blob/main/CHANGELOG.md#900-rc14-2020-02-03).
 
 # v0.900.9
 
 This release upgrades `@angular/language-service` to v9.0.0-rc.13.
-For a complete change log see [here](https://github.com/angular/angular/blob/master/CHANGELOG.md#900-rc13-2020-02-01).
+For a complete change log see [here](https://github.com/angular/angular/blob/main/CHANGELOG.md#900-rc13-2020-02-01).
 
 Bug fixes:
 - more accurate and specific binding scopes (#598)
@@ -684,7 +684,7 @@ Bug fixes:
 # v0.900.8
 
 This release upgrades `@angular/language-service` to v9.0.0-rc.12.
-For a complete change log see [here](https://github.com/angular/angular/blob/master/CHANGELOG.md#900-rc12-2020-01-30).
+For a complete change log see [here](https://github.com/angular/angular/blob/main/CHANGELOG.md#900-rc12-2020-01-30).
 
 New features:
 - completions for output $event properties in (#34570) (2a53727)
@@ -700,7 +700,7 @@ Bug fixes:
 # v0.900.7
 
 This release upgrades `@angular/language-service` to v9.0.0-rc.11.
-For a complete change log see [here](https://github.com/angular/angular/blob/master/CHANGELOG.md#900-rc11-2020-01-24).
+For a complete change log see [here](https://github.com/angular/angular/blob/main/CHANGELOG.md#900-rc11-2020-01-24).
 
 New features:
 - Specific suggestions for template context diags (#34751) (cc7fca4)
@@ -712,7 +712,7 @@ Bug fixes:
 # v0.900.6
 
 This release upgrades `@angular/language-service` to v9.0.0-rc.10.
-For a complete change log see [here](https://github.com/angular/angular/blob/master/CHANGELOG.md#900-rc10-2020-01-22).
+For a complete change log see [here](https://github.com/angular/angular/blob/main/CHANGELOG.md#900-rc10-2020-01-22).
 
 It also upgrades `vscode-languageclient` and `vscode-languageserver` to major
 version 6.
@@ -726,7 +726,7 @@ New features:
 # v0.900.5
 
 This release upgrades `@angular/language-service` to v9.0.0-rc.9.
-For a complete change log see [here](https://github.com/angular/angular/blob/master/CHANGELOG.md#900-rc9-2020-01-15).
+For a complete change log see [here](https://github.com/angular/angular/blob/main/CHANGELOG.md#900-rc9-2020-01-15).
 
 It also upgrades `typescript` to v3.7.4.
 
@@ -749,7 +749,7 @@ Bug fixes:
 # v0.900.4
 
 This release upgrades `@angular/language-service` to v9.0.0-rc.8.
-For a complete change log see [here](https://github.com/angular/angular/blob/master/CHANGELOG.md#900-rc8-2020-01-08).
+For a complete change log see [here](https://github.com/angular/angular/blob/main/CHANGELOG.md#900-rc8-2020-01-08).
 
 New features:
 - Append symbol type to hover tooltip (#34515) (381b895)
@@ -765,7 +765,7 @@ Bug fixes:
 # v0.900.3
 
 This release upgrades `@angular/language-service` to v9.0.0-rc.7.
-For a complete change log see [here](https://github.com/angular/angular/blob/master/CHANGELOG.md#900-rc7-2019-12-18).
+For a complete change log see [here](https://github.com/angular/angular/blob/main/CHANGELOG.md#900-rc7-2019-12-18).
 
 New features:
 - add textmate grammar for inline CSS styles
@@ -780,7 +780,7 @@ Bug fixes:
 # v0.900.2
 
 This release upgrades `@angular/language-service` to v9.0.0-rc.6.
-For a complete change log see [here](https://github.com/angular/angular/blob/master/CHANGELOG.md#900-rc6-2019-12-11).
+For a complete change log see [here](https://github.com/angular/angular/blob/main/CHANGELOG.md#900-rc6-2019-12-11).
 
 Bug fixes:
 - Fixed accessing a string index signature using dot notation

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Angular Language Service
 
-![demo](https://github.com/angular/vscode-ng-language-service/raw/master/demo.gif)
+![demo](https://github.com/angular/vscode-ng-language-service/raw/main/demo.gif)
 
 ## Features
 

--- a/override_rename_ts_plugin/README.md
+++ b/override_rename_ts_plugin/README.md
@@ -3,4 +3,4 @@ This package is applied to the built-in TS extension by the config [`typescriptS
 Detail about this package is [here][2].
 
 [1]: https://code.visualstudio.com/api/references/contribution-points#contributes.typescriptServerPlugins
-[2]: https://github.com/angular/angular/blob/master/packages/language-service/README.md#override-rename-ts-plugin
+[2]: https://github.com/angular/angular/blob/main/packages/language-service/README.md#override-rename-ts-plugin

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
         "angular.disableAutomaticNgcc": {
           "type": "boolean",
           "default": false,
-          "markdownDescription": "Disable the step to automatically run ngcc. [ngcc](https://github.com/angular/angular/blob/master/packages/compiler/design/architecture.md#high-level-proposal) is required to run and gather metadata from libraries not published with Ivy instructions. This can be run outside of VSCode instead (for example, as part of the build/rebuild in the CLI). Note that ngcc needs to run not only at startup, but also whenever the dependencies change. Failing to run ngcc when required can result in incomplete information and spurious errors reported by the language service."
+          "markdownDescription": "Disable the step to automatically run ngcc. [ngcc](https://github.com/angular/angular/blob/main/packages/compiler/design/architecture.md#high-level-proposal) is required to run and gather metadata from libraries not published with Ivy instructions. This can be run outside of VSCode instead (for example, as part of the build/rebuild in the CLI). Note that ngcc needs to run not only at startup, but also whenever the dependencies change. Failing to run ngcc when required can result in incomplete information and spurious errors reported by the language service."
         },
         "angular.forceStrictTemplates": {
           "type": "boolean",

--- a/syntaxes/README.md
+++ b/syntaxes/README.md
@@ -2,7 +2,7 @@
 
 **The JSON files in this directory are not meant to be edited by hand.**
 
-If you need to make modification, the respective files should be changed within the repository's [`syntaxes/src`](https://github.com/angular/vscode-ng-language-service/tree/master/syntaxes/src) directory.
+If you need to make modification, the respective files should be changed within the repository's [`syntaxes/src`](https://github.com/angular/vscode-ng-language-service/tree/main/syntaxes/src) directory.
 
 Running `yarn build:syntaxes` will then appropriately update the files in this directory.
 


### PR DESCRIPTION
Cleans up all references to the old `master` branch.