### PR TITLE
build: update build.sh script for bazel

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -30,17 +30,9 @@ fi
 
 set -ex -o pipefail
 
-# Clean up from last build
-rm -rf dist
-
 # Run legacy yarn install to update the lock file since we may have modified the package.json above
 # and so that we can call bazel via yarn bazel
 yarn install
 
 # Build the npm package with bazel
 yarn bazel build //:npm --config=release
-
-# Copy the bazel built package to dist/npm
-mkdir -p dist/npm
-cp -r bazel-bin/npm/ dist/npm
-chmod -R +w dist/npm


### PR DESCRIPTION
There is no reason to copy files to the dist folder anymore with bazel. Update the build.sh to clean up previous builds by running 'bazel clean'.