### PR TITLE
fix(client,server): Correctly use bundled version unless tsdk is specified

### DIFF
--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -322,8 +322,11 @@ export class AngularLanguageClient implements vscode.Disposable {
       args.push('--forceStrictTemplates');
     }
 
-    const tsdk: string|null = config.get('typescript.tsdk', null);
-    const tsProbeLocations = [tsdk, ...getProbeLocations(this.context.extensionPath)];
+    const tsdk = config.get('typescript.tsdk', '');
+    if (tsdk.trim().length > 0) {
+      args.push('--tsdk', tsdk);
+    }
+    const tsProbeLocations = [...getProbeLocations(this.context.extensionPath)];
     args.push('--tsProbeLocations', tsProbeLocations.join(','));
 
     return args;

--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -253,7 +253,8 @@ export class AngularLanguageClient implements vscode.Disposable {
     // Node module for the language server
     const args = this.constructArgs();
     const prodBundle = this.context.asAbsolutePath('server');
-    const devBundle = this.context.asAbsolutePath(path.join('bazel-bin', 'server', 'src', 'server.js'));
+    const devBundle =
+        this.context.asAbsolutePath(path.join('bazel-bin', 'server', 'src', 'server.js'));
     // VS Code Insider launches extensions in debug mode by default but users
     // install prod bundle so we have to check whether dev bundle exists.
     const latestServerModule = debug && fs.existsSync(devBundle) ? devBundle : prodBundle;
@@ -320,6 +321,9 @@ export class AngularLanguageClient implements vscode.Disposable {
     // block syntax
     if (angularVersions.size > 0 && Array.from(angularVersions).every(v => v.version.major < 17)) {
       args.push('--disableBlockSyntax');
+      this.outputChannel.appendLine(
+          `All workspace roots are using versions of Angular that do not support control flow block syntax.` +
+          ` Block syntax parsing in templates will be disabled.`);
     }
 
     const forceStrictTemplates = config.get<boolean>('angular.forceStrictTemplates');

--- a/server/src/banner.ts
+++ b/server/src/banner.ts
@@ -31,8 +31,8 @@ export function requireOverride(moduleName: string) {
     throw new Error(`Import '${TSSERVER}' instead of 'typescript'`);
   }
   if (moduleName === TSSERVER) {
-    const {tsProbeLocations} = parseCommandLine(process.argv);
-    moduleName = resolveTsServer(tsProbeLocations).resolvedPath;
+    const {tsProbeLocations, tsdk} = parseCommandLine(process.argv);
+    moduleName = resolveTsServer(tsProbeLocations, tsdk).resolvedPath;
   }
   return originalRequire(moduleName);
 }

--- a/server/src/cmdline_utils.ts
+++ b/server/src/cmdline_utils.ts
@@ -33,6 +33,7 @@ interface CommandLineOptions {
   logToConsole: boolean;
   ngProbeLocations: string[];
   tsProbeLocations: string[];
+  tsdk: string|null;
   includeAutomaticOptionalChainCompletions: boolean;
   includeCompletionsWithSnippetText: boolean;
   forceStrictTemplates: boolean;
@@ -47,6 +48,7 @@ export function parseCommandLine(argv: string[]): CommandLineOptions {
     logToConsole: hasArgument(argv, '--logToConsole'),
     ngProbeLocations: parseStringArray(argv, '--ngProbeLocations'),
     tsProbeLocations: parseStringArray(argv, '--tsProbeLocations'),
+    tsdk: findArgument(argv, '--tsdk') ?? null,
     includeAutomaticOptionalChainCompletions:
         hasArgument(argv, '--includeAutomaticOptionalChainCompletions'),
     includeCompletionsWithSnippetText: hasArgument(argv, '--includeCompletionsWithSnippetText'),

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -27,7 +27,7 @@ function main() {
     logVerbosity: options.logVerbosity,
   });
 
-  const ts = resolveTsServer(options.tsProbeLocations);
+  const ts = resolveTsServer(options.tsProbeLocations, options.tsdk);
   const ng = resolveNgLangSvc(options.ngProbeLocations);
 
   const isG3 = ts.resolvedPath.includes('/google3/');

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {version as tsServerVersion} from 'typescript/lib/tsserverlibrary';
+
 import {generateHelpMessage, parseCommandLine} from './cmdline_utils';
 
 // Parse command line arguments
@@ -51,7 +53,7 @@ function main() {
 
   // Log initialization info
   session.info(`Angular language server process ID: ${process.pid}`);
-  session.info(`Using ${ts.name} v${ts.version} from ${ts.resolvedPath}`);
+  session.info(`Imported typescript/lib/tsserverlibrary is version ${tsServerVersion}.`);
   session.info(`Using ${ng.name} v${ng.version} from ${ng.resolvedPath}`);
   if (logger.loggingEnabled()) {
     session.info(`Log file: ${logger.getLogFileName()}`);

--- a/server/src/tests/version_provider_spec.ts
+++ b/server/src/tests/version_provider_spec.ts
@@ -14,7 +14,7 @@ describe('Node Module Resolver', () => {
   const probeLocations = [__dirname];
 
   it('should be able to resolve tsserver', () => {
-    const result = resolveTsServer(probeLocations);
+    const result = resolveTsServer(probeLocations, null);
     expect(result).toBeDefined();
     expect(result.resolvedPath).toMatch(/typescript\/lib\/tsserverlibrary.js$/);
   });
@@ -23,7 +23,7 @@ describe('Node Module Resolver', () => {
     // Resolve relative to cwd.
     const absPath = resolve('node_modules/typescript/lib');
     expect(isAbsolute(absPath)).toBeTrue();
-    const result = resolveTsServer([absPath]);
+    const result = resolveTsServer(probeLocations, absPath);
     expect(result.resolvedPath.endsWith('typescript/lib/tsserverlibrary.js')).toBeTrue();
   });
 

--- a/server/src/version_provider.ts
+++ b/server/src/version_provider.ts
@@ -47,10 +47,9 @@ function resolveWithMinVersion(
  * Resolve `typescript/lib/tsserverlibrary` from the given locations.
  * @param probeLocations
  */
-export function resolveTsServer(probeLocations: string[]): NodeModule {
-  if (probeLocations.length > 0) {
-    // The first probe location is `typescript.tsdk` if it is specified.
-    const resolvedFromTsdk = resolveTsServerFromTsdk(probeLocations[0], probeLocations.slice(1));
+export function resolveTsServer(probeLocations: string[], tsdk: string|null): NodeModule {
+  if (tsdk !== null) {
+    const resolvedFromTsdk = resolveTsServerFromTsdk(tsdk, probeLocations);
     const minVersion = new Version(MIN_TS_VERSION);
     if (resolvedFromTsdk !== undefined) {
       if (resolvedFromTsdk.version.greaterThanOrEqual(minVersion)) {


### PR DESCRIPTION
When the `typescript.tsdk` is empty, it should be ignored. Instead, the
logic previously would _always_ add an empty string tsdk to the
beginning of the probe locations. This would result in resolving the ts
server from the user's node modules rather than prefering the bundled
version as intended unless a different tsdk is specifically set in the
config.

Additionally, if the workspace has many roots, the first one would be
seen as a tsdk. While this would probably still result in the correct
behavior, the code is much easier to follow when the tsdk is a separate
option passed to the server.

(first 3 commits are from #1968)