### PR TITLE
fix(syntaxes): Do not apply block syntax highlighting to JS and CSS i…

### DIFF
--- a/syntaxes/src/template-blocks.ts
+++ b/syntaxes/src/template-blocks.ts
@@ -10,7 +10,7 @@ import {GrammarDefinition} from './types';
 
 export const TemplateBlocks: GrammarDefinition = {
   scopeName: 'template.blocks.ng',
-  injectionSelector: 'L:text.html -comment -expression.ng -meta.tag',
+  injectionSelector: 'L:text.html -comment -expression.ng -meta.tag -source.css -source.js',
   patterns: [
     {include: '#block'},
   ],

--- a/syntaxes/template-blocks.json
+++ b/syntaxes/template-blocks.json
@@ -1,6 +1,6 @@
 {
   "scopeName": "template.blocks.ng",
-  "injectionSelector": "L:text.html -comment -expression.ng -meta.tag",
+  "injectionSelector": "L:text.html -comment -expression.ng -meta.tag -source.css -source.js",
   "patterns": [
     {
       "include": "#block"


### PR DESCRIPTION
…n templates

This commit excludes the block syntax highlighting from JS and CSS scopes in templates. This would include `script` and `style` tags.