### PR TITLE
fix: add v12_language_service/node_modules to release package

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,4 +1,5 @@
 node_modules/
+v12_language_service/node_modules
 dist/
 integration/pre_apf_project/node_modules/
 integration/project/node_modules/

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -79,14 +79,15 @@ npm_translate_lock(
         # running `bazel build //:vsix` and burning down missing packages. We do this so that we
         # don't have to run an additional `npm install` action to create a node_modules within the
         # //:npm npm_package where the vsce build takes place.
-        "semver@7.3.7": [""],
-        "lru-cache@6.0.0": [""],
-        "yallist@4.0.0": [""],
-        "minimatch@3.1.2": [""],
-        "brace-expansion@1.1.11": [""],
-        "vscode-languageserver-types@3.16.0": [""],
-        "concat-map@0.0.1": [""],
         "balanced-match@1.0.0": [""],
+        "brace-expansion@1.1.11": [""],
+        "concat-map@0.0.1": [""],
+        "lru-cache@6.0.0": [""],
+        "minimatch@3.1.2": [""],
+        "semver@7.3.7": [""],
+        "vscode-languageserver-types@3.16.0": [""],
+        "vscode-nls@5.2.0": [""],
+        "yallist@4.0.0": [""],
     },
     # PLACE_HOLDER_FOR_packages/language-service/build.sh_IN_angular_REPO
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -73,6 +73,10 @@ npm_translate_lock(
     yarn_lock = "//:yarn.lock",
     package_json = "//:package.json",
     npmrc = "//:.npmrc",
+    data = [
+        "//:pnpm-workspace.yaml",
+        "//v12_language_service:package.json",
+    ],
     verify_node_modules_ignored = "//:.bazelignore",
     public_hoist_packages = {
         # Hoist transitive closure of npm deps needed for vsce; this set was determined manually by

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - v12_language_service

--- a/v12_language_service/BUILD.bazel
+++ b/v12_language_service/BUILD.bazel
@@ -1,8 +1,16 @@
+load("@npm//:defs.bzl", "npm_link_all_packages")
+
+npm_link_all_packages(name = "node_modules")
+
 filegroup(
     name = "npm_files",
     srcs = [
         "package.json",
         "yarn.lock",
+        # There are needed for backward compat with Angular v12.
+        # See https://github.com/angular/vscode-ng-language-service/issues/1821.
+        ":node_modules/@angular/language-service",
+        ":node_modules/@angular/language-server",
     ],
     visibility = ["//:__pkg__"],
 )


### PR DESCRIPTION
Stacked on top of https://github.com/angular/vscode-ng-language-service/pull/1825 which should land first