### PR TITLE
testing: fix task endPattern for iBazel

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -30,7 +30,7 @@
         "background": {
           "activeOnStart": true,
           "beginsPattern": "^iBazel \\[\\d{1,2}:\\d{1,2}(?:AM|PM)\\]: Querying for files to watch.*",
-          "endsPattern": "^INFO: Build completed successfully, \\d total action(s)?"
+          "endsPattern": "^INFO: Build completed successfully, \\d+ total action(s)?"
         }
       }
     },


### PR DESCRIPTION
The task end pattern was only configured to support single digit tasks