### PR TITLE
refactor(syntaxes): Update embedded languages and block name

### DIFF
--- a/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
+++ b/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
@@ -2,7 +2,7 @@
 # Input hashes for repository rule npm_translate_lock(name = "npm", pnpm_lock = "//:pnpm-lock.yaml").
 # This file should be checked into version control along with the pnpm-lock.yaml file.
 .npmrc=974837034
-pnpm-lock.yaml=1988059937
-yarn.lock=448809282
-package.json=172429918
+pnpm-lock.yaml=-1342496482
+yarn.lock=-1243860663
+package.json=1843460007
 pnpm-workspace.yaml=1711114604

--- a/package.json
+++ b/package.json
@@ -164,12 +164,22 @@
       {
         "path": "./syntaxes/template.json",
         "scopeName": "template.ng",
-        "injectTo": ["text.html.derivative", "source.ts"]
+        "injectTo": ["text.html.derivative", "source.ts"],
+        "embeddedLanguages": {
+          "text.html": "html",
+          "source.css": "css",
+          "expression.ng": "javascript"
+        }
       },
       {
         "path": "./syntaxes/template-blocks.json",
         "scopeName": "template.blocks.ng",
-        "injectTo": ["text.html.derivative", "source.ts"]
+        "injectTo": ["text.html.derivative", "source.ts"],
+        "embeddedLanguages": {
+          "text.html": "html",
+          "control.block.expression.ng": "javascript",
+          "control.block.body.ng": "html"
+        }
       },
       {
         "path": "./syntaxes/let-declaration.json",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,7 +28,7 @@ importers:
         version: 7.0.0
       vscode-languageserver-textdocument:
         specifier: ^1.0.7
-        version: 1.0.7
+        version: 1.0.11
       vscode-uri:
         specifier: 3.0.7
         version: 3.0.7
@@ -3745,8 +3745,8 @@ packages:
       '@socket.io/base64-arraybuffer': 1.0.2
     dev: true
 
-  /engine.io-parser@5.2.2:
-    resolution: {integrity: sha512-RcyUFKA93/CXH20l4SoVvzZfrSDMOTUS3bWVpTt2FuFP+XYrL8i8oonHP7WInRyVHXh0n/ORtoeiE1os+8qkSw==}
+  /engine.io-parser@5.2.3:
+    resolution: {integrity: sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==}
     engines: {node: '>=10.0.0'}
     dev: true
 
@@ -3782,7 +3782,7 @@ packages:
       cookie: 0.4.2
       cors: 2.8.5
       debug: 4.3.4
-      engine.io-parser: 5.2.2
+      engine.io-parser: 5.2.3
       ws: 8.17.1
     transitivePeerDependencies:
       - bufferutil
@@ -8262,7 +8262,7 @@ packages:
   /vscode-html-languageservice@4.2.5:
     resolution: {integrity: sha512-dbr10KHabB9EaK8lI0XZW7SqOsTfrNyT3Nuj0GoPi4LjGKUmMiLtsqzfedIzRTzqY+w0FiLdh0/kQrnQ0tLxrw==}
     dependencies:
-      vscode-languageserver-textdocument: 1.0.7
+      vscode-languageserver-textdocument: 1.0.11
       vscode-languageserver-types: 3.17.2
       vscode-nls: 5.2.0
       vscode-uri: 3.0.7
@@ -8287,8 +8287,8 @@ packages:
       vscode-jsonrpc: 6.0.0
       vscode-languageserver-types: 3.16.0
 
-  /vscode-languageserver-textdocument@1.0.7:
-    resolution: {integrity: sha512-bFJH7UQxlXT8kKeyiyu41r22jCZXG8kuuVVA33OEJn1diWOZK5n8zBSPZFHVBOu8kXZ6h0LIRhf5UnCo61J4Hg==}
+  /vscode-languageserver-textdocument@1.0.11:
+    resolution: {integrity: sha512-X+8T3GoiwTVlJbicx/sIAF+yuJAqz8VvwJyoMVhwEMoEKE/fkDmrqUgDMyBECcM2A2frVZIUj5HI/ErRXCfOeA==}
     dev: false
 
   /vscode-languageserver-types@3.16.0:

--- a/syntaxes/src/template-blocks.ts
+++ b/syntaxes/src/template-blocks.ts
@@ -33,7 +33,7 @@ export const TemplateBlocks: GrammarDefinition = {
         2: {name: 'keyword.control.block.kind.ng'},
       },
       patterns: [{include: '#blockExpression'}, {include: '#blockBody'}],
-      contentName: 'control.block.ng',
+      name: 'control.block.ng',
       // The block ends at the close `}` but we don't capture it here because. It's captured instead
       // by the #blockBody.
       end: /(?<=\})/,

