### PR TITLE
fix: pass oldest Angular version in the workspace to the compiler

### DIFF
--- a/server/src/cmdline_utils.ts
+++ b/server/src/cmdline_utils.ts
@@ -38,6 +38,7 @@ interface CommandLineOptions {
   includeCompletionsWithSnippetText: boolean;
   forceStrictTemplates: boolean;
   disableBlockSyntax: boolean;
+  angularCoreVersion?: string;
 }
 
 export function parseCommandLine(argv: string[]): CommandLineOptions {
@@ -54,6 +55,7 @@ export function parseCommandLine(argv: string[]): CommandLineOptions {
     includeCompletionsWithSnippetText: hasArgument(argv, '--includeCompletionsWithSnippetText'),
     forceStrictTemplates: hasArgument(argv, '--forceStrictTemplates'),
     disableBlockSyntax: hasArgument(argv, '--disableBlockSyntax'),
+    angularCoreVersion: findArgument(argv, '--angularCoreVersion'),
   };
 }
 

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -49,6 +49,7 @@ function main() {
     includeCompletionsWithSnippetText: options.includeCompletionsWithSnippetText,
     forceStrictTemplates: isG3 || options.forceStrictTemplates,
     disableBlockSyntax: options.disableBlockSyntax,
+    angularCoreVersion: options.angularCoreVersion ?? null,
   });
 
   // Log initialization info

--- a/server/src/session.ts
+++ b/server/src/session.ts
@@ -34,6 +34,7 @@ export interface SessionOptions {
   includeCompletionsWithSnippetText: boolean;
   forceStrictTemplates: boolean;
   disableBlockSyntax: boolean;
+  angularCoreVersion: string|null;
 }
 
 enum LanguageId {
@@ -159,6 +160,10 @@ export class Session {
     }
     if (options.disableBlockSyntax) {
       pluginConfig.enableBlockSyntax = false;
+    }
+    if (options.angularCoreVersion !== null) {
+      // TODO(crisbeto): temporarily cast to `any` until 17.2 is released.
+      (pluginConfig as any).angularCoreVersion = options.angularCoreVersion;
     }
     projSvc.configurePlugin({
       pluginName: options.ngPlugin,


### PR DESCRIPTION
Adds some logic to pass the oldest version of Angular that was detected in the workspace to the compiler so that it can produce the most compatible code possible.

Companion change to https://github.com/angular/angular/pull/54423.