### PR TITLE
test: fix jasmine spec_files paths after updating source paths

### DIFF
--- a/jasmine.json
+++ b/jasmine.json
@@ -1,8 +1,8 @@
 {
   "spec_dir": "dist",
   "spec_files": [
-    "client/tests/*_spec.js",
+    "client/src/tests/*_spec.js",
     "common/tests/*_spec.js",
-    "server/tests/*_spec.js"
+    "server/src/tests/*_spec.js"
   ]
 }

--- a/server/src/tests/ngcc_spec.ts
+++ b/server/src/tests/ngcc_spec.ts
@@ -14,7 +14,7 @@ import {takeUntil} from 'rxjs/operators';
 
 import {resolveAndRunNgcc} from '../ngcc';
 
-const PACKAGE_ROOT = resolve(__dirname, '../../..');
+const PACKAGE_ROOT = resolve(__dirname, '../../../..');
 const WORKSPACE_ROOT = join(PACKAGE_ROOT, 'integration', 'workspace');
 const PROJECT = join(WORKSPACE_ROOT, 'projects', 'demo');
 const PRE_APF_PROJECT = join(PACKAGE_ROOT, 'integration', 'pre_apf_project');


### PR DESCRIPTION
The jasmine spec paths were broken in
https://github.com/angular/vscode-ng-language-service/commit/69fad33204474930d0fa867c5e23c82041a91dc6
but is trivially fixed with this update.