### PR TITLE
feat: support block completions

### DIFF
--- a/server/src/completion.ts
+++ b/server/src/completion.ts
@@ -14,6 +14,7 @@ import {lspPositionToTsPosition, tsTextSpanToLspRange} from './utils';
 // TODO: Move this to `@angular/language-service`.
 enum CompletionKind {
   attribute = 'attribute',
+  block = 'block',
   htmlAttribute = 'html attribute',
   property = 'property',
   component = 'component',
@@ -90,6 +91,8 @@ function ngCompletionKindToLspCompletionItemKind(kind: CompletionKind): lsp.Comp
     case CompletionKind.reference:
     case CompletionKind.variable:
       return lsp.CompletionItemKind.Variable;
+    case CompletionKind.block:
+      return lsp.CompletionItemKind.Keyword;
     case CompletionKind.entity:
     default:
       return lsp.CompletionItemKind.Text;

--- a/server/src/session.ts
+++ b/server/src/session.ts
@@ -676,7 +676,7 @@ export class Session {
         codeLensProvider: {resolveProvider: true},
         textDocumentSync: lsp.TextDocumentSyncKind.Incremental,
         completionProvider:
-            {resolveProvider: true, triggerCharacters: ['<', '.', '*', '[', '(', '$', '|']},
+            {resolveProvider: true, triggerCharacters: ['<', '.', '*', '[', '(', '$', '|', '@']},
         definitionProvider: true,
         typeDefinitionProvider: true,
         referencesProvider: true,


### PR DESCRIPTION
Two changes are necessary to support autocompletion of block keywords:
1. The `@` keyword causes immediate completion
2. The new block completion item kind maps onto the keyword icon