### PR TITLE
build: Move 'test' package to dev dependencies

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -20,7 +20,9 @@
     "vscode-jsonrpc": "6.0.0",
     "vscode-languageserver": "7.0.0",
     "vscode-languageserver-textdocument": "^1.0.7",
-    "vscode-uri": "3.0.7",
+    "vscode-uri": "3.0.7"
+  },
+  "devDependencies": {
     "test": "3.3.0"
   },
   "publishConfig": {


### PR DESCRIPTION
The test package is only used for, you guessed it, tests and should not be in the regular deps

resolves #1927