### PR TITLE
fix: support deeply nested pnpm virtual store node_modules paths in resolveAndRunNgcc

### DIFF
--- a/server/src/ngcc.ts
+++ b/server/src/ngcc.ts
@@ -27,7 +27,7 @@ export async function resolveAndRunNgcc(tsconfig: string, progress: Progress): P
   if (!ngcc) {
     throw new Error(`Failed to resolve ngcc from ${directory}`);
   }
-  const index = ngcc.resolvedPath.lastIndexOf('node_modules');
+  const index = ngcc.resolvedPath.indexOf('node_modules');
   // By default, ngcc assumes the node_modules directory that it needs to process
   // is in the cwd. In our case, we should set cwd to the directory where ngcc
   // is resolved to, not the directory where tsconfig.json is located. See


### PR DESCRIPTION
Uses indexOf instead of lastIndexOf in resolveAndRunNgcc.

This resolves the case where a user is using pnpm and ngcc is resolved through symlinks to a deeply nested virtual store node_modules location:

`some/user/path/node_modules/.pnpm/@angular/compiler-cli@1.2.3/node_modules/@angular/compiler-cli/...`

lastIndexOf would resolve to `some/user/path/node_modules/.pnpm/@angular/compiler-cli@1.2.3` which is incorrect. indexOf gets you to the desired `some/user/path`