### PR TITLE
fix(client): fix detection of Angular context after string interpolation

### DIFF
--- a/client/src/embedded_support.ts
+++ b/client/src/embedded_support.ts
@@ -77,8 +77,23 @@ function isPropertyAssignmentToStringOrStringInArray(
   let lastTokenText: string|undefined;
   let unclosedBraces = 0;
   let unclosedBrackets = 0;
+  let unclosedTaggedTemplates = 0;
   let propertyAssignmentContext = false;
+
+  function isTemplateStartOfTaggedTemplate() {
+    return token === ts.SyntaxKind.NoSubstitutionTemplateLiteral ||
+        token === ts.SyntaxKind.TemplateHead;
+  }
+
   while (token !== ts.SyntaxKind.EndOfFileToken && scanner.getStartPos() < offset) {
+    if (isTemplateStartOfTaggedTemplate()) {
+      unclosedTaggedTemplates++;
+    }
+    if (token === ts.SyntaxKind.CloseBraceToken && unclosedTaggedTemplates > 0) {
+      // https://github.com/Microsoft/TypeScript/issues/20055
+      token = scanner.reScanTemplateToken(/*isTaggedTemplate*/ true);
+      unclosedTaggedTemplates--;
+    }
     if (lastToken === ts.SyntaxKind.Identifier && lastTokenText !== undefined &&
         propertyAssignmentNames.includes(lastTokenText) && token === ts.SyntaxKind.ColonToken) {
       propertyAssignmentContext = true;

--- a/client/src/tests/embedded_support_spec.ts
+++ b/client/src/tests/embedded_support_spec.ts
@@ -38,6 +38,21 @@ describe('embedded language support', () => {
     it('at end of template', () => {
       test(`template: '<div></div>¦'`, isInsideInlineTemplateRegion, true);
     });
+
+    it('works for inline templates after a template string', () => {
+      test(
+          'const x = `${""}`;\n' +
+              'template: `hello ¦world`',
+          isInsideInlineTemplateRegion, true);
+    });
+
+    it('works for inline templates after a tagged template string inside tagged template string',
+       () => {
+         test(
+             'const x = `${`${""}`}`;\n' +
+                 'template: `hello ¦world`',
+             isInsideInlineTemplateRegion, true);
+       });
   });
 
   describe('isInsideAngularContext', () => {


### PR DESCRIPTION
This probably still has its own issues but seems to be at least an improvement over past scanner issues.

It may be good to spend more time on the correctness of this or just `ts.createSourceFile`. This previously wasn't done due to perfomance concerns.

fixes #1872