### PR TITLE
build: disable lib check when compiling TS

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
     "sourceMap": true,
     "strict": true,
     "esModuleInterop": true,
-    "declaration": true
+    "declaration": true,
+    "skipLibCheck": true
   },
   "files": [],
   "references": [


### PR DESCRIPTION
When compiling TS, we can skip checking unused `d.ts` files of `node_modules`. Those may fail with errors given potential easy mismatches of types/node and e.g. Chokidar's implementation of `fs.Watcher`. This is a known popular issue. We don't need to check their types though, and can also speed up compilation.