### PR TITLE
build: update translate lock action cache

### DIFF
--- a/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
+++ b/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
@@ -3,5 +3,5 @@
 .npmrc=974837034
 pnpm-lock.yaml=-1475648007
 yarn.lock=-146594567
-package.json=-487157359
+package.json=-168090251
 pnpm-workspace.yaml=1711114604


### PR DESCRIPTION
The `package.json` file was modified, so the action cache needs an update. This is done by `rules_js` so that it knows when to run `pnpm import` or not. This will be gone in the future when we use pnpm always.