### PR TITLE
build: fix .bazelrc --build_test_only flag

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -56,7 +56,7 @@ build --enable_runfiles
 # Keep tests tagged "exclusive" in the sandbox
 test --incompatible_exclusive_test_sandboxed
 
-build --build_tests_only
+test --build_tests_only
 
 ###############################
 # Output                      #


### PR DESCRIPTION
This flag should only be set for the `bazel test` command