### PR TITLE
build: fix dev bundle location after updating source paths

### DIFF
--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -482,7 +482,7 @@ function getServerOptions(ctx: vscode.ExtensionContext, debug: boolean): lsp.Nod
   // Node module for the language server
   const args = constructArgs(ctx, viewEngine, vscode.workspace.isTrusted);
   const prodBundle = ctx.asAbsolutePath('server');
-  const devBundle = ctx.asAbsolutePath(path.join('dist', 'server', 'server.js'));
+  const devBundle = ctx.asAbsolutePath(path.join('dist', 'server', 'src', 'server.js'));
   // VS Code Insider launches extensions in debug mode by default but users
   // install prod bundle so we have to check whether dev bundle exists.
   const latestServerModule = debug && fs.existsSync(devBundle) ? devBundle : prodBundle;


### PR DESCRIPTION
The dev bundle mapping was broken in
https://github.com/angular/vscode-ng-language-service/commit/69fad33204474930d0fa867c5e23c82041a91dc6
but is trivially fixed with this update.