### PR TITLE
feat(server): support code action

### DIFF
--- a/package.json
+++ b/package.json
@@ -216,7 +216,7 @@
     "test:syntaxes": "yarn compile:syntaxes-test && yarn build:syntaxes && jasmine dist/syntaxes/test/driver.js"
   },
   "dependencies": {
-    "@angular/language-service": "14.1.0",
+    "@angular/language-service": "14.2.0-next.0",
     "typescript": "4.7.4",
     "vscode-jsonrpc": "6.0.0",
     "vscode-languageclient": "7.0.0",

--- a/server/package.json
+++ b/server/package.json
@@ -15,7 +15,7 @@
     "ngserver": "./bin/ngserver"
   },
   "dependencies": {
-    "@angular/language-service": "14.1.0",
+    "@angular/language-service": "14.2.0-next.0",
     "vscode-jsonrpc": "6.0.0",
     "vscode-languageserver": "7.0.0",
     "vscode-uri": "3.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -158,10 +158,10 @@
     uuid "^8.3.2"
     yargs "^17.0.0"
 
-"@angular/language-service@14.1.0":
-  version "14.1.0"
-  resolved "https://registry.yarnpkg.com/@angular/language-service/-/language-service-14.1.0.tgz#e5ca5f948d1930ebd5791795c983dd0887d0fd63"
-  integrity sha512-ldL4xMDjXYZ93FCEIBVGipx9Qfgr7NuBNO+e25d+nWikXrUOnLfvF4UOL/TSUwSwqN4jxDI2KMNQIF6SecZfvQ==
+"@angular/language-service@14.2.0-next.0":
+  version "14.2.0-next.0"
+  resolved "https://registry.yarnpkg.com/@angular/language-service/-/language-service-14.2.0-next.0.tgz#f1e60f00c5cbcd0b88b563837dfd01332b7d611f"
+  integrity sha512-Uj2XGSS6Z7wb6zuZ39uaXxwlXNTN+ByhUr5qJ8Ya4GkxjKJLN1uQDvFhjGIwMyG75q2Wv4GOIGeGo+0Gts2b6A==
 
 "@assemblyscript/loader@^0.10.1":
   version "0.10.1"


### PR DESCRIPTION
In ts service, the
`codeFixes`([getCodeFixesAtPosition](https://github.com/microsoft/TypeScript/blob/7584e6aad6b21f7334562bfd9d8c3c80aafed064/src/services/services.ts#L2689))
and
refactors([getApplicableRefactors](https://github.com/microsoft/TypeScript/blob/7584e6aad6b21f7334562bfd9d8c3c80aafed064/src/services/services.ts#L2699))
are resolved in different request. But in LSP they are resolved in the `CodeAction` request.
Now, this PR only handles the `codeFixes` because the `@angular/language-service` only supports it.
