### PR TITLE
feat(extension): Update virtualWorkspace support to allow syntax high…

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,10 @@
     "untrustedWorkspaces": {
       "supported": false,
       "description": "This extension requires workspace trust because it needs to execute ngcc from the node_modules in the workspace."
+    },
+    "virtualWorkspaces": {
+      "supported": "limited",
+      "description": "The Language Server Protocol does not support remote file systems. Functionality is limited to syntax highlighting only."
     }
   },
   "categories": [
@@ -59,26 +63,34 @@
       "commandPalette": [
         {
           "command": "angular.goToComponentWithTemplateFile",
-          "when": "editorLangId == html"
+          "when": "editorLangId == html && !virtualWorkspace"
         },
         {
           "command": "angular.goToTemplateForComponent",
-          "when": "editorLangId == typescript"
+          "when": "editorLangId == typescript && !virtualWorkspace"
+        },
+        {
+          "command": "angular.runNgcc",
+          "when": "!virtualWorkspace"
+        },
+        {
+          "command": "angular.getTemplateTcb",
+          "when": "!virtualWorkspace"
         }
       ],
       "editor/context": [
         {
-          "when": "resourceLangId == html || resourceLangId == typescript",
+          "when": "(resourceLangId == html || resourceLangId == typescript) && !virtualWorkspace",
           "command": "angular.getTemplateTcb",
           "group": "angular"
         },
         {
-          "when": "resourceLangId == html",
+          "when": "resourceLangId == html && !virtualWorkspace",
           "command": "angular.goToComponentWithTemplateFile",
           "group": "angular"
         },
         {
-          "when": "resourceLangId == typescript",
+          "when": "resourceLangId == typescript && !virtualWorkspace",
           "command": "angular.goToTemplateForComponent",
           "group": "angular"
         }


### PR DESCRIPTION
…lighting

You can find more information about virtual workspaces here: https://code.visualstudio.com/api/extension-guides/virtual-workspaces

The LSP does not support access to virtual resources: https://github.com/microsoft/language-server-protocol/issues/1264
As a result, we cannot provide much in the way of features since the
extension relies on the LSP for every provider.

While we cannot provide any features from the @angular/language-server,
we still can provide "limited" support to enable syntax highlighting in
virtual workspaces.