### PR TITLE
Respect the client capability "textDocument.definition.linkSupport."

### DIFF
--- a/integration/lsp/test_utils.ts
+++ b/integration/lsp/test_utils.ts
@@ -73,6 +73,8 @@ export function initializeServer(client: MessageConnection): Promise<lsp.Initial
           }
         },
         moniker: {},
+        definition: {linkSupport: true},
+        typeDefinition: {linkSupport: true}
       }
     },
     /**


### PR DESCRIPTION
If the client doesn't explicitly tells the server that they have this capability then a `Location` should be send instead of `LocationLink` as a reply to a "Goto Definition Request".

See the relevant documentation:
https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_definition

Closes #1874 