### PR TITLE
chore: update node types. (#2055)

### DIFF
--- a/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
+++ b/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
@@ -2,7 +2,7 @@
 # Input hashes for repository rule npm_translate_lock(name = "npm", pnpm_lock = "//:pnpm-lock.yaml").
 # This file should be checked into version control along with the pnpm-lock.yaml file.
 .npmrc=974837034
-pnpm-lock.yaml=943190807
-yarn.lock=-1098466397
-package.json=1654749565
+pnpm-lock.yaml=-1459672203
+yarn.lock=449424569
+package.json=765457460
 pnpm-workspace.yaml=1711114604

--- a/package.json
+++ b/package.json
@@ -235,7 +235,7 @@
     "@bazel/bazelisk": "1.18.0",
     "@bazel/ibazel": "0.16.2",
     "@types/jasmine": "3.10.7",
-    "@types/node": "14.18.33",
+    "@types/node": "18.19.39",
     "@types/vscode": "1.67.0",
     "clang-format": "1.8.0",
     "cross-env": "^7.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ importers:
         specifier: 3.10.7
         version: 3.10.7
       '@types/node':
-        specifier: 14.18.33
-        version: 14.18.33
+        specifier: 18.19.39
+        version: 18.19.39
       '@types/vscode':
         specifier: 1.67.0
         version: 1.67.0
@@ -71,7 +71,7 @@ importers:
         version: 6.6.7
       ts-node:
         specifier: ^10.8.1
-        version: 10.8.1(@types/node@14.18.33)(typescript@5.4.5)
+        version: 10.8.1(@types/node@18.19.39)(typescript@5.4.5)
       tslint:
         specifier: 6.1.3
         version: 6.1.3(typescript@5.4.5)
@@ -1998,20 +1998,20 @@ packages:
     resolution: {integrity: sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==}
     dependencies:
       '@types/connect': 3.4.35
-      '@types/node': 17.0.30
+      '@types/node': 18.19.39
     dev: true
 
   /@types/bonjour@3.5.10:
     resolution: {integrity: sha512-p7ienRMiS41Nu2/igbJxxLDWrSZ0WxM8UQgCeO9KhoVF7cOVFkrKsiDr1EsJIla8vV3oEEjGcz11jc5yimhzZw==}
     dependencies:
-      '@types/node': 17.0.30
+      '@types/node': 18.19.39
     dev: true
 
   /@types/browser-sync@2.26.3:
     resolution: {integrity: sha512-HIiI438D8q/DXFhdc2JELRMPtuHmR+0q+QNwP/mQoItHvPi7LK+bkZC7amKrSpnB2t4ct8BRd32LtOfd6TMNIw==}
     dependencies:
       '@types/micromatch': 2.3.31
-      '@types/node': 17.0.30
+      '@types/node': 18.19.39
       '@types/serve-static': 1.13.10
       chokidar: 3.5.3
     dev: true
@@ -2024,13 +2024,13 @@ packages:
     resolution: {integrity: sha512-h8QJa8xSb1WD4fpKBDcATDNGXghFj6/3GRWG6dhmRcu0RX1Ubasur2Uvx5aeEwlf0MwblEC2bMzzMQntxnw/Cw==}
     dependencies:
       '@types/express-serve-static-core': 4.17.28
-      '@types/node': 17.0.30
+      '@types/node': 18.19.39
     dev: true
 
   /@types/connect@3.4.35:
     resolution: {integrity: sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==}
     dependencies:
-      '@types/node': 17.0.30
+      '@types/node': 18.19.39
     dev: true
 
   /@types/cookie@0.4.1:
@@ -2062,7 +2062,7 @@ packages:
   /@types/express-serve-static-core@4.17.28:
     resolution: {integrity: sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==}
     dependencies:
-      '@types/node': 17.0.30
+      '@types/node': 18.19.39
       '@types/qs': 6.9.7
       '@types/range-parser': 1.2.4
     dev: true
@@ -2079,7 +2079,7 @@ packages:
   /@types/http-proxy@1.17.8:
     resolution: {integrity: sha512-5kPLG5BKpWYkw/LVOGWpiq3nEVqxiN32rTgI53Sk12/xHFQ2rG3ehI9IO+O3W2QoKeyB92dJkoka8SUm6BX1pA==}
     dependencies:
-      '@types/node': 17.0.30
+      '@types/node': 18.19.39
     dev: true
 
   /@types/jasmine@3.10.7:
@@ -2112,16 +2112,14 @@ packages:
     resolution: {integrity: sha512-yxDeaQIAJlMav7fH5AQqPH1u8YIuhYJXYBzxaQ4PifsU0GDO38MSdmEDeRlIxrKbC6NbEaaEHDanWb+y30U8SQ==}
     dev: true
 
-  /@types/node@14.18.33:
-    resolution: {integrity: sha512-qelS/Ra6sacc4loe/3MSjXNL1dNQ/GjxNHVzuChwMfmk7HuycRLVQN2qNY3XahK+fZc5E2szqQSKUyAF0E+2bg==}
-    dev: true
-
   /@types/node@16.10.9:
     resolution: {integrity: sha512-H9ReOt+yqIJPCutkTYjFjlyK6WEMQYT9hLZMlWtOjFQY2ItppsWZ6RJf8Aw+jz5qTYceuHvFgPIaKOHtLAEWBw==}
     dev: true
 
-  /@types/node@17.0.30:
-    resolution: {integrity: sha512-oNBIZjIqyHYP8VCNAV9uEytXVeXG2oR0w9lgAXro20eugRQfY002qr3CUl6BAe+Yf/z3CRjPdz27Pu6WWtuSRw==}
+  /@types/node@18.19.39:
+    resolution: {integrity: sha512-nPwTRDKUctxw3di5b4TfT3I0sWDiWoPQCZjXhvdkINntwr8lcoVCKsTgnXeRubKIlfnV+eN/HYk6Jb40tbcEAQ==}
+    dependencies:
+      undici-types: 5.26.5
     dev: true
 
   /@types/parse-glob@3.0.29:
@@ -2160,7 +2158,7 @@ packages:
     resolution: {integrity: sha512-Cwo8LE/0rnvX7kIIa3QHCkcuF21c05Ayb0ZfxPiv0W8VRiZiNW/WuRupHKpqqGVGf7SUA44QSOUKaEd9lIrd/Q==}
     dependencies:
       '@types/mime': 1.3.2
-      '@types/node': 17.0.30
+      '@types/node': 18.19.39
     dev: true
 
   /@types/serve-index@1.9.1:
@@ -2173,13 +2171,13 @@ packages:
     resolution: {integrity: sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==}
     dependencies:
       '@types/mime': 1.3.2
-      '@types/node': 17.0.30
+      '@types/node': 18.19.39
     dev: true
 
   /@types/sockjs@0.3.33:
     resolution: {integrity: sha512-f0KEEe05NvUnat+boPTZ0dgaLZ4SfSouXUgv5noUiefG2ajgKjmETo9ZJyuqsl7dfl2aHlLJUiki6B4ZYldiiw==}
     dependencies:
-      '@types/node': 17.0.30
+      '@types/node': 18.19.39
     dev: true
 
   /@types/tmp@0.2.3:
@@ -2197,7 +2195,7 @@ packages:
   /@types/ws@8.5.3:
     resolution: {integrity: sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==}
     dependencies:
-      '@types/node': 17.0.30
+      '@types/node': 18.19.39
     dev: true
 
   /@types/yargs-parser@21.0.0:
@@ -3744,7 +3742,7 @@ packages:
     dependencies:
       '@types/cookie': 0.4.1
       '@types/cors': 2.8.12
-      '@types/node': 17.0.30
+      '@types/node': 18.19.39
       accepts: 1.3.8
       base64id: 2.0.0
       cookie: 0.4.2
@@ -3764,7 +3762,7 @@ packages:
     dependencies:
       '@types/cookie': 0.4.1
       '@types/cors': 2.8.12
-      '@types/node': 17.0.30
+      '@types/node': 18.19.39
       accepts: 1.3.8
       base64id: 2.0.0
       cookie: 0.4.2
@@ -5269,7 +5267,7 @@ packages:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 17.0.30
+      '@types/node': 18.19.39
       merge-stream: 2.0.0
       supports-color: 8.1.1
     dev: true
@@ -7913,7 +7911,7 @@ packages:
     resolution: {integrity: sha512-0z3j8R7MCjy10kc/g+qg7Ln3alJTodw9aDuVWZa3uiWqfuBMKeAeP2ocWcxoyM3D73yz3Jt/Pu4qPr4wHSdB/Q==}
     dev: true
 
-  /ts-node@10.8.1(@types/node@14.18.33)(typescript@5.4.5):
+  /ts-node@10.8.1(@types/node@18.19.39)(typescript@5.4.5):
     resolution: {integrity: sha512-Wwsnao4DQoJsN034wePSg5nZiw4YKXf56mPIAeD6wVmiv+RytNSWqc2f3fKvcUoV+Yn2+yocD71VOfQHbmVX4g==}
     hasBin: true
     peerDependencies:
@@ -7932,7 +7930,7 @@ packages:
       '@tsconfig/node12': 1.0.9
       '@tsconfig/node14': 1.0.1
       '@tsconfig/node16': 1.0.2
-      '@types/node': 14.18.33
+      '@types/node': 18.19.39
       acorn: 8.7.1
       acorn-walk: 8.2.0
       arg: 4.1.3
@@ -8093,6 +8091,10 @@ packages:
 
   /underscore@1.13.1:
     resolution: {integrity: sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g==}
+    dev: true
+
+  /undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
     dev: true
 
   /unicode-canonical-property-names-ecmascript@2.0.0:

--- a/syntaxes/src/inline-styles.ts
+++ b/syntaxes/src/inline-styles.ts
@@ -43,6 +43,7 @@ export const InlineStyles: GrammarDefinition = {
     style: {
       begin: /\s*([`|'|"])/,
       beginCaptures: {1: {name: 'string'}},
+      // @ts-ignore
       end: /\1/,
       endCaptures: {0: {name: 'string'}},
       contentName: 'source.css.scss',

--- a/syntaxes/src/inline-template.ts
+++ b/syntaxes/src/inline-template.ts
@@ -34,6 +34,7 @@ export const InlineTemplate: GrammarDefinition = {
     ngTemplate: {
       begin: /\G\s*([`|'|"])/,
       beginCaptures: {1: {name: 'string'}},
+      // @ts-ignore
       end: /\1/,
       endCaptures: {0: {name: 'string'}},
       contentName: 'text.html.derivative',

--- a/syntaxes/src/template-tag.ts
+++ b/syntaxes/src/template-tag.ts
@@ -31,6 +31,7 @@ export const TemplateTag: GrammarDefinition = {
         2: {name: 'punctuation.separator.key-value.html'},
         3: {name: 'string.quoted.html punctuation.definition.string.begin.html'},
       },
+      // @ts-ignore
       end: /\3/,
       endCaptures: {
         0: {name: 'string.quoted.html punctuation.definition.string.end.html'},
@@ -54,6 +55,7 @@ export const TemplateTag: GrammarDefinition = {
         2: {name: 'punctuation.separator.key-value.html'},
         3: {name: 'string.quoted.html punctuation.definition.string.begin.html'},
       },
+      // @ts-ignore
       end: /\3/,
       endCaptures: {
         0: {name: 'string.quoted.html punctuation.definition.string.end.html'},
@@ -77,6 +79,7 @@ export const TemplateTag: GrammarDefinition = {
         2: {name: 'punctuation.separator.key-value.html'},
         3: {name: 'string.quoted.html punctuation.definition.string.begin.html'},
       },
+      // @ts-ignore
       end: /\3/,
       endCaptures: {
         0: {name: 'string.quoted.html punctuation.definition.string.end.html'},
@@ -100,6 +103,7 @@ export const TemplateTag: GrammarDefinition = {
         2: {name: 'punctuation.separator.key-value.html'},
         3: {name: 'string.quoted.html punctuation.definition.string.begin.html'},
       },
+      // @ts-ignore
       end: /\3/,
       endCaptures: {
         0: {name: 'string.quoted.html punctuation.definition.string.end.html'},

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
     "sourceMap": true,
     "strict": true,
     "esModuleInterop": true,
-    "declaration": true
+    "declaration": true,
+    "skipLibCheck": true
   },
   "files": [],
   "references": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -1836,15 +1836,17 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.24.tgz#c37ac69cb2948afb4cef95f424fa0037971a9a5c"
   integrity sha512-yxDeaQIAJlMav7fH5AQqPH1u8YIuhYJXYBzxaQ4PifsU0GDO38MSdmEDeRlIxrKbC6NbEaaEHDanWb+y30U8SQ==
 
-"@types/node@14.18.33":
-  version "14.18.33"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.33.tgz#8c29a0036771569662e4635790ffa9e057db379b"
-  integrity sha512-qelS/Ra6sacc4loe/3MSjXNL1dNQ/GjxNHVzuChwMfmk7HuycRLVQN2qNY3XahK+fZc5E2szqQSKUyAF0E+2bg==
-
 "@types/node@16.10.9":
   version "16.10.9"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.10.9.tgz#8f1cdd517972f76a3b928298f4c0747cd6fef25a"
   integrity sha512-H9ReOt+yqIJPCutkTYjFjlyK6WEMQYT9hLZMlWtOjFQY2ItppsWZ6RJf8Aw+jz5qTYceuHvFgPIaKOHtLAEWBw==
+
+"@types/node@18.19.39":
+  version "18.19.39"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.39.tgz#c316340a5b4adca3aee9dcbf05de385978590593"
+  integrity sha512-nPwTRDKUctxw3di5b4TfT3I0sWDiWoPQCZjXhvdkINntwr8lcoVCKsTgnXeRubKIlfnV+eN/HYk6Jb40tbcEAQ==
+  dependencies:
+    undici-types "~5.26.4"
 
 "@types/node@^10.1.0":
   version "10.17.60"
@@ -7425,6 +7427,11 @@ underscore@^1.12.1:
   version "1.13.1"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.1.tgz#0c1c6bd2df54b6b69f2314066d65b6cde6fcf9d1"
   integrity sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g==
+
+undici-types@~5.26.4:
+  version "5.26.5"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
+  integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
 
 unicode-canonical-property-names-ecmascript@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This fixes the compilation issue where node & ts.dom had conflicting types for `AbortSignal`