### PR TITLE
fix: fix "install local @angular/language-service" workflow under Bazel build

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -56,6 +56,8 @@ build --enable_runfiles
 # Keep tests tagged "exclusive" in the sandbox
 test --incompatible_exclusive_test_sandboxed
 
+build --build_tests_only
+
 ###############################
 # Output                      #
 ###############################

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ dist/
 
 # bazel
 bazel-*
+.angular_packages

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -88,6 +88,7 @@ npm_translate_lock(
         "concat-map@0.0.1": [""],
         "balanced-match@1.0.0": [""],
     },
+    # PLACE_HOLDER_FOR_packages/language-service/build.sh_IN_angular_REPO
 )
 
 load("@npm//:repositories.bzl", "npm_repositories")


### PR DESCRIPTION
Part of fix for #1815.

This is safe to land before any of the other fixes required do as it doesn't change anything here. Fix won't be in effect until rules_js & angular PRs land and this repo is updated to a release of rules_js that includes the its fixes.

See issue for details.