### PR TITLE
fix(extension): disable rename override to allow built in TS renaming

### DIFF
--- a/override_rename_ts_plugin/README.md
+++ b/override_rename_ts_plugin/README.md
@@ -1,3 +1,5 @@
+Note: This is currently disabled. See conversations in https://github.com/angular/vscode-ng-language-service/issues/1685 and https://github.com/angular/vscode-ng-language-service/issues/1683
+
 This package is applied to the built-in TS extension by the config [`typescriptServerPlugins`][1] and is used to disable rename provider of the built-in TS extension so VSCode asks the Angular Language Service for the answer instead.
 
 Detail about this package is [here][2].

--- a/package.json
+++ b/package.json
@@ -180,12 +180,6 @@
         "path": "./syntaxes/expression.json",
         "scopeName": "expression.ng"
       }
-    ],
-    "typescriptServerPlugins": [
-      {
-        "name": "@angular/override-rename-ts-plugin",
-        "enableForWorkspaceTypeScriptVersions": true
-      }
     ]
   },
   "activationEvents": [
@@ -209,7 +203,6 @@
     "test:syntaxes": "yarn compile:syntaxes-test && yarn build:syntaxes && jasmine dist/syntaxes/test/driver.js"
   },
   "dependencies": {
-    "@angular/override-rename-ts-plugin": "file:override_rename_ts_plugin",
     "@angular/language-service": "14.0.0",
     "typescript": "4.5.4",
     "vscode-jsonrpc": "6.0.0",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -53,7 +53,6 @@ cp package.json angular.png CHANGELOG.md README.md dist/npm
 # Copy files to server directory
 cp -r server/package.json server/README.md server/bin dist/npm/server
 cp -r v12_language_service dist/npm/v12_language_service
-cp -r override_rename_ts_plugin dist/npm/override_rename_ts_plugin
 # Build and copy files to syntaxes directory
 yarn run build:syntaxes
 mkdir dist/npm/syntaxes

--- a/yarn.lock
+++ b/yarn.lock
@@ -165,9 +165,6 @@
   resolved "https://registry.yarnpkg.com/@angular/language-service/-/language-service-14.0.0.tgz#749b52642fe0ba04f8475667d2eac0b3cf60d400"
   integrity sha512-05P+3IJ+pT9WQdUcXVM4NGY1a8V1bGKRVEE6BFFPYG+ElrM2aR7e0j997zAPIwPLWT1Z8/oC1wJ3MCBBTbECVQ==
 
-"@angular/override-rename-ts-plugin@file:override_rename_ts_plugin":
-  version "0.0.1"
-
 "@assemblyscript/loader@^0.10.1":
   version "0.10.1"
   resolved "https://registry.yarnpkg.com/@assemblyscript/loader/-/loader-0.10.1.tgz#70e45678f06c72fa2e350e8553ec4a4d72b92e06"


### PR DESCRIPTION
This is a rollback of #1589 due to breaking rename scenarios in
projects.
https://github.com/angular/vscode-ng-language-service/issues/1683#issuecomment-1148816800

Fixes https://github.com/angular/vscode-ng-language-service/issues/1685