### PR TITLE
build: do not manage package version in Starlark file

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,3 +1,7 @@
+# Release configuration
+build:release --workspace_status_command="yarn -s ng-dev release build-env-stamp --mode=release"
+build:release --stamp
+
 # ======================================================================================================================
 # Support for debugging Node.js tests
 # Use `--config=debug` to enable these settings

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -4,7 +4,6 @@ load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@aspect_rules_ts//ts:defs.bzl", "ts_config")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:vsce/package_json.bzl", vsce_bin = "bin")
-load(":version.bzl", "VERSION")
 
 npm_link_all_packages(name = "node_modules")
 
@@ -17,17 +16,19 @@ js_library(
 ts_config(
     name = "tsconfig",
     src = "tsconfig.json",
-    visibility = ["//visibility:public"]
+    visibility = ["//visibility:public"],
 )
 
 expand_template(
     name = "package_json_expanded",
-    template = "package.json",
     out = "package_expanded.json",
+    stamp_substitutions = {
+        "0.0.0-PLACEHOLDER": "{{BUILD_SCM_VERSION}}",
+    },
     substitutions = {
-        "0.0.0-PLACEHOLDER": VERSION,
         "./dist/client/src/extension": "./index",
-    }
+    },
+    template = "package.json",
 )
 
 npm_package(
@@ -62,12 +63,12 @@ npm_package(
         ":node_modules/vscode-uri",
         ":node_modules/yallist",
     ],
-    include_srcs_packages = [
-        "**",
-    ],
     exclude_srcs_patterns = [
         "*.map",
         "**/*.map",
+    ],
+    include_srcs_packages = [
+        "**",
     ],
     replace_prefixes = {
         "package_expanded.json": "package.json",
@@ -82,13 +83,13 @@ vsce_bin.vsce(
     srcs = [
         ":vsix_sandbox",
     ],
-    outs = ["ng-template-{}.vsix".format(VERSION)],
-    chdir = "vsix_sandbox",
+    outs = ["ng-template.vsix"],
     args = [
         "package",
         "-o",
-        "../ng-template-{}.vsix".format(VERSION)
+        "../ng-template.vsix",
     ],
+    chdir = "vsix_sandbox",
     # vsce requires npm on the PATH; we can get this from the Bazel rules_nodejs but it is not
     # included by default in rules_js binary rules so we include it here explicitly
     include_npm = True,
@@ -97,11 +98,11 @@ vsce_bin.vsce(
 npm_package(
     name = "npm",
     srcs = [
-        ":vsix_sandbox",
         ":vsix",
+        ":vsix_sandbox",
     ],
     root_paths = [
-        "vsix_sandbox"
+        "vsix_sandbox",
     ],
     visibility = ["//integration:__subpackages__"],
 )

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ng-template",
   "displayName": "Angular Language Service",
   "description": "Editor services for Angular templates",
-  "version": "0.0.0-PLACEHOLDER",
+  "version": "14.2.0",
   "publisher": "Angular",
   "icon": "angular.png",
   "license": "MIT",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -38,7 +38,7 @@ rm -rf dist
 yarn install
 
 # Build the npm package with bazel
-yarn bazel build //:npm
+yarn bazel build //:npm --config=release
 
 # Copy the bazel built package to dist/npm
 mkdir -p dist/npm

--- a/server/BUILD.bazel
+++ b/server/BUILD.bazel
@@ -1,53 +1,50 @@
 load("@aspect_rules_ts//ts:defs.bzl", "ts_config")
 load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
 load("@aspect_rules_js//js/private:expand_template.bzl", "expand_template")
-load("//:version.bzl", "VERSION")
 
 ts_config(
     name = "tsconfig",
     src = "tsconfig.json",
+    visibility = [
+        "//integration:__subpackages__",
+        "//server:__subpackages__",
+    ],
     deps = [
         "//:tsconfig",
         "//common:tsconfig",
     ],
-    visibility = [
-        "//server:__subpackages__",
-        "//integration:__subpackages__",
-    ]
 )
 
 esbuild(
     name = "banner",
-    entry_point = "//server/src:banner.js",
-    data = ["//server/src"],
-    platform = "node",
-    format = "cjs",
-    sourcemap = "external",
-    external = [
-        "path",
-    ],
     config = {
         # This is described in more detail in the `server/banner.ts` but this line actually overrides
         # the built-in `require` function by adding a line at the bottom of the generated banner code
         # to assign the override function to the `require` name.
-        "footer": { "js": "require = requireOverride;" },
+        "footer": {"js": "require = requireOverride;"},
         # Workaround for https://github.com/aspect-build/rules_esbuild/issues/58
         "resolveExtensions": [".js"],
     },
+    data = ["//server/src"],
+    entry_point = "//server/src:banner.js",
+    external = [
+        "path",
+    ],
+    format = "cjs",
     # Do not enable minification. It seems to break the extension on Windows (with WSL). See #1198.
     minify = False,
+    platform = "node",
+    sourcemap = "external",
 )
 
 esbuild(
     name = "index",
-    entry_point = "//server/src:server.js",
     srcs = [
-        "//server/src",
         ":banner.js",
+        "//server/src",
     ],
-    platform = "node",
-    format = "cjs",
-    sourcemap = "external",
+    config = "esbuild.mjs",
+    entry_point = "//server/src:server.js",
     external = [
         "fs",
         "path",
@@ -58,30 +55,32 @@ esbuild(
         "vscode-languageserver-textdocument",
         "vscode-html-languageservice",
     ],
-    config = "esbuild.mjs",
+    format = "cjs",
     # Do not enable minification. It seems to break the extension on Windows (with WSL). See #1198.
     minify = False,
+    platform = "node",
+    sourcemap = "external",
     visibility = [
         "//integration:__subpackages__",
-    ]
+    ],
 )
 
 expand_template(
     name = "package_json_expanded",
-    template = "package.json",
     out = "package_expanded.json",
-    substitutions = {
-        "0.0.0-PLACEHOLDER": VERSION,
-    }
+    stamp_substitutions = {
+        "0.0.0-PLACEHOLDER": "{{BUILD_SCM_VERSION}}",
+    },
+    template = "package.json",
 )
 
 filegroup(
     name = "npm_files",
     srcs = [
-        "package_expanded.json",
         "README.md",
-        "index.js",
         "bin/ngserver",
+        "index.js",
+        "package_expanded.json",
     ],
     visibility = ["//:__pkg__"],
 )

--- a/version.bzl
+++ b/version.bzl
@@ -1,2 +1,0 @@
-# This version is used by Bazel to generate the release artifacts
-VERSION="14.2.0"


### PR DESCRIPTION
The package/project version should be managed via the `package.json` file so that existing tooling like `yarn ng-dev` does not break with the recent Bazel migration. Tools like `ng-dev` expect a project version to be present in the top-level `package.json`. The current placeholder breaks the release and branching expectations.