### PR TITLE
fix(language-server): Ensure diagnostics are refreshed when language …

### DIFF
--- a/server/src/session.ts
+++ b/server/src/session.ts
@@ -404,6 +404,7 @@ export class Session {
     // (because language service was disabled while waiting for ngcc).
     // First, make sure the Angular project is complete.
     this.runGlobalAnalysisForNewlyLoadedProject(project);
+    project.refreshDiagnostics();
   }
 
   private disableLanguageServiceForProject(project: ts.server.Project, reason: string): void {


### PR DESCRIPTION
…service gets enabled

There is currently some amount magic that triggers diagnostics after the language service is enabled.
The mechanism that causes this to happen is ngcc. ngcc generates a lockfile named `__ngcc_lock_file__`
in the node_modules directory, this triggers the directory watcher,
and [ProjectsUpdatedInBackgroundEvent](https://github.com/angular/vscode-ng-language-service/blob/8c809a2982ccad19997caef7ffeaa899e9d8ddb5/server/src/session.ts#L491)
event is send by the method [delayUpdateProjectGraphAndEnsureProjectStructureForOpenFiles](https://github.com/microsoft/TypeScript/blob/56a4a93718ce016f038bcbce425bd3f47c3bec78/src/server/editorServices.ts#L1356).

But this [PR](https://github.com/angular/angular/pull/44228) broke this.
Because the `.ngcc_lock_file` is [ignored by tsserver](https://github.com/microsoft/TypeScript/blob/ab2523bbe0352d4486f67b73473d2143ad64d03d/src/compiler/sys.ts#L500)
and the tsserver will [skip updating the project](https://github.com/microsoft/TypeScript/blob/56a4a93718ce016f038bcbce425bd3f47c3bec78/src/server/editorServices.ts#L1316).

When updating the integration project to use v14, the tests begin to fail:
https://app.circleci.com/pipelines/github/angular/vscode-ng-language-service/3585/workflows/40f00184-ea1e-441a-8af3-0fe5f017883f/jobs/3512

Instead of relying on magic/automatic triggering, this commit explictly requests that the
project refresh diagnostics after enabling the language service. In
fact, this change would have eventually been necessary when `ngcc` is no
longer run at all.

Special thanks to @ivanwonder for pinpointing the exact reasons for this
breakage: https://github.com/angular/vscode-ng-language-service/pull/1659#issuecomment-1131706722