### PR TITLE
fix(language-server): Fix detection of Angular for v14+ projects

### DIFF
--- a/server/src/session.ts
+++ b/server/src/session.ts
@@ -1245,7 +1245,7 @@ function isAngularCore(path: string): boolean {
 }
 
 function isExternalAngularCore(path: string): boolean {
-  return path.endsWith('@angular/core/core.d.ts');
+  return path.endsWith('@angular/core/core.d.ts') || path.endsWith('@angular/core/index.d.ts');
 }
 
 function isInternalAngularCore(path: string): boolean {


### PR DESCRIPTION
In v14, the .d.ts file for angular core is now "index.d.ts" rather than "core.d.ts".

This change happened in https://github.com/ng-packagr/ng-packagr/commit/c6f6e4d701d31e3d9e8636703ede731c3790778b

fixes #1657