### PR TITLE
fix(server): disable let syntax when not supported

### DIFF
--- a/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
+++ b/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
@@ -2,7 +2,7 @@
 # Input hashes for repository rule npm_translate_lock(name = "npm", pnpm_lock = "//:pnpm-lock.yaml").
 # This file should be checked into version control along with the pnpm-lock.yaml file.
 .npmrc=974837034
-pnpm-lock.yaml=1771343819
-yarn.lock=1590538245
-package.json=1973544585
+pnpm-lock.yaml=943190807
+yarn.lock=-1098466397
+package.json=-90176185
 pnpm-workspace.yaml=1711114604

--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -323,11 +323,25 @@ export class AngularLanguageClient implements vscode.Disposable {
 
     // Only disable block syntax if we find angular/core and every one we find does not support
     // block syntax
-    if (angularVersions.length > 0 && angularVersions.every(v => v.version.major < 17)) {
-      args.push('--disableBlockSyntax');
-      this.outputChannel.appendLine(
-          `All workspace roots are using versions of Angular that do not support control flow block syntax.` +
-          ` Block syntax parsing in templates will be disabled.`);
+    if (angularVersions.length > 0) {
+      const disableBlocks = angularVersions.every(v => v.version.major < 17);
+      const disableLet = angularVersions.every(v => {
+        return v.version.major < 18 || v.version.major === 18 && v.version.minor < 1;
+      });
+
+      if (disableBlocks) {
+        args.push('--disableBlockSyntax');
+        this.outputChannel.appendLine(
+            `All workspace roots are using versions of Angular that do not support control flow block syntax.` +
+            ` Block syntax parsing in templates will be disabled.`);
+      }
+
+      if (disableLet) {
+        args.push('--disableLetSyntax');
+        this.outputChannel.appendLine(
+            `All workspace roots are using versions of Angular that do not support @let syntax.` +
+            ` @let syntax parsing in templates will be disabled.`);
+      }
     }
 
     // Pass the earliest Angular version along to the compiler for maximum compatibility.

--- a/package.json
+++ b/package.json
@@ -238,7 +238,7 @@
     "test:legacy-syntaxes": "yarn compile:syntaxes-test && yarn build:syntaxes && jasmine dist/syntaxes/test/driver.js"
   },
   "dependencies": {
-    "@angular/language-service": "18.1.0-next.2",
+    "@angular/language-service": "18.1.0-next.4",
     "typescript": "5.4.5",
     "vscode-html-languageservice": "^4.2.5",
     "vscode-jsonrpc": "6.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@angular/language-service':
-        specifier: 18.1.0-next.2
-        version: 18.1.0-next.2
+        specifier: 18.1.0-next.4
+        version: 18.1.0-next.4
       typescript:
         specifier: 5.4.5
         version: 5.4.5
@@ -313,8 +313,8 @@ packages:
       zone.js: 0.11.8
     dev: true
 
-  /@angular/language-service@18.1.0-next.2:
-    resolution: {integrity: sha512-d1c/rOmbmVxigzuENEdSKjEx+/tqSbuoQJ5iHUmof/rRQGub4fzFI2I3d2sVOJ4eP38/jifVMWGrX0MdrBbJAw==}
+  /@angular/language-service@18.1.0-next.4:
+    resolution: {integrity: sha512-1ZBwjnNvZczJ3KkBndLzVIxx1SJ8kSoTlig0E6QlDdExdtduC54ZoSQpugYoPyUUfP6ILxfVyt7Z+Xr9/yHZgQ==}
     engines: {node: ^18.19.1 || ^20.11.1 || >=22.0.0}
     dev: false
 

--- a/server/src/cmdline_utils.ts
+++ b/server/src/cmdline_utils.ts
@@ -38,6 +38,7 @@ interface CommandLineOptions {
   includeCompletionsWithSnippetText: boolean;
   forceStrictTemplates: boolean;
   disableBlockSyntax: boolean;
+  disableLetSyntax: boolean;
   angularCoreVersion?: string;
 }
 
@@ -55,6 +56,7 @@ export function parseCommandLine(argv: string[]): CommandLineOptions {
     includeCompletionsWithSnippetText: hasArgument(argv, '--includeCompletionsWithSnippetText'),
     forceStrictTemplates: hasArgument(argv, '--forceStrictTemplates'),
     disableBlockSyntax: hasArgument(argv, '--disableBlockSyntax'),
+    disableLetSyntax: hasArgument(argv, '--disableLetSyntax'),
     angularCoreVersion: findArgument(argv, '--angularCoreVersion'),
   };
 }

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -49,6 +49,7 @@ function main() {
     includeCompletionsWithSnippetText: options.includeCompletionsWithSnippetText,
     forceStrictTemplates: isG3 || options.forceStrictTemplates,
     disableBlockSyntax: options.disableBlockSyntax,
+    disableLetSyntax: options.disableLetSyntax,
     angularCoreVersion: options.angularCoreVersion ?? null,
   });
 

