### PR TITLE
fix(syntaxes): Use expression.ng instead of JS for block expressions

### DIFF
--- a/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
+++ b/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
@@ -3,5 +3,5 @@
 .npmrc=974837034
 pnpm-lock.yaml=-788183804
 yarn.lock=1782215124
-package.json=1628153514
+package.json=-1597267529
 pnpm-workspace.yaml=1711114604

--- a/package.json
+++ b/package.json
@@ -182,7 +182,7 @@
         ],
         "embeddedLanguages": {
           "text.html": "html",
-          "source.js": "javascript"
+          "expression.ng": "javascript"
         }
       },
       {

--- a/syntaxes/src/template-blocks.ts
+++ b/syntaxes/src/template-blocks.ts
@@ -44,7 +44,7 @@ export const TemplateBlocks: GrammarDefinition = {
         0: {name: 'meta.brace.round.ts'},
       },
       contentName: 'control.block.expression.ng',
-      patterns: [{include: 'source.js'}],
+      patterns: [{include: 'expression.ng'}],
       end: /\)/,
       endCaptures: {
         0: {name: 'meta.brace.round.ts'},

--- a/syntaxes/template-blocks.json
+++ b/syntaxes/template-blocks.json
@@ -46,7 +46,7 @@
       "contentName": "control.block.expression.ng",
       "patterns": [
         {
-          "include": "source.js"
+          "include": "expression.ng"
         }
       ],
       "end": "\\)",

--- a/syntaxes/test/cases.ts
+++ b/syntaxes/test/cases.ts
@@ -21,7 +21,8 @@ export const cases = [
   {
     'name': 'block syntax',
     'scopeName': 'template.blocks.ng',
-    'grammarFiles': ['syntaxes/template-blocks.json'],
+    'grammarFiles':
+        ['syntaxes/template-blocks.json', 'syntaxes/expression.json', 'syntaxes/template.json'],
     'testFile': 'syntaxes/test/data/template-blocks.html'
   },
   {

--- a/syntaxes/test/data/template-blocks.html
+++ b/syntaxes/test/data/template-blocks.html
@@ -32,7 +32,8 @@
 
 @if (
     items;
-    track $index
+    track $index;
+    let o = $odd
 ) {
-    bla
+    {{o}}
 }

--- a/syntaxes/test/data/template-blocks.html.snap
+++ b/syntaxes/test/data/template-blocks.html.snap
@@ -2,9 +2,14 @@
 #^ template.blocks.ng keyword.control.block.transition.ng
 # ^^^^^^ template.blocks.ng keyword.control.block.kind.ng
 #       ^ template.blocks.ng control.block.ng meta.brace.round.ts
-#        ^^^^^^^^^^^^^^^^^ template.blocks.ng control.block.ng control.block.expression.ng
-#                         ^ template.blocks.ng control.block.ng meta.brace.round.ts
-#                          ^^ template.blocks.ng control.block.ng
+#        ^^^^^^^^^^^ template.blocks.ng control.block.ng control.block.expression.ng entity.name.function.ts
+#                   ^ template.blocks.ng control.block.ng control.block.expression.ng meta.brace.round.ts
+#                    ^ template.blocks.ng control.block.ng control.block.expression.ng
+#                     ^^^ template.blocks.ng control.block.ng control.block.expression.ng constant.numeric.decimal.ts
+#                        ^ template.blocks.ng control.block.ng control.block.expression.ng
+#                         ^ template.blocks.ng control.block.ng control.block.expression.ng meta.brace.round.ts
+#                          ^ template.blocks.ng control.block.ng meta.brace.round.ts
+#                           ^ template.blocks.ng control.block.ng
 #                            ^ template.blocks.ng control.block.ng punctuation.definition.block.ts
 >    <a></a>
 #^^^^^^^^^^^^ template.blocks.ng control.block.ng control.block.body.ng
@@ -24,33 +29,43 @@
 #^ template.blocks.ng keyword.control.block.transition.ng
 # ^^^^^^^ template.blocks.ng keyword.control.block.kind.ng
 #        ^ template.blocks.ng control.block.ng meta.brace.round.ts
-#         ^ template.blocks.ng control.block.ng control.block.expression.ng
+#         ^ template.blocks.ng control.block.ng control.block.expression.ng variable.other.readwrite.ts
 #          ^ template.blocks.ng control.block.ng meta.brace.round.ts
 #           ^ template.blocks.ng control.block.ng
 #            ^ template.blocks.ng control.block.ng punctuation.definition.block.ts
 >    @case (1) {
 #^^^^^^^^^^^^^^^^ template.blocks.ng control.block.ng control.block.body.ng
 >        {{getCase1()}}
-#^^^^^^^^^^^^^^^^^^^^ template.blocks.ng control.block.ng control.block.body.ng
-#                    ^ template.blocks.ng control.block.ng punctuation.definition.block.ts
-#                     ^^ template.blocks.ng
+#^^^^^^^^ template.blocks.ng control.block.ng control.block.body.ng
+#        ^^ template.blocks.ng control.block.ng control.block.body.ng punctuation.definition.block.ts
+#          ^^^^^^^^ template.blocks.ng control.block.ng control.block.body.ng expression.ng entity.name.function.ts
+#                  ^ template.blocks.ng control.block.ng control.block.body.ng expression.ng meta.brace.round.ts
+#                   ^ template.blocks.ng control.block.ng control.block.body.ng expression.ng meta.brace.round.ts
+#                    ^^ template.blocks.ng control.block.ng control.block.body.ng punctuation.definition.block.ts
 >    }
-#^^^^^^ template.blocks.ng
+#^^^^ template.blocks.ng control.block.ng control.block.body.ng
+#    ^ template.blocks.ng control.block.ng punctuation.definition.block.ts
 >    @case (2) {
 #^^^^ template.blocks.ng
 #    ^ template.blocks.ng keyword.control.block.transition.ng
 #     ^^^^^ template.blocks.ng keyword.control.block.kind.ng
 #          ^ template.blocks.ng control.block.ng meta.brace.round.ts
-#           ^ template.blocks.ng control.block.ng control.block.expression.ng
+#           ^ template.blocks.ng control.block.ng control.block.expression.ng constant.numeric.decimal.ts
 #            ^ template.blocks.ng control.block.ng meta.brace.round.ts
 #             ^ template.blocks.ng control.block.ng
 #              ^ template.blocks.ng control.block.ng punctuation.definition.block.ts
 >        {{a.b.c}}
-#^^^^^^^^^^^^^^^ template.blocks.ng control.block.ng control.block.body.ng
-#               ^ template.blocks.ng control.block.ng punctuation.definition.block.ts
-#                ^^ template.blocks.ng
+#^^^^^^^^ template.blocks.ng control.block.ng control.block.body.ng
+#        ^^ template.blocks.ng control.block.ng control.block.body.ng punctuation.definition.block.ts
+#          ^ template.blocks.ng control.block.ng control.block.body.ng expression.ng variable.other.object.ts
+#           ^ template.blocks.ng control.block.ng control.block.body.ng expression.ng punctuation.accessor.ts
+#            ^ template.blocks.ng control.block.ng control.block.body.ng expression.ng variable.other.object.property.ts
+#             ^ template.blocks.ng control.block.ng control.block.body.ng expression.ng punctuation.accessor.ts
+#              ^ template.blocks.ng control.block.ng control.block.body.ng expression.ng variable.other.property.ts
+#               ^^ template.blocks.ng control.block.ng control.block.body.ng punctuation.definition.block.ts
 >    }
-#^^^^^^ template.blocks.ng
+#^^^^ template.blocks.ng control.block.ng control.block.body.ng
+#    ^ template.blocks.ng control.block.ng punctuation.definition.block.ts
 >    @default {
 #^^^^ template.blocks.ng
 #    ^ template.blocks.ng keyword.control.block.transition.ng
@@ -68,7 +83,9 @@
 #^ template.blocks.ng keyword.control.block.transition.ng
 # ^^^ template.blocks.ng keyword.control.block.kind.ng
 #    ^ template.blocks.ng control.block.ng meta.brace.round.ts
-#     ^^^^ template.blocks.ng control.block.ng control.block.expression.ng
+#     ^ template.blocks.ng control.block.ng control.block.expression.ng variable.other.readwrite.ts
+#      ^^ template.blocks.ng control.block.ng control.block.expression.ng keyword.operator.comparison.ts
+#        ^ template.blocks.ng control.block.ng control.block.expression.ng variable.other.readwrite.ts
 #         ^ template.blocks.ng control.block.ng meta.brace.round.ts
 #          ^ template.blocks.ng control.block.ng
 #           ^ template.blocks.ng control.block.ng punctuation.definition.block.ts
@@ -85,7 +102,9 @@
 #^ template.blocks.ng keyword.control.block.transition.ng
 # ^^^ template.blocks.ng keyword.control.block.kind.ng
 #    ^ template.blocks.ng control.block.ng meta.brace.round.ts
-#     ^^^^ template.blocks.ng control.block.ng control.block.expression.ng
+#     ^ template.blocks.ng control.block.ng control.block.expression.ng variable.other.readwrite.ts
+#      ^^ template.blocks.ng control.block.ng control.block.expression.ng keyword.operator.comparison.ts
+#        ^ template.blocks.ng control.block.ng control.block.expression.ng variable.other.readwrite.ts
 #         ^ template.blocks.ng control.block.ng meta.brace.round.ts
 #          ^ template.blocks.ng control.block.ng
 #           ^ template.blocks.ng control.block.ng punctuation.definition.block.ts
@@ -98,7 +117,9 @@
 #  ^ template.blocks.ng keyword.control.block.transition.ng
 #   ^^^^^^^^ template.blocks.ng keyword.control.block.kind.ng
 #           ^ template.blocks.ng control.block.ng meta.brace.round.ts
-#            ^^^^ template.blocks.ng control.block.ng control.block.expression.ng
+#            ^ template.blocks.ng control.block.ng control.block.expression.ng variable.other.readwrite.ts
+#             ^^ template.blocks.ng control.block.ng control.block.expression.ng keyword.operator.comparison.ts
+#               ^ template.blocks.ng control.block.ng control.block.expression.ng variable.other.readwrite.ts
 #                ^ template.blocks.ng control.block.ng meta.brace.round.ts
 #                 ^ template.blocks.ng control.block.ng
 #                  ^ template.blocks.ng control.block.ng punctuation.definition.block.ts
@@ -112,7 +133,21 @@
 #^ template.blocks.ng keyword.control.block.transition.ng
 # ^^^^ template.blocks.ng keyword.control.block.kind.ng
 #     ^ template.blocks.ng control.block.ng meta.brace.round.ts
-#      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.blocks.ng control.block.ng control.block.expression.ng
+#      ^^^ template.blocks.ng control.block.ng control.block.expression.ng storage.type.ts
+#         ^ template.blocks.ng control.block.ng control.block.expression.ng
+#          ^^^^ template.blocks.ng control.block.ng control.block.expression.ng variable.other.readwrite.ts
+#              ^ template.blocks.ng control.block.ng control.block.expression.ng
+#               ^^ template.blocks.ng control.block.ng control.block.expression.ng keyword.operator.expression.of.ts
+#                 ^ template.blocks.ng control.block.ng control.block.expression.ng
+#                  ^^^^^ template.blocks.ng control.block.ng control.block.expression.ng variable.other.readwrite.ts
+#                       ^^ template.blocks.ng control.block.ng control.block.expression.ng
+#                         ^^ template.blocks.ng control.block.ng control.block.expression.ng storage.type.as.ts
+#                           ^ template.blocks.ng control.block.ng control.block.expression.ng
+#                            ^^^^^ template.blocks.ng control.block.ng control.block.expression.ng entity.name.type.ts
+#                                 ^^ template.blocks.ng control.block.ng control.block.expression.ng
+#                                   ^^^^^ template.blocks.ng control.block.ng control.block.expression.ng variable.other.readwrite.ts
+#                                        ^^ template.blocks.ng control.block.ng control.block.expression.ng
+#                                          ^^^^^^ template.blocks.ng control.block.ng control.block.expression.ng variable.other.readwrite.ts
 #                                                ^ template.blocks.ng control.block.ng meta.brace.round.ts
 #                                                 ^ template.blocks.ng control.block.ng
 #                                                  ^ template.blocks.ng control.block.ng punctuation.definition.block.ts
@@ -126,15 +161,33 @@
 # ^^^ template.blocks.ng keyword.control.block.kind.ng
 #    ^ template.blocks.ng control.block.ng meta.brace.round.ts
 >    items;
-#^^^^^^^^^^^ template.blocks.ng control.block.ng control.block.expression.ng
->    track $index
-#^^^^^^^^^^^^^^^^^ template.blocks.ng control.block.ng control.block.expression.ng
+#^^^^ template.blocks.ng control.block.ng control.block.expression.ng
+#    ^^^^^ template.blocks.ng control.block.ng control.block.expression.ng variable.other.readwrite.ts
+#         ^^ template.blocks.ng control.block.ng control.block.expression.ng
+>    track $index;
+#^^^^ template.blocks.ng control.block.ng control.block.expression.ng
+#    ^^^^^ template.blocks.ng control.block.ng control.block.expression.ng variable.other.readwrite.ts
+#         ^ template.blocks.ng control.block.ng control.block.expression.ng
+#          ^^^^^^ template.blocks.ng control.block.ng control.block.expression.ng variable.other.readwrite.ts
+#                ^^ template.blocks.ng control.block.ng control.block.expression.ng
+>    let o = $odd
+#^^^^ template.blocks.ng control.block.ng control.block.expression.ng
+#    ^^^ template.blocks.ng control.block.ng control.block.expression.ng storage.type.ts
+#       ^ template.blocks.ng control.block.ng control.block.expression.ng
+#        ^ template.blocks.ng control.block.ng control.block.expression.ng variable.other.readwrite.ts
+#         ^ template.blocks.ng control.block.ng control.block.expression.ng
+#          ^ template.blocks.ng control.block.ng control.block.expression.ng keyword.operator.assignment.ts
+#           ^ template.blocks.ng control.block.ng control.block.expression.ng
+#            ^^^^ template.blocks.ng control.block.ng control.block.expression.ng variable.other.readwrite.ts
 >) {
 #^ template.blocks.ng control.block.ng meta.brace.round.ts
 # ^ template.blocks.ng control.block.ng
 #  ^ template.blocks.ng control.block.ng punctuation.definition.block.ts
->    bla
-#^^^^^^^^ template.blocks.ng control.block.ng control.block.body.ng
+>    {{o}}
+#^^^^ template.blocks.ng control.block.ng control.block.body.ng
+#    ^^ template.blocks.ng control.block.ng control.block.body.ng punctuation.definition.block.ts
+#      ^ template.blocks.ng control.block.ng control.block.body.ng expression.ng variable.other.readwrite.ts
+#       ^^ template.blocks.ng control.block.ng control.block.body.ng punctuation.definition.block.ts
 >}
 #^ template.blocks.ng control.block.ng punctuation.definition.block.ts
 >


### PR DESCRIPTION
JS syntax has certain expectations for statements that do not hold true inside Angular template expressions. A missing trailing `;` in a variable assignment in a `for` expression will cause the javascript to never terminate. This commit updates the expression to use `expression.ng` instead.

fixes #1957