### PR TITLE
feat(server): Add folding range support for Angular template syntax

### DIFF
--- a/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
+++ b/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
@@ -1,7 +1,7 @@
 # Input hashes for repository rule npm_translate_lock(name = "npm", pnpm_lock = "//:pnpm-lock.yaml").
 # This file should be checked into version control along with the pnpm-lock.yaml file.
 .npmrc=974837034
-pnpm-lock.yaml=1223698519
-yarn.lock=-2147056255
-package.json=-381752920
+pnpm-lock.yaml=-1547217849
+yarn.lock=1378739518
+package.json=733870343
 pnpm-workspace.yaml=1711114604

--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -166,7 +166,7 @@ export class AngularLanguageClient implements vscode.Disposable {
         provideFoldingRanges: async (
             document: vscode.TextDocument, context: vscode.FoldingContext,
             token: vscode.CancellationToken, next) => {
-          if (!(await this.isInAngularProject(document)) || document.languageId !== 'typescript') {
+          if (!await this.isInAngularProject(document)) {
             return null;
           }
           return next(document, context, token);

--- a/package.json
+++ b/package.json
@@ -222,7 +222,7 @@
     "test:legacy-syntaxes": "yarn compile:syntaxes-test && yarn build:syntaxes && jasmine dist/syntaxes/test/driver.js"
   },
   "dependencies": {
-    "@angular/language-service": "17.0.0-next.7",
+    "@angular/language-service": "17.0.0-next.8",
     "typescript": "5.1.3",
     "vscode-html-languageservice": "^4.2.5",
     "vscode-jsonrpc": "6.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ importers:
   .:
     specifiers:
       '@angular/dev-infra-private': https://github.com/angular/dev-infra-private-builds.git#262cb3bb487e8dddb3c404f4f2c8b34a9a1f14c2
-      '@angular/language-service': 17.0.0-next.7
+      '@angular/language-service': 17.0.0-next.8
       '@bazel/bazelisk': 1.18.0
       '@bazel/ibazel': 0.16.2
       '@types/jasmine': 3.10.7
@@ -33,7 +33,7 @@ importers:
       vscode-tmgrammar-test: 0.0.11
       vscode-uri: 3.0.7
     dependencies:
-      '@angular/language-service': 17.0.0-next.7
+      '@angular/language-service': 17.0.0-next.8
       typescript: 5.1.3
       vscode-html-languageservice: 4.2.5
       vscode-jsonrpc: 6.0.0
@@ -243,8 +243,8 @@ packages:
       tslib: 2.4.0
     dev: true
 
-  /@angular/language-service/17.0.0-next.7:
-    resolution: {integrity: sha512-eC0OyhKq9+mZ+uSrb2upmC1kXWbHajV199W/YvFTY0N5yI5dAdRziRfp1ntB8gK/nCmdtpKugP6As+yNAKwK6w==}
+  /@angular/language-service/17.0.0-next.8:
+    resolution: {integrity: sha512-c/Dk6OwV1UQd6a51WzYhPlsbg+lLi/YjZsWtSyvp3Q5lQp5I1q2lZfXSPrzGgJ7S0Fhrge69wcno4UWvWkrS9g==}
     engines: {node: '>=18.13.0'}
     dev: false
 

--- a/server/package.json
+++ b/server/package.json
@@ -15,7 +15,7 @@
     "ngserver": "./bin/ngserver"
   },
   "dependencies": {
-    "@angular/language-service": "17.0.0-next.7",
+    "@angular/language-service": "17.0.0-next.8",
     "vscode-html-languageservice": "^4.2.5",
     "vscode-jsonrpc": "6.0.0",
     "vscode-languageserver": "7.0.0",

--- a/server/src/session.ts
+++ b/server/src/session.ts
@@ -820,16 +820,26 @@ export class Session {
     }
   }
 
-  private onFoldingRanges(params: lsp.FoldingRangeParams) {
-    if (!params.textDocument.uri?.endsWith('ts')) {
-      return null;
-    }
-
+  private onFoldingRanges(params: lsp.FoldingRangeParams): lsp.FoldingRange[]|null {
     const lsInfo = this.getLSAndScriptInfo(params.textDocument);
     if (lsInfo === null) {
       return null;
     }
-    const {scriptInfo} = lsInfo;
+    const {scriptInfo, languageService} = lsInfo;
+    const angularOutliningSpans = languageService.getOutliningSpans(scriptInfo.fileName);
+    const angularFoldingRanges = angularOutliningSpans.map(outliningSpan => {
+      const range = tsTextSpanToLspRange(
+          scriptInfo, {start: outliningSpan.textSpan.start, length: outliningSpan.textSpan.length});
+      // We do not want to fold the line containing the closing of the block because then the
+      // closing character (and line) would get hidden in the folding range. We only want to fold
+      // the inside and leave the start/end lines visible.
+      const endLine = Math.max(range.end.line - 1, range.start.line);
+      return lsp.FoldingRange.create(range.start.line, endLine);
+    });
+
+    if (!params.textDocument.uri?.endsWith('ts')) {
+      return angularFoldingRanges;
+    }
     const sf = this.getDefaultProjectForScriptInfo(scriptInfo)?.getSourceFile(scriptInfo.path);
     if (sf === undefined) {
       return null;
@@ -837,7 +847,7 @@ export class Session {
     const virtualHtmlDocContents = getHTMLVirtualContent(sf);
     const virtualHtmlDoc =
         TextDocument.create(params.textDocument.uri.toString(), 'html', 0, virtualHtmlDocContents);
-    return htmlLS.getFoldingRanges(virtualHtmlDoc);
+    return [...htmlLS.getFoldingRanges(virtualHtmlDoc), ...angularFoldingRanges];
   }
 
   private onDefinition(params: lsp.TextDocumentPositionParams):

--- a/yarn.lock
+++ b/yarn.lock
@@ -158,10 +158,10 @@
     uuid "^8.3.2"
     yargs "^17.0.0"
 
-"@angular/language-service@17.0.0-next.7":
-  version "17.0.0-next.7"
-  resolved "https://registry.yarnpkg.com/@angular/language-service/-/language-service-17.0.0-next.7.tgz#795731f9a0bc7dd69c49c51b49a9e4af75c2cafc"
-  integrity sha512-eC0OyhKq9+mZ+uSrb2upmC1kXWbHajV199W/YvFTY0N5yI5dAdRziRfp1ntB8gK/nCmdtpKugP6As+yNAKwK6w==
+"@angular/language-service@17.0.0-next.8":
+  version "17.0.0-next.8"
+  resolved "https://registry.yarnpkg.com/@angular/language-service/-/language-service-17.0.0-next.8.tgz#1366bd68bcd3dfe4d315636b31b54bf06adf85e5"
+  integrity sha512-c/Dk6OwV1UQd6a51WzYhPlsbg+lLi/YjZsWtSyvp3Q5lQp5I1q2lZfXSPrzGgJ7S0Fhrge69wcno4UWvWkrS9g==
 
 "@assemblyscript/loader@^0.10.1":
   version "0.10.1"


### PR DESCRIPTION
This commit adds integration with the @angular/language-service package to get Angular-specific folding ranges in templates. At the moment, this only includes control flow blocks.