### PR TITLE
fix: Disable block syntax parsing when no project in workspace suppor…

### DIFF
--- a/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
+++ b/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
@@ -1,7 +1,7 @@
 # Input hashes for repository rule npm_translate_lock(name = "npm", pnpm_lock = "//:pnpm-lock.yaml").
 # This file should be checked into version control along with the pnpm-lock.yaml file.
 .npmrc=974837034
-pnpm-lock.yaml=-788183804
-yarn.lock=1782215124
-package.json=-1597267529
+pnpm-lock.yaml=-1149894156
+yarn.lock=1254518305
+package.json=-2138089801
 pnpm-workspace.yaml=1711114604

--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -13,7 +13,7 @@ import * as lsp from 'vscode-languageclient/node';
 
 import {OpenOutputChannel, ProjectLoadingFinish, ProjectLoadingStart, SuggestStrictMode, SuggestStrictModeParams} from '../../common/notifications';
 import {GetComponentsWithTemplateFile, GetTcbRequest, GetTemplateLocationForComponent, IsInAngularProject} from '../../common/requests';
-import {resolve} from '../../common/resolver';
+import {NodeModule, resolve} from '../../common/resolver';
 
 import {isInsideComponentDecorator, isInsideInlineTemplateRegion, isInsideStringLiteral} from './embedded_support';
 
@@ -432,6 +432,13 @@ function constructArgs(ctx: vscode.ExtensionContext): string[] {
     args.push('--includeCompletionsWithSnippetText');
   }
 
+  const angularVersions = getAngularVersionsInWorkspace();
+  // Only disable block syntax if we find angular/core and every one we find does not support block
+  // syntax
+  if (angularVersions.size > 0 && Array.from(angularVersions).every(v => v.version.major < 17)) {
+    args.push('--disableBlockSyntax');
+  }
+
   const forceStrictTemplates = config.get<boolean>('angular.forceStrictTemplates');
   if (forceStrictTemplates) {
     args.push('--forceStrictTemplates');
@@ -504,4 +511,20 @@ function extensionVersionCompatibleWithAllProjects(serverModuleLocation: string)
     }
   }
   return true;
+}
+
+/**
+ * Returns true if any project in the workspace supports block syntax (v17+).
+ */
+function getAngularVersionsInWorkspace(): Set<NodeModule> {
+  const angularCoreModules = new Set<NodeModule>();
+  const workspaceFolders = vscode.workspace.workspaceFolders || [];
+  for (const workspaceFolder of workspaceFolders) {
+    const angularCore = resolve('@angular/core', workspaceFolder.uri.fsPath);
+    if (angularCore === undefined) {
+      continue;
+    }
+    angularCoreModules.add(angularCore);
+  }
+  return angularCoreModules;
 }

