### PR TITLE
feat(syntaxes): add support for let declarations

### DIFF
--- a/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
+++ b/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
@@ -2,7 +2,7 @@
 # Input hashes for repository rule npm_translate_lock(name = "npm", pnpm_lock = "//:pnpm-lock.yaml").
 # This file should be checked into version control along with the pnpm-lock.yaml file.
 .npmrc=974837034
-pnpm-lock.yaml=915470004
+pnpm-lock.yaml=730915817
 yarn.lock=1032276408
-package.json=-1247013691
+package.json=-257701941
 pnpm-workspace.yaml=1711114604

--- a/package.json
+++ b/package.json
@@ -186,6 +186,14 @@
         }
       },
       {
+        "path": "./syntaxes/let-declaration.json",
+        "scopeName": "template.let.ng",
+        "injectTo": [
+          "text.html.derivative",
+          "source.ts"
+        ]
+      },
+      {
         "path": "./syntaxes/template-tag.json",
         "scopeName": "template.tag.ng",
         "injectTo": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3631,7 +3631,7 @@ packages:
     resolution: {integrity: sha512-Yra4DbvoW7/Z6LBN560ZwXMjoNOSAN2wRsKFGc4iBeso+mpIA6qj1vfdf9HpMaKAqG6wXTy+1SYEzmNpKXOSsQ==}
     dependencies:
       custom-event: 1.0.1
-      ent: 2.2.0
+      ent: 2.2.1
       extend: 3.0.2
       void-elements: 2.0.1
     dev: true
@@ -3758,8 +3758,8 @@ packages:
       - utf-8-validate
     dev: true
 
-  /engine.io@6.5.4:
-    resolution: {integrity: sha512-KdVSDKhVKyOi+r5uEabrDLZw2qXStVvCsEB/LN3mw4WFi6Gx50jTyuxYVCwAAC0U46FdnzP/ScKRBTXb/NiEOg==}
+  /engine.io@6.5.5:
+    resolution: {integrity: sha512-C5Pn8Wk+1vKBoHghJODM63yk8MvrO9EWZUfkAt5HAqIgPE4/8FF0PEGHXtEd40l223+cE5ABWuPzm38PHFXfMA==}
     engines: {node: '>=10.2.0'}
     dependencies:
       '@types/cookie': 0.4.1
@@ -3771,7 +3771,7 @@ packages:
       cors: 2.8.5
       debug: 4.3.4
       engine.io-parser: 5.2.2
-      ws: 8.11.0
+      ws: 8.17.1
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -3786,8 +3786,11 @@ packages:
       tapable: 2.2.1
     dev: true
 
-  /ent@2.2.0:
-    resolution: {integrity: sha512-GHrMyVZQWvTIdDtpiEXdHZnFQKzeO09apj8Cbl4pKWy4i0Oprcq17usfDt5aO63swf0JOeMWjWQE/LzgSRuWpA==}
+  /ent@2.2.1:
+    resolution: {integrity: sha512-QHuXVeZx9d+tIQAz/XztU0ZwZf2Agg9CcXcgE1rurqvdBeDBrpSwjl8/6XUqMg7tw2Y7uAdKb2sRv+bSEFqQ5A==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      punycode: 1.4.1
     dev: true
 
   /entities@2.0.3:
@@ -5614,7 +5617,7 @@ packages:
       date-format: 4.0.14
       debug: 4.3.4
       flatted: 3.3.1
-      rfdc: 1.3.1
+      rfdc: 1.4.1
       streamroller: 3.1.5
     transitivePeerDependencies:
       - supports-color
@@ -6744,6 +6747,10 @@ packages:
     resolution: {integrity: sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==}
     dev: true
 
+  /punycode@1.4.1:
+    resolution: {integrity: sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==}
+    dev: true
+
   /punycode@2.1.1:
     resolution: {integrity: sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==}
     engines: {node: '>=6'}
@@ -6752,11 +6759,19 @@ packages:
   /q@1.4.1:
     resolution: {integrity: sha512-/CdEdaw49VZVmyIDGUQKDDT53c7qBkO6g5CefWz91Ae+l4+cRtcDYwMTXh6me4O8TMldeGHG3N2Bl84V78Ywbg==}
     engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
+    deprecated: |-
+      You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
+
+      (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
     dev: true
 
   /q@1.5.1:
     resolution: {integrity: sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==}
     engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
+    deprecated: |-
+      You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
+
+      (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
     dev: true
 
   /qjobs@1.2.0:
@@ -7021,8 +7036,8 @@ packages:
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
     dev: true
 
-  /rfdc@1.3.1:
-    resolution: {integrity: sha512-r5a3l5HzYlIC68TpmYKlxWjmOP6wiPJ1vWv2HeLhNsRZMrCkxeqxiHlQ21oXmQ4F3SiryXBHhAD7JZqvOJjFmg==}
+  /rfdc@1.4.1:
+    resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
     dev: true
 
   /rimraf@2.7.1:
@@ -7375,11 +7390,11 @@ packages:
     resolution: {integrity: sha512-W4N+o69rkMEGVuk2D/cvca3uYsvGlMwsySWV447y99gUPghxq42BxqLNMndb+a1mm/5/7NeXVQS7RLa2XyXvYg==}
     dev: true
 
-  /socket.io-adapter@2.5.4:
-    resolution: {integrity: sha512-wDNHGXGewWAjQPt3pyeYBtpWSq9cLE5UW1ZUPL/2eGK9jtse/FpXib7epSTsz0Q0m+6sg6Y4KtcFTlah1bdOVg==}
+  /socket.io-adapter@2.5.5:
+    resolution: {integrity: sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==}
     dependencies:
       debug: 4.3.4
-      ws: 8.11.0
+      ws: 8.17.1
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -7455,8 +7470,8 @@ packages:
       base64id: 2.0.0
       cors: 2.8.5
       debug: 4.3.4
-      engine.io: 6.5.4
-      socket.io-adapter: 2.5.4
+      engine.io: 6.5.5
+      socket.io-adapter: 2.5.5
       socket.io-parser: 4.2.4
     transitivePeerDependencies:
       - bufferutil
@@ -8556,12 +8571,12 @@ packages:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
     dev: true
 
-  /ws@8.11.0:
-    resolution: {integrity: sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==}
+  /ws@8.17.1:
+    resolution: {integrity: sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
-      utf-8-validate: ^5.0.2
+      utf-8-validate: '>=5.0.2'
     peerDependenciesMeta:
       bufferutil:
         optional: true

--- a/syntaxes/BUILD.bazel
+++ b/syntaxes/BUILD.bazel
@@ -15,6 +15,7 @@ js_run_binary(
         "_template.json",
         "_template-blocks.json",
         "_template-tag.json",
+        "_let-declaration.json",
     ]
 )
 
@@ -27,6 +28,7 @@ write_source_files(
         "template.json": "_template.json",
         "template-blocks.json": "_template-blocks.json",
         "template-tag.json": "_template-tag.json",
+        "let-declaration.json": "_let-declaration.json",
     }
 )
 

--- a/syntaxes/let-declaration.json
+++ b/syntaxes/let-declaration.json
@@ -1,0 +1,52 @@
+{
+  "scopeName": "template.let.ng",
+  "injectionSelector": "L:text.html -comment -expression.ng -meta.tag -source.css -source.js",
+  "patterns": [
+    {
+      "include": "#letDeclaration"
+    }
+  ],
+  "repository": {
+    "letDeclaration": {
+      "begin": "(@let)\\s+([_$[:alpha:]][_$[:alnum:]]*)\\s*(=)?",
+      "beginCaptures": {
+        "1": {
+          "name": "storage.type.ng"
+        },
+        "2": {
+          "name": "meta.definition.variable.ng"
+        },
+        "3": {
+          "name": "keyword.operator.assignment.ng"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#letInitializer"
+        }
+      ],
+      "contentName": "meta.definition.variable.ng",
+      "end": "(?<=;)"
+    },
+    "letInitializer": {
+      "begin": "\\s*",
+      "beginCaptures": {
+        "0": {
+          "name": "keyword.operator.assignment.ng"
+        }
+      },
+      "contentName": "meta.definition.variable.initializer.ng",
+      "patterns": [
+        {
+          "include": "expression.ng"
+        }
+      ],
+      "end": ";",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.terminator.statement.ng"
+        }
+      }
+    }
+  }
+}

--- a/syntaxes/src/build.ts
+++ b/syntaxes/src/build.ts
@@ -13,6 +13,7 @@ import {InlineStyles} from './inline-styles';
 import {InlineTemplate} from './inline-template';
 import {Template} from './template';
 import {TemplateBlocks} from './template-blocks';
+import {LetDeclaration} from './template-let-declaration';
 import {TemplateTag} from './template-tag';
 import {GrammarDefinition, JsonObject} from './types';
 
@@ -57,3 +58,4 @@ build(InlineTemplate, 'inline-template');
 build(InlineStyles, 'inline-styles');
 build(TemplateBlocks, 'template-blocks');
 build(TemplateTag, 'template-tag');
+build(LetDeclaration, 'let-declaration');

--- a/syntaxes/src/template-let-declaration.ts
+++ b/syntaxes/src/template-let-declaration.ts
@@ -1,0 +1,45 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {GrammarDefinition} from './types';
+
+export const LetDeclaration: GrammarDefinition = {
+  scopeName: 'template.let.ng',
+  injectionSelector: 'L:text.html -comment -expression.ng -meta.tag -source.css -source.js',
+  patterns: [
+    {include: '#letDeclaration'},
+  ],
+  repository: {
+    letDeclaration: {
+      // Equals group is optional so that we start highlighting as
+      // soon as the user starts writing a valid name.
+      begin: /(@let)\s+([_$[:alpha:]][_$[:alnum:]]*)\s*(=)?/,
+      beginCaptures: {
+        1: {name: 'storage.type.ng'},
+        2: {name: 'meta.definition.variable.ng'},
+        3: {name: 'keyword.operator.assignment.ng'},
+      },
+      patterns: [{include: '#letInitializer'}],
+      contentName: 'meta.definition.variable.ng',
+      end: /(?<=;)/,
+    },
+
+    letInitializer: {
+      begin: /\s*/,
+      beginCaptures: {
+        0: {name: 'keyword.operator.assignment.ng'},
+      },
+      contentName: 'meta.definition.variable.initializer.ng',
+      patterns: [{include: 'expression.ng'}],
+      end: /;/,
+      endCaptures: {
+        0: {name: 'punctuation.terminator.statement.ng'},
+      },
+    },
+  },
+};

--- a/syntaxes/test/cases.ts
+++ b/syntaxes/test/cases.ts
@@ -37,5 +37,11 @@ export const cases = [
     'scopeName': 'template.ng',
     'grammarFiles': ['syntaxes/template.json', 'syntaxes/expression.json'],
     'testFile': 'syntaxes/test/data/expression.html'
-  }
+  },
+  {
+    'name': 'let syntax',
+    'scopeName': 'template.let.ng',
+    'grammarFiles': ['syntaxes/let-declaration.json', 'syntaxes/expression.json'],
+    'testFile': 'syntaxes/test/data/let-declaration.html'
+  },
 ];

