### PR TITLE
feat(extension): Update untrusted workspace support from 'false' to '…

### DIFF
--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -395,7 +395,8 @@ function getProbeLocations(bundled: string): string[] {
  * Construct the arguments that's used to spawn the server process.
  * @param ctx vscode extension context
  */
-function constructArgs(ctx: vscode.ExtensionContext, viewEngine: boolean): string[] {
+function constructArgs(
+    ctx: vscode.ExtensionContext, viewEngine: boolean, isTrustedWorkspace: boolean): string[] {
   const config = vscode.workspace.getConfiguration();
   const args: string[] = ['--logToConsole'];
 
@@ -440,6 +441,10 @@ function constructArgs(ctx: vscode.ExtensionContext, viewEngine: boolean): strin
     args.push('--forceStrictTemplates');
   }
 
+  if (!isTrustedWorkspace) {
+    args.push('--untrustedWorkspace');
+  }
+
   const tsdk: string|null = config.get('typescript.tsdk', null);
   const tsProbeLocations = [tsdk, ...getProbeLocations(ctx.extensionPath)];
   args.push('--tsProbeLocations', tsProbeLocations.join(','));
@@ -475,7 +480,7 @@ function getServerOptions(ctx: vscode.ExtensionContext, debug: boolean): lsp.Nod
   }
 
   // Node module for the language server
-  const args = constructArgs(ctx, viewEngine);
+  const args = constructArgs(ctx, viewEngine, vscode.workspace.isTrusted);
   const prodBundle = ctx.asAbsolutePath('server');
   const devBundle = ctx.asAbsolutePath(path.join('dist', 'server', 'server.js'));
   // VS Code Insider launches extensions in debug mode by default but users

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
   },
   "capabilities": {
     "untrustedWorkspaces": {
-      "supported": false,
-      "description": "This extension requires workspace trust because it needs to execute ngcc from the node_modules in the workspace."
+      "supported": "limited",
+      "description": "This extension requires workspace trust because it needs to execute ngcc from the node_modules in the workspace. Projects do not require ngcc if all library dependencies are published with partial-Ivy or Full-Ivy."
     },
     "virtualWorkspaces": {
       "supported": "limited",
@@ -71,7 +71,7 @@
         },
         {
           "command": "angular.runNgcc",
-          "when": "!virtualWorkspace"
+          "when": "!virtualWorkspace && isWorkspaceTrusted"
         },
         {
           "command": "angular.getTemplateTcb",

--- a/server/src/cmdline_utils.ts
+++ b/server/src/cmdline_utils.ts
@@ -44,6 +44,7 @@ interface CommandLineOptions {
   includeAutomaticOptionalChainCompletions: boolean;
   includeCompletionsWithSnippetText: boolean;
   forceStrictTemplates: boolean;
+  untrustedWorkspace: boolean;
 }
 
 export function parseCommandLine(argv: string[]): CommandLineOptions {
@@ -60,6 +61,7 @@ export function parseCommandLine(argv: string[]): CommandLineOptions {
         hasArgument(argv, '--includeAutomaticOptionalChainCompletions'),
     includeCompletionsWithSnippetText: hasArgument(argv, '--includeCompletionsWithSnippetText'),
     forceStrictTemplates: hasArgument(argv, '--forceStrictTemplates'),
+    untrustedWorkspace: hasArgument(argv, '--untrustedWorkspace'),
   };
 }
 

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -43,11 +43,12 @@ function main() {
     ngPlugin: '@angular/language-service',
     resolvedNgLsPath: ng.resolvedPath,
     ivy: isG3 ? true : options.ivy,
-    disableAutomaticNgcc: options.disableAutomaticNgcc,
+    disableAutomaticNgcc: options.disableAutomaticNgcc || options.untrustedWorkspace,
     logToConsole: options.logToConsole,
     includeAutomaticOptionalChainCompletions: options.includeAutomaticOptionalChainCompletions,
     includeCompletionsWithSnippetText: options.includeCompletionsWithSnippetText,
     forceStrictTemplates: isG3 || options.forceStrictTemplates,
+    untrustedWorkspace: options.untrustedWorkspace,
   });
 
   // Log initialization info


### PR DESCRIPTION
…limited'

The workspace trust guide for extension authors can be found here:
https://github.com/microsoft/vscode/issues/120251

Importantly the sectino for evaluating whether the extension should work
in an untrusted workspace asks "Does my extension treat any contents of the workspace as code?".
The answer to this is "yes" for the extension because we execute `ngcc`
from the `node_modules` folder. However, this isn't always necessary and
becomes less so with time. As library authors publish their libraries
with Ivy instructions, we will not need to run `ngcc`.

This commit updates the workspace trust to indicate that it's 'limited'
support due to `ngcc`. In addition the command to run `ngcc` is disabled
on the server and removed from the command palette.