### PR TITLE
build: update angular/angular packages/language-service/build.sh placeholder

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -76,6 +76,7 @@ npm_translate_lock(
     data = [
         "//:pnpm-workspace.yaml",
         "//v12_language_service:package.json",
+        # PLACE_HOLDER_FOR_angular/angular_packages/language-service/build.sh
     ],
     verify_node_modules_ignored = "//:.bazelignore",
     public_hoist_packages = {


### PR DESCRIPTION
New token is within `data` now.

@dylhunn @atscott Adding a new token here so the old one still works until it is not needed anymore. Old one (`PLACE_HOLDER_FOR_packages/language-service/build.sh_IN_angular_REPO`) can be removed anytime if it is not needed.