### PR TITLE
feat(syntaxes): Support inline styles as string

### DIFF
--- a/syntaxes/README.md
+++ b/syntaxes/README.md
@@ -41,7 +41,7 @@ Snapshot test cases are specified in [test/cases.json](./test/cases.json).
 Snapshot golden files can be updated by running
 
 ```bash
-yarn test:syntaxes -u
+yarn test:legacy-syntaxes -u
 ```
 
 in the root directory of this repository. Goldens must be updated when a new

--- a/syntaxes/inline-styles.json
+++ b/syntaxes/inline-styles.json
@@ -24,6 +24,9 @@
         },
         {
           "include": "#tsBracketExpression"
+        },
+        {
+          "include": "#style"
         }
       ]
     },
@@ -46,6 +49,9 @@
         },
         {
           "include": "#tsBracketExpression"
+        },
+        {
+          "include": "#style"
         }
       ]
     },

--- a/syntaxes/src/inline-styles.ts
+++ b/syntaxes/src/inline-styles.ts
@@ -20,7 +20,8 @@ export const InlineStyles: GrammarDefinition = {
         2: {name: 'meta.object-literal.key.ts punctuation.separator.key-value.ts'}
       },
       end: /(?=,|})/,
-      patterns: [{include: '#tsParenExpression'}, {include: '#tsBracketExpression'}]
+      patterns:
+          [{include: '#tsParenExpression'}, {include: '#tsBracketExpression'}, {include: '#style'}]
     },
 
     tsParenExpression: {
@@ -28,7 +29,7 @@ export const InlineStyles: GrammarDefinition = {
       beginCaptures: {1: {name: 'meta.brace.round.ts'}},
       end: /\)/,
       endCaptures: {0: {name: 'meta.brace.round.ts'}},
-      patterns: [{include: '$self'}, {include: '#tsBracketExpression'}]
+      patterns: [{include: '$self'}, {include: '#tsBracketExpression'}, {include: '#style'}]
     },
 
     'tsBracketExpression': {

--- a/syntaxes/test/data/inline-styles.ts
+++ b/syntaxes/test/data/inline-styles.ts
@@ -17,5 +17,10 @@
 
 //// Parenthesization tests
   styles: ( (( [ ( '.example { width: 100px; }' ) ] )) ),
+//// styles string
+  styles: ( ((  ( '.example { width: 100px; }' )  )) ),
+  styles:  `.example { width: 100px; }` ,
+  styles:  ".example { width: 100px; }" ,
+  styles:  '.example { width: 100px; }' ,
 })
 export class TMComponent{}

--- a/syntaxes/test/data/inline-styles.ts.snap
+++ b/syntaxes/test/data/inline-styles.ts.snap
@@ -94,10 +94,62 @@
 #        ^ inline-styles.ng meta.object-literal.key.ts punctuation.separator.key-value.ts
 #         ^ inline-styles.ng
 #          ^ inline-styles.ng meta.brace.round.ts
-#           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ inline-styles.ng
+#           ^^^^^^^ inline-styles.ng
+#                  ^ inline-styles.ng
+#                   ^ inline-styles.ng string
+#                    ^^^^^^^^^^^^^^^^^^^^^^^^^^ inline-styles.ng source.css
+#                                              ^ inline-styles.ng string
+#                                               ^ inline-styles.ng
 #                                                ^ inline-styles.ng meta.brace.round.ts
 #                                                 ^^^^^^^ inline-styles.ng
 #                                                        ^^ inline-styles.ng
+>//// styles string
+#^^^^^^^^^^^^^^^^^^^ inline-styles.ng
+>  styles: ( ((  ( '.example { width: 100px; }' )  )) ),
+#^^ inline-styles.ng
+#  ^^^^^^ inline-styles.ng meta.object-literal.key.ts
+#        ^ inline-styles.ng meta.object-literal.key.ts punctuation.separator.key-value.ts
+#         ^ inline-styles.ng
+#          ^ inline-styles.ng meta.brace.round.ts
+#           ^^^^^^ inline-styles.ng
+#                 ^ inline-styles.ng
+#                  ^ inline-styles.ng string
+#                   ^^^^^^^^^^^^^^^^^^^^^^^^^^ inline-styles.ng source.css
+#                                             ^ inline-styles.ng string
+#                                              ^ inline-styles.ng
+#                                               ^ inline-styles.ng meta.brace.round.ts
+#                                                ^^^^^^ inline-styles.ng
+#                                                      ^^ inline-styles.ng
+>  styles:  `.example { width: 100px; }` ,
+#^^ inline-styles.ng
+#  ^^^^^^ inline-styles.ng meta.object-literal.key.ts
+#        ^ inline-styles.ng meta.object-literal.key.ts punctuation.separator.key-value.ts
+#         ^^ inline-styles.ng
+#           ^ inline-styles.ng string
+#            ^^^^^^^^^^^^^^^^^^^^^^^^^^ inline-styles.ng source.css
+#                                      ^ inline-styles.ng string
+#                                       ^ inline-styles.ng
+#                                        ^^ inline-styles.ng
+>  styles:  ".example { width: 100px; }" ,
+#^^ inline-styles.ng
+#  ^^^^^^ inline-styles.ng meta.object-literal.key.ts
+#        ^ inline-styles.ng meta.object-literal.key.ts punctuation.separator.key-value.ts
+#         ^^ inline-styles.ng
+#           ^ inline-styles.ng string
+#            ^^^^^^^^^^^^^^^^^^^^^^^^^^ inline-styles.ng source.css
+#                                      ^ inline-styles.ng string
+#                                       ^ inline-styles.ng
+#                                        ^^ inline-styles.ng
+>  styles:  '.example { width: 100px; }' ,
+#^^ inline-styles.ng
+#  ^^^^^^ inline-styles.ng meta.object-literal.key.ts
+#        ^ inline-styles.ng meta.object-literal.key.ts punctuation.separator.key-value.ts
+#         ^^ inline-styles.ng
+#           ^ inline-styles.ng string
+#            ^^^^^^^^^^^^^^^^^^^^^^^^^^ inline-styles.ng source.css
+#                                      ^ inline-styles.ng string
+#                                       ^ inline-styles.ng
+#                                        ^^ inline-styles.ng
 >})
 #^^^ inline-styles.ng
 >export class TMComponent{}


### PR DESCRIPTION
https://github.com/angular/angular/commit/59387ee476dff1a893a01fe5cbee3c95b93c0cdb

The above commit added support for inline styles to be a single string literal in addition to the previous array of strings. This commit updates the syntaxes regex of the extension to support this feature.