### PR TITLE
fix(syntaxes): Support multiline block expressions

### DIFF
--- a/syntaxes/src/template-blocks.ts
+++ b/syntaxes/src/template-blocks.ts
@@ -31,25 +31,24 @@ export const TemplateBlocks: GrammarDefinition = {
         },
         2: {name: 'keyword.control.block.kind.ng'},
       },
-      patterns: [{include: '#blockExpression'}],
-      end: '(?<=\\})',
+      patterns: [{include: '#blockExpression'}, {include: '#blockBody'}],
       contentName: 'control.block.ng',
+      // The block ends at the close `}` but we don't capture it here because. It's captured instead
+      // by the #blockBody.
+      end: /(?<=\})/,
     },
 
     blockExpression: {
-      begin: /(?:(\()(.*)(\)))?\s*/,
+      begin: /\(/,
       beginCaptures: {
-        1: {name: 'meta.brace.round.ts'},
-        2: {
-          name: 'control.block.expression.ng',
-          patterns: [
-            {include: 'source.js'},
-          ]
-        },
-        3: {name: 'meta.brace.round.ts'},
+        0: {name: 'meta.brace.round.ts'},
       },
-      end: '(?<=\\})',
-      patterns: [{include: '#blockBody'}]
+      contentName: 'control.block.expression.ng',
+      patterns: [{include: 'source.js'}],
+      end: /\)/,
+      endCaptures: {
+        0: {name: 'meta.brace.round.ts'},
+      },
     },
 
     blockBody: {

--- a/syntaxes/template-blocks.json
+++ b/syntaxes/template-blocks.json
@@ -28,35 +28,33 @@
       "patterns": [
         {
           "include": "#blockExpression"
-        }
-      ],
-      "end": "(?<=\\})",
-      "contentName": "control.block.ng"
-    },
-    "blockExpression": {
-      "begin": "(?:(\\()(.*)(\\)))?\\s*",
-      "beginCaptures": {
-        "1": {
-          "name": "meta.brace.round.ts"
         },
-        "2": {
-          "name": "control.block.expression.ng",
-          "patterns": [
-            {
-              "include": "source.js"
-            }
-          ]
-        },
-        "3": {
-          "name": "meta.brace.round.ts"
-        }
-      },
-      "end": "(?<=\\})",
-      "patterns": [
         {
           "include": "#blockBody"
         }
-      ]
+      ],
+      "contentName": "control.block.ng",
+      "end": "(?<=\\})"
+    },
+    "blockExpression": {
+      "begin": "\\(",
+      "beginCaptures": {
+        "0": {
+          "name": "meta.brace.round.ts"
+        }
+      },
+      "contentName": "control.block.expression.ng",
+      "patterns": [
+        {
+          "include": "source.js"
+        }
+      ],
+      "end": "\\)",
+      "endCaptures": {
+        "0": {
+          "name": "meta.brace.round.ts"
+        }
+      }
     },
     "blockBody": {
       "begin": "\\{",

--- a/syntaxes/test/data/template-blocks.html
+++ b/syntaxes/test/data/template-blocks.html
@@ -26,6 +26,13 @@
     goodbye 
 }
 
-@for (let item of items; as thing; trackBy: $index) {
-    {{item}}
+@for (let item of items; as thing; track: $index) {
+    bla
+}
+
+@if (
+    items;
+    track $index
+) {
+    bla
 }

--- a/syntaxes/test/data/template-blocks.html.snap
+++ b/syntaxes/test/data/template-blocks.html.snap
@@ -2,9 +2,9 @@
 #^ template.blocks.ng keyword.control.block.transition.ng
 # ^^^^^^ template.blocks.ng keyword.control.block.kind.ng
 #       ^ template.blocks.ng control.block.ng meta.brace.round.ts
-#        ^^^^^^^^^^^^^^^^^^ template.blocks.ng control.block.ng control.block.expression.ng
-#                          ^ template.blocks.ng control.block.ng meta.brace.round.ts
-#                           ^ template.blocks.ng control.block.ng
+#        ^^^^^^^^^^^^^^^^^ template.blocks.ng control.block.ng control.block.expression.ng
+#                         ^ template.blocks.ng control.block.ng meta.brace.round.ts
+#                          ^^ template.blocks.ng control.block.ng
 #                            ^ template.blocks.ng control.block.ng punctuation.definition.block.ts
 >    <a></a>
 #^^^^^^^^^^^^ template.blocks.ng control.block.ng control.block.body.ng
@@ -108,18 +108,33 @@
 >}
 #^ template.blocks.ng control.block.ng punctuation.definition.block.ts
 >
->@for (let item of items; as thing; trackBy: $index) {
+>@for (let item of items; as thing; track: $index) {
 #^ template.blocks.ng keyword.control.block.transition.ng
 # ^^^^ template.blocks.ng keyword.control.block.kind.ng
 #     ^ template.blocks.ng control.block.ng meta.brace.round.ts
-#      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.blocks.ng control.block.ng control.block.expression.ng
-#                                                  ^ template.blocks.ng control.block.ng meta.brace.round.ts
-#                                                   ^ template.blocks.ng control.block.ng
-#                                                    ^ template.blocks.ng control.block.ng punctuation.definition.block.ts
->    {{item}}
-#^^^^^^^^^^ template.blocks.ng control.block.ng control.block.body.ng
-#          ^ template.blocks.ng control.block.ng punctuation.definition.block.ts
-#           ^^ template.blocks.ng
+#      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.blocks.ng control.block.ng control.block.expression.ng
+#                                                ^ template.blocks.ng control.block.ng meta.brace.round.ts
+#                                                 ^ template.blocks.ng control.block.ng
+#                                                  ^ template.blocks.ng control.block.ng punctuation.definition.block.ts
+>    bla
+#^^^^^^^^ template.blocks.ng control.block.ng control.block.body.ng
 >}
-#^^ template.blocks.ng
+#^ template.blocks.ng control.block.ng punctuation.definition.block.ts
+>
+>@if (
+#^ template.blocks.ng keyword.control.block.transition.ng
+# ^^^ template.blocks.ng keyword.control.block.kind.ng
+#    ^ template.blocks.ng control.block.ng meta.brace.round.ts
+>    items;
+#^^^^^^^^^^^ template.blocks.ng control.block.ng control.block.expression.ng
+>    track $index
+#^^^^^^^^^^^^^^^^^ template.blocks.ng control.block.ng control.block.expression.ng
+>) {
+#^ template.blocks.ng control.block.ng meta.brace.round.ts
+# ^ template.blocks.ng control.block.ng
+#  ^ template.blocks.ng control.block.ng punctuation.definition.block.ts
+>    bla
+#^^^^^^^^ template.blocks.ng control.block.ng control.block.body.ng
+>}
+#^ template.blocks.ng control.block.ng punctuation.definition.block.ts
 >


### PR DESCRIPTION
The block expression (.*) is currently inside a begin capture. TextMate captures are not able to be multiline. This commit updates the capturing groups so that the expression start capture is `(` and the end capture is `)`. This allows the start and end captures to appear on separate lines.

fixes #1945