### PR TITLE
fix(docs): Fix the link to the demo after branch rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Angular Language Service
 
-![demo](https://github.com/angular/vscode-ng-language-service/raw/master/demo.gif)
+![demo](https://github.com/angular/vscode-ng-language-service/raw/main/demo.gif)
 
 ## Features
 


### PR DESCRIPTION
Renaming the branches broke the gif link in the patch branch