### PR TITLE
Remove eventBinding and propertyBinding

### DIFF
--- a/syntaxes/src/template.ts
+++ b/syntaxes/src/template.ts
@@ -13,8 +13,6 @@ export const Template: GrammarDefinition = {
   injectionSelector: 'L:text.html -comment',
   patterns: [
     {include: '#interpolation'},
-    {include: '#propertyBinding'},
-    {include: '#eventBinding'},
     {include: '#twoWayBinding'},
     {include: '#templateBinding'},
   ],
@@ -29,52 +27,6 @@ export const Template: GrammarDefinition = {
       endCaptures: {
         0: {name: 'punctuation.definition.block.ts'},
       },
-      contentName: 'expression.ng',
-      patterns: [
-        {include: 'expression.ng'},
-      ],
-    },
-
-    propertyBinding: {
-      begin: /(\[\s*@?[-_a-zA-Z0-9.$]*%?\s*])(=)(["'])/,
-      beginCaptures: {
-        1: {
-          name: 'entity.other.attribute-name.html entity.other.ng-binding-name.property.html',
-          patterns: [
-            {include: '#bindingKey'},
-          ],
-        },
-        2: {name: 'punctuation.separator.key-value.html'},
-        3: {name: 'string.quoted.html punctuation.definition.string.begin.html'},
-      },
-      end: /\3/,
-      endCaptures: {
-        0: {name: 'string.quoted.html punctuation.definition.string.end.html'},
-      },
-      name: 'meta.ng-binding.property.html',
-      contentName: 'expression.ng',
-      patterns: [
-        {include: 'expression.ng'},
-      ],
-    },
-
-    eventBinding: {
-      begin: /(\(\s*@?[-_a-zA-Z0-9.$]*\s*\))(=)(["'])/,
-      beginCaptures: {
-        1: {
-          name: 'entity.other.attribute-name.html entity.other.ng-binding-name.event.html',
-          patterns: [
-            {include: '#bindingKey'},
-          ],
-        },
-        2: {name: 'punctuation.separator.key-value.html'},
-        3: {name: 'string.quoted.html punctuation.definition.string.begin.html'},
-      },
-      end: /\3/,
-      endCaptures: {
-        0: {name: 'string.quoted.html punctuation.definition.string.end.html'},
-      },
-      name: 'meta.ng-binding.event.html',
       contentName: 'expression.ng',
       patterns: [
         {include: 'expression.ng'},

--- a/syntaxes/template.json
+++ b/syntaxes/template.json
@@ -6,12 +6,6 @@
       "include": "#interpolation"
     },
     {
-      "include": "#propertyBinding"
-    },
-    {
-      "include": "#eventBinding"
-    },
-    {
       "include": "#twoWayBinding"
     },
     {
@@ -32,70 +26,6 @@
           "name": "punctuation.definition.block.ts"
         }
       },
-      "contentName": "expression.ng",
-      "patterns": [
-        {
-          "include": "expression.ng"
-        }
-      ]
-    },
-    "propertyBinding": {
-      "begin": "(\\[\\s*@?[-_a-zA-Z0-9.$]*%?\\s*])(=)([\"'])",
-      "beginCaptures": {
-        "1": {
-          "name": "entity.other.attribute-name.html entity.other.ng-binding-name.property.html",
-          "patterns": [
-            {
-              "include": "#bindingKey"
-            }
-          ]
-        },
-        "2": {
-          "name": "punctuation.separator.key-value.html"
-        },
-        "3": {
-          "name": "string.quoted.html punctuation.definition.string.begin.html"
-        }
-      },
-      "end": "\\3",
-      "endCaptures": {
-        "0": {
-          "name": "string.quoted.html punctuation.definition.string.end.html"
-        }
-      },
-      "name": "meta.ng-binding.property.html",
-      "contentName": "expression.ng",
-      "patterns": [
-        {
-          "include": "expression.ng"
-        }
-      ]
-    },
-    "eventBinding": {
-      "begin": "(\\(\\s*@?[-_a-zA-Z0-9.$]*\\s*\\))(=)([\"'])",
-      "beginCaptures": {
-        "1": {
-          "name": "entity.other.attribute-name.html entity.other.ng-binding-name.event.html",
-          "patterns": [
-            {
-              "include": "#bindingKey"
-            }
-          ]
-        },
-        "2": {
-          "name": "punctuation.separator.key-value.html"
-        },
-        "3": {
-          "name": "string.quoted.html punctuation.definition.string.begin.html"
-        }
-      },
-      "end": "\\3",
-      "endCaptures": {
-        "0": {
-          "name": "string.quoted.html punctuation.definition.string.end.html"
-        }
-      },
-      "name": "meta.ng-binding.event.html",
       "contentName": "expression.ng",
       "patterns": [
         {


### PR DESCRIPTION
This removes the Angular definitions of event and property bindings, in favour of those provided by the default HTML extension in VS Code.

This fixes #1725

See https://github.com/angular/vscode-ng-language-service/issues/1725#issuecomment-1671803141 for justification