### PR TITLE
fix(language-server): Fix detection of Angular for v14+ projects

### DIFF
--- a/server/src/session.ts
+++ b/server/src/session.ts
@@ -1264,7 +1264,7 @@ function isAngularCore(path: string): boolean {
 }
 
 function isExternalAngularCore(path: string): boolean {
-  return path.endsWith('@angular/core/core.d.ts');
+  return path.endsWith('@angular/core/core.d.ts') || path.endsWith('@angular/core/index.d.ts');
 }
 
 function isInternalAngularCore(path: string): boolean {


### PR DESCRIPTION
In v14, the .d.ts file for angular core is now "index.d.ts" rather than "core.d.ts".

fixes #1657