### PR TITLE
fix: support to show the tag info in the jsDoc

### DIFF
--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -59,6 +59,9 @@ export class AngularLanguageClient implements vscode.Disposable {
       // Don't let our output console pop open
       revealOutputChannelOn: lsp.RevealOutputChannelOn.Never,
       outputChannel: this.outputChannel,
+      markdown: {
+        isTrusted: true,
+      },
       middleware: {
         provideCodeActions: async (
             document: vscode.TextDocument, range: vscode.Range, context: vscode.CodeActionContext,

--- a/common/initialize.ts
+++ b/common/initialize.ts
@@ -9,3 +9,13 @@
 export interface ServerOptions {
   logFile?: string;
 }
+
+export interface OpenJsDocLinkCommand_Args {
+  readonly file: string;
+  readonly position?: {
+    start: {character: number; line: number;},
+    end: {character: number; line: number;},
+  };
+}
+
+export const OpenJsDocLinkCommandId = 'angular.openJsDocLink';

--- a/server/src/tests/text_render_spec.ts
+++ b/server/src/tests/text_render_spec.ts
@@ -1,0 +1,196 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as tss from 'typescript/lib/tsserverlibrary';
+
+import {asPlainTextWithLinks, documentationToMarkdown, tagsToMarkdown} from '../text_render';
+
+
+describe('typescript.previewer', () => {
+  it('Should ignore hyphens after a param tag', () => {
+    expect(
+        tagsToMarkdown([{name: 'param', text: [{kind: 'text', text: 'a - b'}]}], () => undefined))
+        .toBe('*@param* `a` — b');
+  });
+
+  it('Should parse url jsdoc @link', () => {
+    expect(documentationToMarkdown(
+               [
+                 {'text': 'x ', 'kind': 'text'}, {'text': '{@link ', 'kind': 'link'},
+                 {'text': 'http://www.example.com/foo', 'kind': 'linkText'},
+                 {'text': '}', 'kind': 'link'}, {'text': ' y ', 'kind': 'text'},
+                 {'text': '{@link ', 'kind': 'link'}, {
+                   'text': 'https://api.jquery.com/bind/#bind-eventType-eventData-handler',
+                   'kind': 'linkText'
+                 },
+                 {'text': '}', 'kind': 'link'}, {'text': ' z', 'kind': 'text'}
+               ],
+               [], () => undefined))
+        .toEqual([
+          'x http://www.example.com/foo y https://api.jquery.com/bind/#bind-eventType-eventData-handler z'
+        ]);
+  });
+
+  it('Should parse url jsdoc @link with text', () => {
+    expect(documentationToMarkdown(
+               [
+                 {'text': 'x ', 'kind': 'text'}, {'text': '{@link ', 'kind': 'link'},
+                 {'text': 'http://www.example.com/foo abc xyz', 'kind': 'linkText'},
+                 {'text': '}', 'kind': 'link'}, {'text': ' y ', 'kind': 'text'},
+                 {'text': '{@link ', 'kind': 'link'},
+                 {'text': 'http://www.example.com/bar|b a z', 'kind': 'linkText'},
+                 {'text': '}', 'kind': 'link'}, {'text': ' z', 'kind': 'text'}
+               ],
+               [], () => undefined))
+        .toEqual(
+            ['x [abc xyz](http://www.example.com/foo) y [a z](http://www.example.com/bar|b) z']);
+  });
+
+  it('Should treat @linkcode jsdocs links as monospace', () => {
+    expect(documentationToMarkdown(
+               [
+                 {'text': 'x ', 'kind': 'text'}, {'text': '{@linkcode ', 'kind': 'link'},
+                 {'text': 'http://www.example.com/foo', 'kind': 'linkText'},
+                 {'text': '}', 'kind': 'link'}, {'text': ' y ', 'kind': 'text'},
+                 {'text': '{@linkplain ', 'kind': 'link'},
+                 {'text': 'http://www.example.com/bar', 'kind': 'linkText'},
+                 {'text': '}', 'kind': 'link'}, {'text': ' z', 'kind': 'text'}
+               ],
+               [], () => undefined))
+        .toEqual(['x http://www.example.com/foo y http://www.example.com/bar z']);
+  });
+
+  it('Should parse url jsdoc @link in param tag', () => {
+    expect(
+        tagsToMarkdown(
+            [{
+              name: 'param',
+              text: [{
+                kind: 'text',
+                text:
+                    'a x {@link http://www.example.com/foo abc xyz} y {@link http://www.example.com/bar|b a z} z'
+              }]
+
+            }],
+            () => undefined))
+        .toBe(
+            '*@param* `a` — x [abc xyz](http://www.example.com/foo) y [b a z](http://www.example.com/bar) z');
+  });
+
+  it('Should ignore unclosed jsdocs @link', () => {
+    expect(documentationToMarkdown(
+               [
+                 {'text': 'x ', 'kind': 'text'}, {'text': '{@link ', 'kind': 'link'}, {
+                   'text': 'http://www.example.com/foo y {@link http://www.example.com/bar bar',
+                   'kind': 'linkText'
+                 },
+                 {'text': '}', 'kind': 'link'}, {'text': ' z', 'kind': 'text'}
+               ],
+               [], () => undefined))
+        .toEqual(['x [y {@link http://www.example.com/bar bar](http://www.example.com/foo) z']);
+  });
+
+  it('Should support non-ascii characters in parameter name (#90108)', () => {
+    expect(
+        tagsToMarkdown(
+            [
+              {name: 'param', text: [{kind: 'text', text: 'parámetroConDiacríticos this will not'}]}
+            ],
+            () => undefined))
+        .toBe('*@param* `parámetroConDiacríticos` — this will not');
+  });
+
+  it('Should render @example blocks as code', () => {
+    expect(tagsToMarkdown(
+               [{name: 'example', text: [{kind: 'text', text: 'code();'}]}], () => undefined))
+        .toBe('*@example*  \n```\ncode();\n```');
+  });
+
+  it('Should not render @example blocks as code as if they contain a codeblock', () => {
+    expect(tagsToMarkdown(
+               [{name: 'example', text: [{kind: 'text', text: 'Not code\n```\ncode();\n```'}]}],
+               () => undefined))
+        .toBe('*@example*  \nNot code\n```\ncode();\n```');
+  });
+
+  it('Should render @example blocks as code if they contain a <caption>', () => {
+    expect(tagsToMarkdown(
+               [{
+                 name: 'example',
+                 text: [{
+                   kind: 'text',
+                   text: '<caption>Not code</caption>\ncode();',
+                 }]
+               }],
+               () => undefined))
+        .toBe('*@example*  \nNot code\n```\ncode();\n```');
+  });
+
+  it('Should not render @example blocks as code if they contain a <caption> and a codeblock',
+     () => {
+       expect(tagsToMarkdown(
+                  [{
+                    name: 'example',
+                    text: [{kind: 'text', text: '<caption>Not code</caption>\n```\ncode();\n```'}]
+                  }],
+                  () => undefined))
+           .toBe('*@example*  \nNot code\n```\ncode();\n```');
+     });
+
+  it('Should not render @link inside of @example #187768', () => {
+    expect(tagsToMarkdown(
+               [{
+                 'name': 'example',
+                 'text': [
+                   {'text': '1 + 1 ', 'kind': 'text'}, {'text': '{@link ', 'kind': 'link'},
+                   {'text': 'foo', 'kind': 'linkName'}, {'text': '}', 'kind': 'link'}
+                 ]
+               }],
+               () => undefined))
+        .toBe('*@example*  \n```\n1 + 1 {@link foo}\n```');
+  });
+
+  it('Should render @linkcode symbol name as code', () => {
+    expect(asPlainTextWithLinks(
+               [
+                 {'text': 'a ', 'kind': 'text'}, {'text': '{@linkcode ', 'kind': 'link'}, {
+                   'text': 'dog',
+                   'kind': 'linkName',
+                   'target': {
+                     'fileName': '/path/file.ts',
+                     'start': {'line': 7, 'offset': 5},
+                     'end': {'line': 7, 'offset': 13}
+                   }
+                 } as tss.SymbolDisplayPart,
+                 {'text': '}', 'kind': 'link'}, {'text': ' b', 'kind': 'text'}
+               ],
+               () => undefined))
+        .toBe(
+            'a [`dog`](command:angular.openJsDocLink?%7B%22file%22%3A%22%2Fpath%2Ffile.ts%22%7D) b');
+  });
+
+  it('Should render @linkcode text as code', () => {
+    expect(asPlainTextWithLinks(
+               [
+                 {'text': 'a ', 'kind': 'text'}, {'text': '{@linkcode ', 'kind': 'link'}, {
+                   'text': 'dog',
+                   'kind': 'linkName',
+                   'target': {
+                     'fileName': '/path/file.ts',
+                     'start': {'line': 7, 'offset': 5},
+                     'end': {'line': 7, 'offset': 13}
+                   }
+                 } as tss.SymbolDisplayPart,
+                 {'text': 'husky', 'kind': 'linkText'}, {'text': '}', 'kind': 'link'},
+                 {'text': ' b', 'kind': 'text'}
+               ],
+               () => undefined))
+        .toBe(
+            'a [`husky`](command:angular.openJsDocLink?%7B%22file%22%3A%22%2Fpath%2Ffile.ts%22%7D) b');
+  });
+});

--- a/server/src/text_render.ts
+++ b/server/src/text_render.ts
@@ -1,0 +1,273 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as tss from 'typescript/lib/tsserverlibrary';
+
+import {OpenJsDocLinkCommand_Args, OpenJsDocLinkCommandId} from '../../common/initialize';
+
+import {tsTextSpanToLspRange} from './utils';
+
+function replaceLinks(text: string): string {
+  return text
+      // Http(s) links
+      .replace(
+          /\{@(link|linkplain|linkcode) (https?:\/\/[^ |}]+?)(?:[| ]([^{}\n]+?))?\}/gi,
+          (_, tag: string, link: string, text?: string) => {
+            switch (tag) {
+              case 'linkcode':
+                return `[\`${text ? text.trim() : link}\`](${link})`;
+
+              default:
+                return `[${text ? text.trim() : link}](${link})`;
+            }
+          });
+}
+
+function processInlineTags(text: string): string {
+  return replaceLinks(text);
+}
+
+function getTagBodyText(
+    tag: tss.JSDocTagInfo,
+    getScriptInfo: (fileName: string) => tss.server.ScriptInfo | undefined): string|undefined {
+  if (!tag.text) {
+    return undefined;
+  }
+
+  // Convert to markdown code block if it does not already contain one
+  function makeCodeblock(text: string): string {
+    if (/^\s*[~`]{3}/m.test(text)) {
+      return text;
+    }
+    return '```\n' + text + '\n```';
+  }
+
+  let text = convertLinkTags(tag.text, getScriptInfo);
+  switch (tag.name) {
+    case 'example': {
+      // Example text does not support `{@link}` as it is considered code.
+      // TODO: should we support it if it appears outside of an explicit code block?
+      text = asPlainText(tag.text);
+
+      // check for caption tags, fix for #79704
+      const captionTagMatches = text.match(/<caption>(.*?)<\/caption>\s*(\r\n|\n)/);
+      if (captionTagMatches && captionTagMatches.index === 0) {
+        return captionTagMatches[1] + '\n' +
+            makeCodeblock(text.substr(captionTagMatches[0].length));
+      } else {
+        return makeCodeblock(text);
+      }
+    }
+    case 'author': {
+      // fix obsucated email address, #80898
+      const emailMatch = text.match(/(.+)\s<([-.\w]+@[-.\w]+)>/);
+
+      if (emailMatch === null) {
+        return text;
+      } else {
+        return `${emailMatch[1]} ${emailMatch[2]}`;
+      }
+    }
+    case 'default':
+      return makeCodeblock(text);
+  }
+
+  return processInlineTags(text);
+}
+
+function getTagDocumentation(
+    tag: tss.JSDocTagInfo,
+    getScriptInfo: (fileName: string) => tss.server.ScriptInfo | undefined): string|undefined {
+  switch (tag.name) {
+    case 'augments':
+    case 'extends':
+    case 'param':
+    case 'template': {
+      const body = getTagBody(tag, getScriptInfo);
+      if (body?.length === 3) {
+        const param = body[1];
+        const doc = body[2];
+        const label = `*@${tag.name}* \`${param}\``;
+        if (!doc) {
+          return label;
+        }
+        return label +
+            (doc.match(/\r\n|\n/g) ? '  \n' + processInlineTags(doc) :
+                                     ` \u2014 ${processInlineTags(doc)}`);
+      }
+      break;
+    }
+
+    case 'return':
+    case 'returns': {
+      // For return(s), we require a non-empty body
+      if (!tag.text?.length) {
+        return undefined;
+      }
+
+      break;
+    }
+  }
+
+
+  // Generic tag
+  const label = `*@${tag.name}*`;
+  const text = getTagBodyText(tag, getScriptInfo);
+  if (!text) {
+    return label;
+  }
+  return label + (text.match(/\r\n|\n/g) ? '  \n' + text : ` \u2014 ${text}`);
+}
+
+function getTagBody(
+    tag: tss.JSDocTagInfo, getScriptInfo: (fileName: string) => tss.server.ScriptInfo | undefined):
+    Array<string>|undefined {
+  if (tag.name === 'template') {
+    const parts = tag.text;
+    if (parts && typeof (parts) !== 'string') {
+      const params = parts.filter(p => p.kind === 'typeParameterName').map(p => p.text).join(', ');
+      const docs = parts.filter(p => p.kind === 'text')
+                       .map(p => convertLinkTags(p.text.replace(/^\s*-?\s*/, ''), getScriptInfo))
+                       .join(' ');
+      return params ? ['', params, docs] : undefined;
+    }
+  }
+  return (convertLinkTags(tag.text, getScriptInfo)).split(/^(\S+)\s*-?\s*/);
+}
+
+function asPlainText(parts: readonly tss.SymbolDisplayPart[]|string): string {
+  if (typeof parts === 'string') {
+    return parts;
+  }
+  return parts.map(part => part.text).join('');
+}
+
+export function asPlainTextWithLinks(
+    documentation: tss.SymbolDisplayPart[]|undefined,
+    getScriptInfo: (fileName: string) => tss.server.ScriptInfo | undefined): string {
+  return processInlineTags(convertLinkTags(documentation, getScriptInfo));
+}
+
+/**
+ * Convert `@link` inline tags to markdown links
+ */
+function convertLinkTags(
+    documentation: tss.SymbolDisplayPart[]|undefined|string,
+    getScriptInfo: (fileName: string) => tss.server.ScriptInfo | undefined): string {
+  if (!documentation) {
+    return '';
+  }
+
+  if (typeof documentation === 'string') {
+    return documentation;
+  }
+
+  const out: string[] = [];
+
+  let currentLink:
+      {name?: string; target?: tss.DocumentSpan; text?: string; readonly linkcode: boolean}|
+      undefined;
+  for (const part of documentation) {
+    switch (part.kind) {
+      case 'link':
+        if (currentLink) {
+          if (currentLink.target) {
+            const scriptInfo = getScriptInfo(currentLink.target.fileName);
+            const args: OpenJsDocLinkCommand_Args = {
+              file:
+                  currentLink.target.fileName,  // Prevent VS Code from trying to transform the uri,
+              position: scriptInfo ? tsTextSpanToLspRange(scriptInfo, currentLink.target.textSpan) :
+                                     undefined,
+            };
+            const command =
+                `command:${OpenJsDocLinkCommandId}?${encodeURIComponent(JSON.stringify(args))}`;
+
+            const linkText = currentLink.text ?
+                currentLink.text :
+                escapeMarkdownSyntaxTokensForCode(currentLink.name ?? '');
+            out.push(`[${currentLink.linkcode ? '`' + linkText + '`' : linkText}](${command})`);
+          } else {
+            const text = currentLink.text ?? currentLink.name;
+            if (text) {
+              if (/^https?:/.test(text)) {
+                const parts = text.split(' ');
+                if (parts.length === 1) {
+                  out.push(parts[0]);
+                } else if (parts.length > 1) {
+                  const linkText = escapeMarkdownSyntaxTokensForCode(parts.slice(1).join(' '));
+                  out.push(
+                      `[${currentLink.linkcode ? '`' + linkText + '`' : linkText}](${parts[0]})`);
+                }
+              } else {
+                out.push(escapeMarkdownSyntaxTokensForCode(text));
+              }
+            }
+          }
+          currentLink = undefined;
+        } else {
+          currentLink = {linkcode: part.text === '{@linkcode '};
+        }
+        break;
+
+      case 'linkName':
+        if (currentLink) {
+          currentLink.name = part.text;
+          currentLink.target = (part as tss.JSDocLinkDisplayPart).target;
+        }
+        break;
+
+      case 'linkText':
+        if (currentLink) {
+          currentLink.text = part.text;
+        }
+        break;
+
+      default:
+        out.push(part.text);
+        break;
+    }
+  }
+  return processInlineTags(out.join(''));
+}
+
+function escapeMarkdownSyntaxTokensForCode(text: string): string {
+  return text.replace(/`/g, '\\$&');  // CodeQL [SM02383] This is only meant to escape backticks.
+                                      // The Markdown is fully sanitized after being rendered.
+}
+
+export function tagsToMarkdown(
+    tags: tss.JSDocTagInfo[],
+    getScriptInfo: (fileName: string) => tss.server.ScriptInfo | undefined): string {
+  return tags.map(tag => getTagDocumentation(tag, getScriptInfo)).join('  \n\n');
+}
+
+export function documentationToMarkdown(
+    documentation: tss.SymbolDisplayPart[]|undefined, tags: tss.JSDocTagInfo[]|undefined,
+    getScriptInfo: (fileName: string) => tss.server.ScriptInfo | undefined): string[] {
+  const out: string[] = [];
+  appendDocumentationAsMarkdown(out, documentation, tags, getScriptInfo);
+  return out;
+}
+
+function appendDocumentationAsMarkdown(
+    out: string[], documentation: tss.SymbolDisplayPart[]|undefined,
+    tags: tss.JSDocTagInfo[]|undefined,
+    getScriptInfo: (fileName: string) => tss.server.ScriptInfo | undefined): string[] {
+  if (documentation) {
+    out.push(asPlainTextWithLinks(documentation, getScriptInfo));
+  }
+
+  if (tags) {
+    const tagsPreview = tagsToMarkdown(tags, getScriptInfo);
+    if (tagsPreview) {
+      out.push('\n\n' + tagsPreview);
+    }
+  }
+
+  return out;
+}


### PR DESCRIPTION
https://github.com/microsoft/vscode/blob/18136ed6ec4bfabc58664c8b656839709ea997e8/extensions/typescript-language-features/src/languageFeatures/util/textRendering.ts

https://github.com/microsoft/vscode/blob/18136ed6ec4bfabc58664c8b656839709ea997e8/extensions/typescript-language-features/src/test/unit/textRendering.test.ts

The code is copied from the VSCode extension. The difference is that the code runs in the server in the Angular extension, and runs in the client in the VSCode extension

Fixes https://github.com/angular/vscode-ng-language-service/issues/1902

cc @dylhunn 