--- a/package.json
+++ b/package.json
@@ -222,7 +222,7 @@
     "test:legacy-syntaxes": "yarn compile:syntaxes-test && yarn build:syntaxes && jasmine dist/syntaxes/test/driver.js"
   },
   "dependencies": {
-    "@angular/language-service": "17.0.0-rc.3",
+    "@angular/language-service": "17.0.1",
     "typescript": "5.2.2",
     "vscode-html-languageservice": "^4.2.5",
     "vscode-jsonrpc": "6.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ importers:
   .:
     specifiers:
       '@angular/dev-infra-private': https://github.com/angular/dev-infra-private-builds.git#262cb3bb487e8dddb3c404f4f2c8b34a9a1f14c2
-      '@angular/language-service': 17.0.0-rc.3
+      '@angular/language-service': 17.0.1
       '@bazel/bazelisk': 1.18.0
       '@bazel/ibazel': 0.16.2
       '@types/jasmine': 3.10.7
@@ -33,7 +33,7 @@ importers:
       vscode-tmgrammar-test: 0.0.11
       vscode-uri: 3.0.7
     dependencies:
-      '@angular/language-service': 17.0.0-rc.3
+      '@angular/language-service': 17.0.1
       typescript: 5.2.2
       vscode-html-languageservice: 4.2.5
       vscode-jsonrpc: 6.0.0
@@ -243,8 +243,8 @@ packages:
       tslib: 2.4.0
     dev: true
 
-  /@angular/language-service/17.0.0-rc.3:
-    resolution: {integrity: sha512-F2LZUr9Kpeuz8Lqnm/KHxJMWX51+f2DzIPBNOVkNdgcTyQGXlQdJJBznpQ2QwaRaNP30Oz6/hOyAy95SKaVKSg==}
+  /@angular/language-service/17.0.1:
+    resolution: {integrity: sha512-kDKmtMj410We8Rbph4e2xSuIs+MlzE7+QvIR07tofcoAR6Qpe2hr6WdsfExGBNIk5LNMYI3zdbEkAofG/JuRDA==}
     engines: {node: ^18.13.0 || >=20.9.0}
     dev: false
 

--- a/server/package.json
+++ b/server/package.json
@@ -15,7 +15,7 @@
     "ngserver": "./bin/ngserver"
   },
   "dependencies": {
-    "@angular/language-service": "17.0.0-rc.3",
+    "@angular/language-service": "17.0.1",
     "vscode-html-languageservice": "^4.2.5",
     "vscode-jsonrpc": "6.0.0",
     "vscode-languageserver": "7.0.0",

--- a/server/src/cmdline_utils.ts
+++ b/server/src/cmdline_utils.ts
@@ -36,6 +36,7 @@ interface CommandLineOptions {
   includeAutomaticOptionalChainCompletions: boolean;
   includeCompletionsWithSnippetText: boolean;
   forceStrictTemplates: boolean;
+  disableBlockSyntax: boolean;
 }
 
 export function parseCommandLine(argv: string[]): CommandLineOptions {
@@ -50,6 +51,7 @@ export function parseCommandLine(argv: string[]): CommandLineOptions {
         hasArgument(argv, '--includeAutomaticOptionalChainCompletions'),
     includeCompletionsWithSnippetText: hasArgument(argv, '--includeCompletionsWithSnippetText'),
     forceStrictTemplates: hasArgument(argv, '--forceStrictTemplates'),
+    disableBlockSyntax: hasArgument(argv, '--disableBlockSyntax'),
   };
 }
 

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -46,6 +46,7 @@ function main() {
     includeAutomaticOptionalChainCompletions: options.includeAutomaticOptionalChainCompletions,
     includeCompletionsWithSnippetText: options.includeCompletionsWithSnippetText,
     forceStrictTemplates: isG3 || options.forceStrictTemplates,
+    disableBlockSyntax: options.disableBlockSyntax,
   });
 
   // Log initialization info

--- a/server/src/session.ts
+++ b/server/src/session.ts
@@ -33,6 +33,7 @@ export interface SessionOptions {
   includeAutomaticOptionalChainCompletions: boolean;
   includeCompletionsWithSnippetText: boolean;
   forceStrictTemplates: boolean;
+  disableBlockSyntax: boolean;
 }
 
 enum LanguageId {
@@ -155,6 +156,9 @@ export class Session {
     };
     if (options.forceStrictTemplates) {
       pluginConfig.forceStrictTemplates = true;
+    }
+    if (options.disableBlockSyntax) {
+      pluginConfig.enableBlockSyntax = false;
     }
     projSvc.configurePlugin({
       pluginName: options.ngPlugin,

--- a/yarn.lock
+++ b/yarn.lock
@@ -158,10 +158,10 @@
     uuid "^8.3.2"
     yargs "^17.0.0"
 
-"@angular/language-service@17.0.0-rc.3":
-  version "17.0.0-rc.3"
-  resolved "https://registry.yarnpkg.com/@angular/language-service/-/language-service-17.0.0-rc.3.tgz#1594166701ab88ac45a9f67a2b5a9129e04694d5"
-  integrity sha512-F2LZUr9Kpeuz8Lqnm/KHxJMWX51+f2DzIPBNOVkNdgcTyQGXlQdJJBznpQ2QwaRaNP30Oz6/hOyAy95SKaVKSg==
+"@angular/language-service@17.0.1":
+  version "17.0.1"
+  resolved "https://registry.yarnpkg.com/@angular/language-service/-/language-service-17.0.1.tgz#3e08a65a1f02f5fe39e454819729f5ec20259d35"
+  integrity sha512-kDKmtMj410We8Rbph4e2xSuIs+MlzE7+QvIR07tofcoAR6Qpe2hr6WdsfExGBNIk5LNMYI3zdbEkAofG/JuRDA==
 
 "@assemblyscript/loader@^0.10.1":
   version "0.10.1"


### PR DESCRIPTION
…ts it (#1962)

This commit adds a check to ensure a root in the workspace supports block syntax. If not, the block syntax parsing in the compiler is disabled. Note that the language server is shared for all roots and all projects in the workspace. If on supports block syntax, we have to enable it.

In the future, it would be better to find a way to make this a per-project configuration based on the version of Angular used in that project.

fixes #1958