### PR TITLE
refactor(client): Show warning message if a project uses a newer vers…

### DIFF
--- a/common/resolver.ts
+++ b/common/resolver.ts
@@ -51,17 +51,17 @@ export class Version {
     this.patch = patch;
   }
 
-  greaterThanOrEqual(other: Version): boolean {
+  greaterThanOrEqual(other: Version, compare: 'patch'|'minor'|'major' = 'patch'): boolean {
     if (this.major < other.major) {
       return false;
     }
-    if (this.major > other.major) {
+    if (this.major > other.major || (this.major === other.major && compare === 'major')) {
       return true;
     }
     if (this.minor < other.minor) {
       return false;
     }
-    if (this.minor > other.minor) {
+    if (this.minor > other.minor || (this.minor === other.minor && compare === 'minor')) {
       return true;
     }
     return this.patch >= other.patch;


### PR DESCRIPTION
…ion than extension

When the installed extension version is less than the major version of the project, there is likely to be errors. Because new features are added in major/minor releases, a the bundled compiler version in an old extension version may completely fail to even parse a template if there are new syntax features. This problem is very apparent with the new control flow syntax. If a project uses v17 and uses the new control flow, a v16 language service will show all kinds of parse errors.

fixes #1941