### PR TITLE
build: remove build-tests-only flag

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -56,7 +56,7 @@ build --enable_runfiles
 # Keep tests tagged "exclusive" in the sandbox
 test --incompatible_exclusive_test_sandboxed
 
-build --build_tests_only
+build
 
 ###############################
 # Output                      #


### PR DESCRIPTION
Greg asked me to remove this flag from the bazelrc: it controls what gets built when you use the ... selector, but it over filtered from what was intended.