### PR TITLE
fix: Exclude binding like text in templates

### DIFF
--- a/syntaxes/src/template.ts
+++ b/syntaxes/src/template.ts
@@ -36,7 +36,7 @@ export const Template: GrammarDefinition = {
     },
 
     propertyBinding: {
-      begin: /(\[\s*@?[-_a-zA-Z0-9.$]*%?\s*])(=)(["'])/,
+      begin: /(?<!\>)(\[\s*@?[-_a-zA-Z0-9.$]*%?\s*])(=)(["'])/,
       beginCaptures: {
         1: {
           name: 'entity.other.attribute-name.html entity.other.ng-binding-name.property.html',

--- a/syntaxes/template.json
+++ b/syntaxes/template.json
@@ -40,7 +40,7 @@
       ]
     },
     "propertyBinding": {
-      "begin": "(\\[\\s*@?[-_a-zA-Z0-9.$]*%?\\s*])(=)([\"'])",
+      "begin": "(?<!\\>)(\\[\\s*@?[-_a-zA-Z0-9.$]*%?\\s*])(=)([\"'])",
       "beginCaptures": {
         "1": {
           "name": "entity.other.attribute-name.html entity.other.ng-binding-name.property.html",

--- a/syntaxes/test/data/template.html
+++ b/syntaxes/test/data/template.html
@@ -16,6 +16,7 @@
 <div [myProperty$]="val"></div>
 <div [%invalidProperty]="val"></div>
 <div [invalidProperty)="val"></div>
+<div>[my-property]="val"</div>
 
 <!-- Event binding test -->
 <button (click)="onClick($event)"></button>

--- a/syntaxes/test/data/template.html.snap
+++ b/syntaxes/test/data/template.html.snap
@@ -149,6 +149,8 @@
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.ng
 ><div [invalidProperty)="val"></div>
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.ng
+><div>[my-property]="val"</div>
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.ng
 >
 ><!-- Event binding test -->
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.ng


### PR DESCRIPTION
I wanted to give a try to improve the behaviour reported in the 2 tickets below. Let me know what you think of it ! 

With a negative lookbehind we can exclude binding like text (ie `<div>[myInput]=myvar</div>`) from the synthax coloring of bindings

Fixes #1725 and angular/angular#49842