### PR TITLE
fix(syntaxes): Single quote should end `as` alias match

### DIFF
--- a/syntaxes/expression.json
+++ b/syntaxes/expression.json
@@ -138,7 +138,7 @@
               "name": "storage.type.as.ts"
             }
           },
-          "end": "(?=$|\"|[;,:})\\]])",
+          "end": "(?=$|\"|'|[;,:})\\]])",
           "patterns": [
             {
               "include": "#type"

--- a/syntaxes/src/expression.ts
+++ b/syntaxes/src/expression.ts
@@ -147,7 +147,7 @@ export const Expression: GrammarDefinition = {
               name: 'storage.type.as.ts',
             },
           },
-          end: /(?=$|"|[;,:})\]])/,
+          end: /(?=$|"|'|[;,:})\]])/,
           patterns: [
             {
               include: '#type',

--- a/syntaxes/test/data/expression.html
+++ b/syntaxes/test/data/expression.html
@@ -91,6 +91,7 @@
 <!-- As Expression -->
 <div *ngFor="let param of params; index as i;"></div>
 <div *ngFor="let param of params; index as i"></div>
+<div *ngIf='x as y'></div>
 <!-- Mixed -->
 <div *ngFor="let param of params; let i = index; let last = last"></div>
 <div *ngFor="let param of params; let i = index; let last = last;"></div>

--- a/syntaxes/test/data/expression.html.snap
+++ b/syntaxes/test/data/expression.html.snap
@@ -1025,6 +1025,19 @@
 #                                           ^ template.ng meta.ng-binding.template.html expression.ng entity.name.type.ts
 #                                            ^ template.ng meta.ng-binding.template.html string.quoted.html punctuation.definition.string.end.html
 #                                             ^^^^^^^^ template.ng
+><div *ngIf='x as y'></div>
+#^^^^^ template.ng
+#     ^ template.ng meta.ng-binding.template.html entity.other.attribute-name.html entity.other.ng-binding-name.template.html punctuation.definition.ng-binding-name.begin.html
+#      ^^^^ template.ng meta.ng-binding.template.html entity.other.attribute-name.html entity.other.ng-binding-name.template.html entity.other.ng-binding-name.ngIf.html
+#          ^ template.ng meta.ng-binding.template.html punctuation.separator.key-value.html
+#           ^ template.ng meta.ng-binding.template.html string.quoted.html punctuation.definition.string.begin.html
+#            ^ template.ng meta.ng-binding.template.html expression.ng variable.other.readwrite.ts
+#             ^ template.ng meta.ng-binding.template.html expression.ng
+#              ^^ template.ng meta.ng-binding.template.html expression.ng storage.type.as.ts
+#                ^ template.ng meta.ng-binding.template.html expression.ng
+#                 ^ template.ng meta.ng-binding.template.html expression.ng entity.name.type.ts
+#                  ^ template.ng meta.ng-binding.template.html string.quoted.html punctuation.definition.string.end.html
+#                   ^^^^^^^^ template.ng
 ><!-- Mixed -->
 #^^^^^^^^^^^^^^^ template.ng
 ><div *ngFor="let param of params; let i = index; let last = last"></div>
@@ -1454,3 +1467,4 @@
 #                          ^ template.ng meta.ng-binding.template.html expression.ng entity.name.type.ts
 #                           ^ template.ng meta.ng-binding.template.html string.quoted.html punctuation.definition.string.end.html
 #                            ^^^^^^^^ template.ng
+>


### PR DESCRIPTION
While uncommon, single quotes can be used for HTML attribute values.

fixes #1912