--- a/server/src/session.ts
+++ b/server/src/session.ts
@@ -14,7 +14,7 @@ import {TextDocument} from 'vscode-languageserver-textdocument';
 import * as lsp from 'vscode-languageserver/node';
 
 import {ServerOptions} from '../../common/initialize';
-import {OpenOutputChannel, ProjectLanguageService, ProjectLoadingFinish, ProjectLoadingStart, SuggestStrictMode} from '../../common/notifications';
+import {ProjectLanguageService, ProjectLoadingFinish, ProjectLoadingStart, SuggestStrictMode} from '../../common/notifications';
 import {GetComponentsWithTemplateFile, GetTcbParams, GetTcbRequest, GetTcbResponse, GetTemplateLocationForComponent, GetTemplateLocationForComponentParams, IsInAngularProject, IsInAngularProjectParams} from '../../common/requests';
 
 import {readNgCompletionData, tsCompletionEntryToLspCompletionItem} from './completion';
@@ -34,6 +34,7 @@ export interface SessionOptions {
   includeCompletionsWithSnippetText: boolean;
   forceStrictTemplates: boolean;
   disableBlockSyntax: boolean;
+  disableLetSyntax: boolean;
   angularCoreVersion: string|null;
 }
 
@@ -161,9 +162,11 @@ export class Session {
     if (options.disableBlockSyntax) {
       pluginConfig.enableBlockSyntax = false;
     }
+    if (options.disableLetSyntax) {
+      pluginConfig.enableLetSyntax = false;
+    }
     if (options.angularCoreVersion !== null) {
-      // TODO(crisbeto): temporarily cast to `any` until 17.2 is released.
-      (pluginConfig as any).angularCoreVersion = options.angularCoreVersion;
+      pluginConfig.angularCoreVersion = options.angularCoreVersion;
     }
     projSvc.configurePlugin({
       pluginName: options.ngPlugin,

--- a/yarn.lock
+++ b/yarn.lock
@@ -158,10 +158,10 @@
     uuid "^8.3.2"
     yargs "^17.0.0"
 
-"@angular/language-service@18.1.0-next.2":
-  version "18.1.0-next.2"
-  resolved "https://registry.yarnpkg.com/@angular/language-service/-/language-service-18.1.0-next.2.tgz#f8e31a175ea3df6535f50e1bacf5038e83b5d6d4"
-  integrity sha512-d1c/rOmbmVxigzuENEdSKjEx+/tqSbuoQJ5iHUmof/rRQGub4fzFI2I3d2sVOJ4eP38/jifVMWGrX0MdrBbJAw==
+"@angular/language-service@18.1.0-next.4":
+  version "18.1.0-next.4"
+  resolved "https://registry.yarnpkg.com/@angular/language-service/-/language-service-18.1.0-next.4.tgz#c220a83d999754a281b1f5c1232cab9d966cbd45"
+  integrity sha512-1ZBwjnNvZczJ3KkBndLzVIxx1SJ8kSoTlig0E6QlDdExdtduC54ZoSQpugYoPyUUfP6ILxfVyt7Z+Xr9/yHZgQ==
 
 "@assemblyscript/loader@^0.10.1":
   version "0.10.1"


### PR DESCRIPTION
Disables the `@let` syntax for projects that run an Angular version less than 18.1.