--- a/syntaxes/test/data/let-declaration.html
+++ b/syntaxes/test/data/let-declaration.html
@@ -1,0 +1,31 @@
+@let basicLet = 123 + 456;
+
+@let noSpaceAfterEquals =true;
+
+@let noSpaceBeforeEquals= true;
+
+@let noSpaceAroundEquals=true;
+
+@let                    lotOfSpaceAroundEquals      =            true;
+
+@let #invalid = true;
+@let invalidIn#TheMiddle = true;
+@letinvalid = true;
+
+@let stringContainingSemicolon = 'hello ;' + 'world';
+
+@let complexExpression = something ? 123 : {prop: 'hello' + true + 'world'};
+
+@let usingPipes = 123 + foo | async | multiply: 2 | separator: ';';
+
+@if (someExpr | async) {
+  @let inBlock = true;
+
+  @for (foo of bar; track foo) {
+    @let inNestedBlock = 123;
+  }
+}
+
+@let noEquals
+
+@let noValue =

--- a/syntaxes/test/data/let-declaration.html.snap
+++ b/syntaxes/test/data/let-declaration.html.snap
@@ -1,0 +1,192 @@
+>@let basicLet = 123 + 456;
+#^^^^ template.let.ng storage.type.ng
+#    ^ template.let.ng
+#     ^^^^^^^^ template.let.ng meta.definition.variable.ng
+#             ^ template.let.ng
+#              ^ template.let.ng keyword.operator.assignment.ng
+#               ^ template.let.ng meta.definition.variable.ng keyword.operator.assignment.ng
+#                ^^^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng constant.numeric.decimal.ts
+#                   ^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng
+#                    ^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng keyword.operator.arithmetic.ts
+#                     ^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng
+#                      ^^^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng constant.numeric.decimal.ts
+#                         ^ template.let.ng meta.definition.variable.ng punctuation.terminator.statement.ng
+>
+>@let noSpaceAfterEquals =true;
+#^^^^ template.let.ng storage.type.ng
+#    ^ template.let.ng
+#     ^^^^^^^^^^^^^^^^^^ template.let.ng meta.definition.variable.ng
+#                       ^ template.let.ng
+#                        ^ template.let.ng keyword.operator.assignment.ng
+#                         ^^^^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng constant.language.boolean.true.ts
+#                             ^ template.let.ng meta.definition.variable.ng punctuation.terminator.statement.ng
+>
+>@let noSpaceBeforeEquals= true;
+#^^^^ template.let.ng storage.type.ng
+#    ^ template.let.ng
+#     ^^^^^^^^^^^^^^^^^^^ template.let.ng meta.definition.variable.ng
+#                        ^ template.let.ng keyword.operator.assignment.ng
+#                         ^ template.let.ng meta.definition.variable.ng keyword.operator.assignment.ng
+#                          ^^^^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng constant.language.boolean.true.ts
+#                              ^ template.let.ng meta.definition.variable.ng punctuation.terminator.statement.ng
+>
+>@let noSpaceAroundEquals=true;
+#^^^^ template.let.ng storage.type.ng
+#    ^ template.let.ng
+#     ^^^^^^^^^^^^^^^^^^^ template.let.ng meta.definition.variable.ng
+#                        ^ template.let.ng keyword.operator.assignment.ng
+#                         ^^^^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng constant.language.boolean.true.ts
+#                             ^ template.let.ng meta.definition.variable.ng punctuation.terminator.statement.ng
+>
+>@let                    lotOfSpaceAroundEquals      =            true;
+#^^^^ template.let.ng storage.type.ng
+#    ^^^^^^^^^^^^^^^^^^^^ template.let.ng
+#                        ^^^^^^^^^^^^^^^^^^^^^^ template.let.ng meta.definition.variable.ng
+#                                              ^^^^^^ template.let.ng
+#                                                    ^ template.let.ng keyword.operator.assignment.ng
+#                                                     ^^^^^^^^^^^^ template.let.ng meta.definition.variable.ng keyword.operator.assignment.ng
+#                                                                 ^^^^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng constant.language.boolean.true.ts
+#                                                                     ^ template.let.ng meta.definition.variable.ng punctuation.terminator.statement.ng
+>
+>@let #invalid = true;
+#^^^^^^^^^^^^^^^^^^^^^^ template.let.ng
+>@let invalidIn#TheMiddle = true;
+#^^^^ template.let.ng storage.type.ng
+#    ^ template.let.ng
+#     ^^^^^^^^^ template.let.ng meta.definition.variable.ng
+#              ^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng
+#               ^^^^^^^^^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng variable.other.readwrite.ts
+#                        ^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng
+#                         ^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng keyword.operator.assignment.ts
+#                          ^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng
+#                           ^^^^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng constant.language.boolean.true.ts
+#                               ^ template.let.ng meta.definition.variable.ng punctuation.terminator.statement.ng
+>@letinvalid = true;
+#^^^^^^^^^^^^^^^^^^^^ template.let.ng
+>
+>@let stringContainingSemicolon = 'hello ;' + 'world';
+#^^^^ template.let.ng storage.type.ng
+#    ^ template.let.ng
+#     ^^^^^^^^^^^^^^^^^^^^^^^^^ template.let.ng meta.definition.variable.ng
+#                              ^ template.let.ng
+#                               ^ template.let.ng keyword.operator.assignment.ng
+#                                ^ template.let.ng meta.definition.variable.ng keyword.operator.assignment.ng
+#                                 ^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng string.quoted.single.ts punctuation.definition.string.begin.ts
+#                                  ^^^^^^^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng string.quoted.single.ts
+#                                         ^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng string.quoted.single.ts punctuation.definition.string.end.ts
+#                                          ^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng
+#                                           ^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng keyword.operator.arithmetic.ts
+#                                            ^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng
+#                                             ^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng string.quoted.single.ts punctuation.definition.string.begin.ts
+#                                              ^^^^^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng string.quoted.single.ts
+#                                                   ^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng string.quoted.single.ts punctuation.definition.string.end.ts
+#                                                    ^ template.let.ng meta.definition.variable.ng punctuation.terminator.statement.ng
+>
+>@let complexExpression = something ? 123 : {prop: 'hello' + true + 'world'};
+#^^^^ template.let.ng storage.type.ng
+#    ^ template.let.ng
+#     ^^^^^^^^^^^^^^^^^ template.let.ng meta.definition.variable.ng
+#                      ^ template.let.ng
+#                       ^ template.let.ng keyword.operator.assignment.ng
+#                        ^ template.let.ng meta.definition.variable.ng keyword.operator.assignment.ng
+#                         ^^^^^^^^^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng variable.other.readwrite.ts
+#                                  ^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng
+#                                   ^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng keyword.operator.ternary.ts
+#                                    ^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng
+#                                     ^^^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng constant.numeric.decimal.ts
+#                                        ^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng
+#                                         ^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng keyword.operator.ternary.ts
+#                                          ^^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng
+#                                            ^^^^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng variable.other.readwrite.ts
+#                                                ^^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng
+#                                                  ^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng string.quoted.single.ts punctuation.definition.string.begin.ts
+#                                                   ^^^^^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng string.quoted.single.ts
+#                                                        ^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng string.quoted.single.ts punctuation.definition.string.end.ts
+#                                                         ^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng
+#                                                          ^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng keyword.operator.arithmetic.ts
+#                                                           ^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng
+#                                                            ^^^^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng constant.language.boolean.true.ts
+#                                                                ^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng
+#                                                                 ^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng keyword.operator.arithmetic.ts
+#                                                                  ^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng
+#                                                                   ^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng string.quoted.single.ts punctuation.definition.string.begin.ts
+#                                                                    ^^^^^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng string.quoted.single.ts
+#                                                                         ^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng string.quoted.single.ts punctuation.definition.string.end.ts
+#                                                                          ^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng
+#                                                                           ^ template.let.ng meta.definition.variable.ng punctuation.terminator.statement.ng
+>
+>@let usingPipes = 123 + foo | async | multiply: 2 | separator: ';';
+#^^^^ template.let.ng storage.type.ng
+#    ^ template.let.ng
+#     ^^^^^^^^^^ template.let.ng meta.definition.variable.ng
+#               ^ template.let.ng
+#                ^ template.let.ng keyword.operator.assignment.ng
+#                 ^ template.let.ng meta.definition.variable.ng keyword.operator.assignment.ng
+#                  ^^^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng constant.numeric.decimal.ts
+#                     ^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng
+#                      ^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng keyword.operator.arithmetic.ts
+#                       ^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng
+#                        ^^^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng variable.other.readwrite.ts
+#                           ^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng
+#                            ^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng keyword.operator.logical.ts
+#                             ^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng
+#                              ^^^^^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng entity.name.function.pipe.ng
+#                                   ^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng
+#                                    ^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng keyword.operator.logical.ts
+#                                     ^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng
+#                                      ^^^^^^^^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng entity.name.function.pipe.ng
+#                                              ^^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng
+#                                                ^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng constant.numeric.decimal.ts
+#                                                 ^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng
+#                                                  ^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng keyword.operator.logical.ts
+#                                                   ^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng
+#                                                    ^^^^^^^^^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng entity.name.function.pipe.ng
+#                                                             ^^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng
+#                                                               ^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng string.quoted.single.ts punctuation.definition.string.begin.ts
+#                                                                ^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng string.quoted.single.ts
+#                                                                 ^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng string.quoted.single.ts punctuation.definition.string.end.ts
+#                                                                  ^ template.let.ng meta.definition.variable.ng punctuation.terminator.statement.ng
+>
+>@if (someExpr | async) {
+#^^^^^^^^^^^^^^^^^^^^^^^^^ template.let.ng
+>  @let inBlock = true;
+#^^ template.let.ng
+#  ^^^^ template.let.ng storage.type.ng
+#      ^ template.let.ng
+#       ^^^^^^^ template.let.ng meta.definition.variable.ng
+#              ^ template.let.ng
+#               ^ template.let.ng keyword.operator.assignment.ng
+#                ^ template.let.ng meta.definition.variable.ng keyword.operator.assignment.ng
+#                 ^^^^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng constant.language.boolean.true.ts
+#                     ^ template.let.ng meta.definition.variable.ng punctuation.terminator.statement.ng
+>
+>  @for (foo of bar; track foo) {
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.let.ng
+>    @let inNestedBlock = 123;
+#^^^^ template.let.ng
+#    ^^^^ template.let.ng storage.type.ng
+#        ^ template.let.ng
+#         ^^^^^^^^^^^^^ template.let.ng meta.definition.variable.ng
+#                      ^ template.let.ng
+#                       ^ template.let.ng keyword.operator.assignment.ng
+#                        ^ template.let.ng meta.definition.variable.ng keyword.operator.assignment.ng
+#                         ^^^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng constant.numeric.decimal.ts
+#                            ^ template.let.ng meta.definition.variable.ng punctuation.terminator.statement.ng
+>  }
+#^^^^ template.let.ng
+>}
+#^^ template.let.ng
+>
+>@let noEquals
+#^^^^ template.let.ng storage.type.ng
+#    ^ template.let.ng
+#     ^^^^^^^^ template.let.ng meta.definition.variable.ng
+>
+>@let noValue =
+#^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng
+# ^^^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng storage.type.ts
+#    ^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng
+#     ^^^^^^^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng variable.other.readwrite.ts
+#            ^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng
+#             ^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng keyword.operator.assignment.ts
+>


### PR DESCRIPTION
Adds highlighting support for the new `@let` syntax.

Example inside vscode:
<img width="617" alt="image" src="https://github.com/angular/vscode-ng-language-service/assets/4450522/4018cc70-94fe-4614-b170-cfd72a131d45">
