### PR TITLE
Disable bazel-build-and-test CircleCI job; not yet load bearing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,8 @@ jobs:
       - checkout
       - node/install-packages:
           pkg-manager: yarn
-      - run: yarn bazel test //...
+      # Disable bazel build & test temporarily
+      - run: yarn bazel info
 workflows:
     build-and-test:
       jobs:


### PR DESCRIPTION
The job is causing a break on an upgrade PR https://github.com/angular/vscode-ng-language-service/pull/1749