### PR TITLE
fix(server): Fall back to bundled TS version if specified TSDK is too…

### DIFF
--- a/server/src/version_provider.ts
+++ b/server/src/version_provider.ts
@@ -51,8 +51,16 @@ export function resolveTsServer(probeLocations: string[]): NodeModule {
   if (probeLocations.length > 0) {
     // The first probe location is `typescript.tsdk` if it is specified.
     const resolvedFromTsdk = resolveTsServerFromTsdk(probeLocations[0], probeLocations.slice(1));
+    const minVersion = new Version(MIN_TS_VERSION);
     if (resolvedFromTsdk !== undefined) {
-      return resolvedFromTsdk;
+      if (resolvedFromTsdk.version.greaterThanOrEqual(minVersion)) {
+        return resolvedFromTsdk;
+      } else {
+        console.warn(`Ignoring TSDK version specified in the TypeScript extension options ${
+            resolvedFromTsdk
+                .version} because it is lower than the required TS version for the language service (${
+            MIN_TS_VERSION}).`);
+      }
     }
   }
   return resolveWithMinVersion(TSSERVERLIB, MIN_TS_VERSION, probeLocations, 'typescript');


### PR DESCRIPTION
… old

We attempt to use the version of typescript defined in the extension options. However, this might be too old for the required version in the bundled Angular compiler. If this happens, we now attempt to resolve the version from the bundled one instead (and print a warning to the output).

Fixes #1855