### PR TITLE
refactor(server): Remove references to Ivy and improve help message docs 

### DIFF
--- a/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
+++ b/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
@@ -3,5 +3,5 @@
 .npmrc=974837034
 pnpm-lock.yaml=-997189543
 yarn.lock=812186388
-package.json=482498770
+package.json=2022241265
 pnpm-workspace.yaml=1711114604

--- a/package.json
+++ b/package.json
@@ -124,12 +124,12 @@
         "angular.suggest.includeAutomaticOptionalChainCompletions": {
           "type": "boolean",
           "default": true,
-          "markdownDescription": "Enable/disable showing completions on potentially undefined values that insert an optional chain call. Requires TS 3.7+, strict null checks to be enabled and the `legacy View Engine` option to be disabled."
+          "markdownDescription": "Enable/disable showing completions on potentially undefined values that insert an optional chain call. Requires TS 3.7+ and strict null checks to be enabled."
         },
         "angular.suggest.includeCompletionsWithSnippetText": {
           "type": "boolean",
           "default": true,
-          "markdownDescription": "Enable/disable snippet completions from Angular language server. Requires using TypeScript 4.3+ in the workspace and the `legacy View Engine` option to be disabled."
+          "markdownDescription": "Enable/disable snippet completions from Angular language server. Requires using TypeScript 4.3+ in the workspace."
         },
         "angular.forceStrictTemplates": {
           "type": "boolean",

--- a/server/src/cmdline_utils.ts
+++ b/server/src/cmdline_utils.ts
@@ -28,10 +28,6 @@ function hasArgument(argv: string[], argName: string): boolean {
 
 interface CommandLineOptions {
   help: boolean;
-  /**
-   * If true, use Ivy LS, otherwise use legacy View Engine LS.
-   */
-  ivy: boolean;
   logFile?: string;
   logVerbosity?: string;
   logToConsole: boolean;
@@ -45,7 +41,6 @@ interface CommandLineOptions {
 export function parseCommandLine(argv: string[]): CommandLineOptions {
   return {
     help: hasArgument(argv, '--help'),
-    ivy: !hasArgument(argv, '--viewEngine'),
     logFile: findArgument(argv, '--logFile'),
     logVerbosity: findArgument(argv, '--logVerbosity'),
     logToConsole: hasArgument(argv, '--logToConsole'),
@@ -65,12 +60,14 @@ export function generateHelpMessage(argv: string[]) {
 
   Options:
     --help: Prints help message.
-    --viewEngine: Use legacy View Engine language service. Defaults to false.
     --logFile: Location to log messages. Logging to file is disabled if not provided.
     --logVerbosity: terse|normal|verbose|requestTime. See ts.server.LogLevel.
     --logToConsole: Enables logging to console via 'window/logMessage'. Defaults to false.
     --ngProbeLocations: Path of @angular/language-service. Required.
     --tsProbeLocations: Path of typescript. Required.
+    --includeAutomaticOptionalChainCompletions: Shows completions on potentially undefined values that insert an optional chain call. Requires TS 3.7+ and strict null checks to be enabled.
+    --includeCompletionsWithSnippetText: Enables snippet completions from Angular language server;
+    --forceStrictTemplates: Forces the language service to use strictTemplates and ignore the user settings in the 'tsconfig.json'.
 
   Additional options supported by vscode-languageserver:
     --clientProcessId=<number>: Automatically kills the server if the client process dies.

--- a/server/src/completion.ts
+++ b/server/src/completion.ts
@@ -104,7 +104,7 @@ function ngCompletionKindToLspCompletionItemKind(kind: CompletionKind): lsp.Comp
  */
 export function tsCompletionEntryToLspCompletionItem(
     entry: ts.CompletionEntry, position: lsp.Position, scriptInfo: ts.server.ScriptInfo,
-    insertReplaceSupport: boolean, isIvy: boolean): lsp.CompletionItem {
+    insertReplaceSupport: boolean): lsp.CompletionItem {
   const item = lsp.CompletionItem.create(entry.name);
   // Even though `entry.kind` is typed as ts.ScriptElementKind, it's
   // really Angular's CompletionKind. This is because ts.ScriptElementKind does
@@ -120,14 +120,12 @@ export function tsCompletionEntryToLspCompletionItem(
   const insertText = entry.insertText || entry.name;
   item.textEdit = createTextEdit(scriptInfo, entry, position, insertText, insertReplaceSupport);
 
-  if (isIvy) {
-    // If the user enables the config `includeAutomaticOptionalChainCompletions`, the `insertText`
-    // range will include the dot. the `insertText` should be assigned to the `filterText` to filter
-    // the completion items.
-    item.filterText = entry.insertText;
-    if (entry.isSnippet) {
-      item.insertTextFormat = lsp.InsertTextFormat.Snippet;
-    }
+  // If the user enables the config `includeAutomaticOptionalChainCompletions`, the `insertText`
+  // range will include the dot. the `insertText` should be assigned to the `filterText` to filter
+  // the completion items.
+  item.filterText = entry.insertText;
+  if (entry.isSnippet) {
+    item.insertTextFormat = lsp.InsertTextFormat.Snippet;
   }
 
   item.data = {

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -8,7 +8,6 @@
 
 // Parse command line arguments
 const options = parseCommandLine(process.argv);
-
 if (options.help) {
   console.error(generateHelpMessage(process.argv));
   process.exit(0);
@@ -42,7 +41,6 @@ function main() {
     // TypeScript allows only package names as plugin names.
     ngPlugin: '@angular/language-service',
     resolvedNgLsPath: ng.resolvedPath,
-    ivy: isG3 ? true : options.ivy,
     logToConsole: options.logToConsole,
     includeAutomaticOptionalChainCompletions: options.includeAutomaticOptionalChainCompletions,
     includeCompletionsWithSnippetText: options.includeCompletionsWithSnippetText,


### PR DESCRIPTION
This commit removes the references to the Ivy option, as it's not supported anymore. This also adds
more documentation to the help message to cover new features since the help message was
last updated.