--- a/syntaxes/template-blocks.json
+++ b/syntaxes/template-blocks.json
@@ -33,7 +33,7 @@
           "include": "#blockBody"
         }
       ],
-      "contentName": "control.block.ng",
+      "name": "control.block.ng",
       "end": "(?<=\\})"
     },
     "blockExpression": {

--- a/syntaxes/test/data/template-blocks.html.snap
+++ b/syntaxes/test/data/template-blocks.html.snap
@@ -1,7 +1,7 @@
 >@defer (doSomething({111})) {
-#^ template.blocks.ng keyword.control.block.transition.ng
-# ^^^^^ template.blocks.ng keyword.control.block.kind.ng
-#      ^ template.blocks.ng
+#^ template.blocks.ng control.block.ng keyword.control.block.transition.ng
+# ^^^^^ template.blocks.ng control.block.ng keyword.control.block.kind.ng
+#      ^ template.blocks.ng control.block.ng
 #       ^ template.blocks.ng control.block.ng meta.brace.round.ts
 #        ^^^^^^^^^^^ template.blocks.ng control.block.ng control.block.expression.ng entity.name.function.ts
 #                   ^ template.blocks.ng control.block.ng control.block.expression.ng meta.brace.round.ts
@@ -18,9 +18,9 @@
 #^ template.blocks.ng control.block.ng punctuation.definition.block.ts
 >
 >@defer {
-#^ template.blocks.ng keyword.control.block.transition.ng
-# ^^^^^ template.blocks.ng keyword.control.block.kind.ng
-#      ^ template.blocks.ng
+#^ template.blocks.ng control.block.ng keyword.control.block.transition.ng
+# ^^^^^ template.blocks.ng control.block.ng keyword.control.block.kind.ng
+#      ^ template.blocks.ng control.block.ng
 #       ^ template.blocks.ng control.block.ng punctuation.definition.block.ts
 >    <a></a>
 #^^^^^^^^^^^^ template.blocks.ng control.block.ng control.block.body.ng
@@ -28,9 +28,9 @@
 #^ template.blocks.ng control.block.ng punctuation.definition.block.ts
 >
 >@switch (a) {
-#^ template.blocks.ng keyword.control.block.transition.ng
-# ^^^^^^ template.blocks.ng keyword.control.block.kind.ng
-#       ^ template.blocks.ng
+#^ template.blocks.ng control.block.ng keyword.control.block.transition.ng
+# ^^^^^^ template.blocks.ng control.block.ng keyword.control.block.kind.ng
+#       ^ template.blocks.ng control.block.ng
 #        ^ template.blocks.ng control.block.ng meta.brace.round.ts
 #         ^ template.blocks.ng control.block.ng control.block.expression.ng variable.other.readwrite.ts
 #          ^ template.blocks.ng control.block.ng meta.brace.round.ts
@@ -50,9 +50,9 @@
 #    ^ template.blocks.ng control.block.ng punctuation.definition.block.ts
 >    @case (2) {
 #^^^^ template.blocks.ng
-#    ^ template.blocks.ng keyword.control.block.transition.ng
-#     ^^^^ template.blocks.ng keyword.control.block.kind.ng
-#         ^ template.blocks.ng
+#    ^ template.blocks.ng control.block.ng keyword.control.block.transition.ng
+#     ^^^^ template.blocks.ng control.block.ng keyword.control.block.kind.ng
+#         ^ template.blocks.ng control.block.ng
 #          ^ template.blocks.ng control.block.ng meta.brace.round.ts
 #           ^ template.blocks.ng control.block.ng control.block.expression.ng constant.numeric.decimal.ts
 #            ^ template.blocks.ng control.block.ng meta.brace.round.ts
@@ -72,9 +72,9 @@
 #    ^ template.blocks.ng control.block.ng punctuation.definition.block.ts
 >    @default {
 #^^^^ template.blocks.ng
-#    ^ template.blocks.ng keyword.control.block.transition.ng
-#     ^^^^^^^ template.blocks.ng keyword.control.block.kind.ng
-#            ^ template.blocks.ng
+#    ^ template.blocks.ng control.block.ng keyword.control.block.transition.ng
+#     ^^^^^^^ template.blocks.ng control.block.ng keyword.control.block.kind.ng
+#            ^ template.blocks.ng control.block.ng
 #             ^ template.blocks.ng control.block.ng punctuation.definition.block.ts
 >        default case
 #^^^^^^^^^^^^^^^^^^^^^ template.blocks.ng control.block.ng control.block.body.ng
@@ -85,9 +85,9 @@
 #^^ template.blocks.ng
 >
 >@if (a==b) { hello } @else  { goodbye }
-#^ template.blocks.ng keyword.control.block.transition.ng
-# ^^ template.blocks.ng keyword.control.block.kind.ng
-#   ^ template.blocks.ng
+#^ template.blocks.ng control.block.ng keyword.control.block.transition.ng
+# ^^ template.blocks.ng control.block.ng keyword.control.block.kind.ng
+#   ^ template.blocks.ng control.block.ng
 #    ^ template.blocks.ng control.block.ng meta.brace.round.ts
 #     ^ template.blocks.ng control.block.ng control.block.expression.ng variable.other.readwrite.ts
 #      ^^ template.blocks.ng control.block.ng control.block.expression.ng keyword.operator.comparison.ts
@@ -98,17 +98,17 @@
 #            ^^^^^^^ template.blocks.ng control.block.ng control.block.body.ng
 #                   ^ template.blocks.ng control.block.ng punctuation.definition.block.ts
 #                    ^ template.blocks.ng
-#                     ^ template.blocks.ng keyword.control.block.transition.ng
-#                      ^^^^ template.blocks.ng keyword.control.block.kind.ng
-#                          ^^ template.blocks.ng
+#                     ^ template.blocks.ng control.block.ng keyword.control.block.transition.ng
+#                      ^^^^ template.blocks.ng control.block.ng keyword.control.block.kind.ng
+#                          ^^ template.blocks.ng control.block.ng
 #                            ^ template.blocks.ng control.block.ng punctuation.definition.block.ts
 #                             ^^^^^^^^^ template.blocks.ng control.block.ng control.block.body.ng
 #                                      ^ template.blocks.ng control.block.ng punctuation.definition.block.ts
 >
 >@if (a==b) { 
-#^ template.blocks.ng keyword.control.block.transition.ng
-# ^^ template.blocks.ng keyword.control.block.kind.ng
-#   ^ template.blocks.ng
+#^ template.blocks.ng control.block.ng keyword.control.block.transition.ng
+# ^^ template.blocks.ng control.block.ng keyword.control.block.kind.ng
+#   ^ template.blocks.ng control.block.ng
 #    ^ template.blocks.ng control.block.ng meta.brace.round.ts
 #     ^ template.blocks.ng control.block.ng control.block.expression.ng variable.other.readwrite.ts
 #      ^^ template.blocks.ng control.block.ng control.block.expression.ng keyword.operator.comparison.ts
@@ -122,9 +122,9 @@
 >} @else if (b==a) { 
 #^ template.blocks.ng control.block.ng punctuation.definition.block.ts
 # ^ template.blocks.ng
-#  ^ template.blocks.ng keyword.control.block.transition.ng
-#   ^^^^^^^ template.blocks.ng keyword.control.block.kind.ng
-#          ^ template.blocks.ng
+#  ^ template.blocks.ng control.block.ng keyword.control.block.transition.ng
+#   ^^^^^^^ template.blocks.ng control.block.ng keyword.control.block.kind.ng
+#          ^ template.blocks.ng control.block.ng
 #           ^ template.blocks.ng control.block.ng meta.brace.round.ts
 #            ^ template.blocks.ng control.block.ng control.block.expression.ng variable.other.readwrite.ts
 #             ^^ template.blocks.ng control.block.ng control.block.expression.ng keyword.operator.comparison.ts
@@ -139,9 +139,9 @@
 #^ template.blocks.ng control.block.ng punctuation.definition.block.ts
 >
 >@for (let item of items; track $index) {
-#^ template.blocks.ng keyword.control.block.transition.ng
-# ^^^ template.blocks.ng keyword.control.block.kind.ng
-#    ^ template.blocks.ng
+#^ template.blocks.ng control.block.ng keyword.control.block.transition.ng
+# ^^^ template.blocks.ng control.block.ng keyword.control.block.kind.ng
+#    ^ template.blocks.ng control.block.ng
 #     ^ template.blocks.ng control.block.ng meta.brace.round.ts
 #      ^^^ template.blocks.ng control.block.ng control.block.expression.ng storage.type.ts
 #         ^ template.blocks.ng control.block.ng control.block.expression.ng
@@ -163,9 +163,9 @@
 #^ template.blocks.ng control.block.ng punctuation.definition.block.ts
 >
 >@if (
-#^ template.blocks.ng keyword.control.block.transition.ng
-# ^^ template.blocks.ng keyword.control.block.kind.ng
-#   ^ template.blocks.ng
+#^ template.blocks.ng control.block.ng keyword.control.block.transition.ng
+# ^^ template.blocks.ng control.block.ng keyword.control.block.kind.ng
+#   ^ template.blocks.ng control.block.ng
 #    ^ template.blocks.ng control.block.ng meta.brace.round.ts
 >    items;
 #^^^^ template.blocks.ng control.block.ng control.block.expression.ng
@@ -199,9 +199,9 @@
 #^ template.blocks.ng control.block.ng punctuation.definition.block.ts
 >
 >@if 
-#^ template.blocks.ng keyword.control.block.transition.ng
-# ^^ template.blocks.ng keyword.control.block.kind.ng
-#   ^^ template.blocks.ng
+#^ template.blocks.ng control.block.ng keyword.control.block.transition.ng
+# ^^ template.blocks.ng control.block.ng keyword.control.block.kind.ng
+#   ^^ template.blocks.ng control.block.ng
 >(items) {}
 #^ template.blocks.ng control.block.ng meta.brace.round.ts
 # ^^^^^ template.blocks.ng control.block.ng control.block.expression.ng variable.other.readwrite.ts
@@ -211,9 +211,9 @@
 #         ^ template.blocks.ng control.block.ng punctuation.definition.block.ts
 >
 >@for 
-#^ template.blocks.ng keyword.control.block.transition.ng
-# ^^^ template.blocks.ng keyword.control.block.kind.ng
-#    ^^ template.blocks.ng
+#^ template.blocks.ng control.block.ng keyword.control.block.transition.ng
+# ^^^ template.blocks.ng control.block.ng keyword.control.block.kind.ng
+#    ^^ template.blocks.ng control.block.ng
 >(item of items; track $index) { }
 #^ template.blocks.ng control.block.ng meta.brace.round.ts
 # ^^^^ template.blocks.ng control.block.ng control.block.expression.ng variable.other.readwrite.ts
@@ -232,9 +232,9 @@
 #                                ^ template.blocks.ng control.block.ng punctuation.definition.block.ts
 >
 >@for (item of items; track $index) { 
-#^ template.blocks.ng keyword.control.block.transition.ng
-# ^^^ template.blocks.ng keyword.control.block.kind.ng
-#    ^ template.blocks.ng
+#^ template.blocks.ng control.block.ng keyword.control.block.transition.ng
+# ^^^ template.blocks.ng control.block.ng keyword.control.block.kind.ng
+#    ^ template.blocks.ng control.block.ng
 #     ^ template.blocks.ng control.block.ng meta.brace.round.ts
 #      ^^^^ template.blocks.ng control.block.ng control.block.expression.ng variable.other.readwrite.ts
 #          ^ template.blocks.ng control.block.ng control.block.expression.ng
@@ -254,9 +254,9 @@
 #^ template.blocks.ng control.block.ng punctuation.definition.block.ts
 # ^^ template.blocks.ng
 >@empty 
-#^ template.blocks.ng keyword.control.block.transition.ng
-# ^^^^^ template.blocks.ng keyword.control.block.kind.ng
-#      ^^ template.blocks.ng
+#^ template.blocks.ng control.block.ng keyword.control.block.transition.ng
+# ^^^^^ template.blocks.ng control.block.ng keyword.control.block.kind.ng
+#      ^^ template.blocks.ng control.block.ng
 >{
 #^ template.blocks.ng control.block.ng punctuation.definition.block.ts
 >


### PR DESCRIPTION
This commit updates the embedded languages of template.blocks.ng to more accurately reflect content. It also makes expressions switch the javascript language. Lastly, this updates the block capture to name the entire content control.block.ng rather than just contentName, which excluded the block name and expression.