### PR TITLE
fix(syntaxes): inject template tags to top-level source.ts (#2058)

### DIFF
--- a/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
+++ b/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
@@ -4,5 +4,5 @@
 .npmrc=974837034
 pnpm-lock.yaml=943190807
 yarn.lock=-1098466397
-package.json=619455070
+package.json=1654749565
 pnpm-workspace.yaml=1711114604

--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
           "source.ts"
         ],
         "embeddedLanguages": {
-          "text.html": "html",
+          "text.html.derivative": "html",
           "source.css": "css",
           "source.js": "javascript"
         }
@@ -174,12 +174,15 @@
       {
         "path": "./syntaxes/let-declaration.json",
         "scopeName": "template.let.ng",
-        "injectTo": [ "text.html.derivative" ]
+        "injectTo": ["text.html.derivative"]
       },
       {
         "path": "./syntaxes/template-tag.json",
         "scopeName": "template.tag.ng",
-        "injectTo": ["text.html.derivative"]
+        "injectTo": [
+          "text.html.derivative",
+          "source.ts"
+        ]
       },
       {
         "path": "./syntaxes/expression.json",

--- a/syntaxes/inline-template.json
+++ b/syntaxes/inline-template.json
@@ -62,7 +62,7 @@
           "name": "string"
         }
       },
-      "contentName": "text.html",
+      "contentName": "text.html.derivative",
       "patterns": [
         {
           "include": "text.html.derivative"
@@ -72,9 +72,6 @@
         },
         {
           "include": "template.blocks.ng"
-        },
-        {
-          "include": "template.tag.ng"
         },
         {
           "include": "template.let.ng"

--- a/syntaxes/src/inline-template.ts
+++ b/syntaxes/src/inline-template.ts
@@ -36,13 +36,16 @@ export const InlineTemplate: GrammarDefinition = {
       beginCaptures: {1: {name: 'string'}},
       end: /\1/,
       endCaptures: {0: {name: 'string'}},
-      contentName: 'text.html',
+      contentName: 'text.html.derivative',
       patterns: [
-        {include: 'text.html.derivative'},
-        {include: 'template.ng'},
-        {include: 'template.blocks.ng'},
-        {include: 'template.tag.ng'},
-        {include: 'template.let.ng'},
+        {include: 'text.html.derivative'}, {include: 'template.ng'},
+        {include: 'template.blocks.ng'}, {include: 'template.let.ng'},
+        // note: template.tag.ng isn't used here and needs to be directly injected into source.ts
+        // scopes at the top level because it relies entirely on the injectionSelector to filter its
+        // matching out of non-html tag contexts. Since we don't have any scopes that match HTML
+        // tags, we rely entirely on the text.html.derivative pattern matching and apply the tag
+        // scope via injectionSelector only rather than being able to include it in a pattern list
+        // of another match.
       ]
     }
   }

--- a/syntaxes/test/data/inline-template.ts.snap
+++ b/syntaxes/test/data/inline-template.ts.snap
@@ -13,7 +13,7 @@
 #          ^ inline-template.ng meta.object-literal.key.ts punctuation.separator.key-value.ts
 #           ^ inline-template.ng
 #            ^ inline-template.ng string
-#             ^^^^^^^^^^^ inline-template.ng text.html
+#             ^^^^^^^^^^^ inline-template.ng text.html.derivative
 #                        ^ inline-template.ng string
 #                         ^^ inline-template.ng
 >
@@ -25,7 +25,7 @@
 #          ^ inline-template.ng meta.object-literal.key.ts punctuation.separator.key-value.ts
 #           ^ inline-template.ng
 #            ^ inline-template.ng string
-#             ^^^^^^^^^^^ inline-template.ng text.html
+#             ^^^^^^^^^^^ inline-template.ng text.html.derivative
 #                        ^ inline-template.ng string
 #                         ^^ inline-template.ng
 >  template: "<div></div>",
@@ -34,7 +34,7 @@
 #          ^ inline-template.ng meta.object-literal.key.ts punctuation.separator.key-value.ts
 #           ^ inline-template.ng
 #            ^ inline-template.ng string
-#             ^^^^^^^^^^^ inline-template.ng text.html
+#             ^^^^^^^^^^^ inline-template.ng text.html.derivative
 #                        ^ inline-template.ng string
 #                         ^^ inline-template.ng
 >  template: '<div></div>',
@@ -43,7 +43,7 @@
 #          ^ inline-template.ng meta.object-literal.key.ts punctuation.separator.key-value.ts
 #           ^ inline-template.ng
 #            ^ inline-template.ng string
-#             ^^^^^^^^^^^ inline-template.ng text.html
+#             ^^^^^^^^^^^ inline-template.ng text.html.derivative
 #                        ^ inline-template.ng string
 #                         ^^ inline-template.ng
 >
@@ -60,7 +60,7 @@
 #               ^ inline-template.ng meta.brace.round.ts
 #                ^ inline-template.ng
 #                 ^ inline-template.ng string
-#                  ^^^^^^^^^^^ inline-template.ng text.html
+#                  ^^^^^^^^^^^ inline-template.ng text.html.derivative
 #                             ^ inline-template.ng string
 #                              ^ inline-template.ng
 #                               ^ inline-template.ng meta.brace.round.ts
@@ -77,7 +77,7 @@
 #             ^ inline-template.ng meta.object-literal.key.ts punctuation.separator.key-value.ts
 #              ^ inline-template.ng
 #               ^ inline-template.ng string
-#                ^^^^^^^^^^^ inline-template.ng text.html
+#                ^^^^^^^^^^^ inline-template.ng text.html.derivative
 #                           ^ inline-template.ng string
 >  /*
 #^^^^^ inline-template.ng
@@ -108,9 +108,9 @@
 #          ^ inline-template.ng meta.object-literal.key.ts punctuation.separator.key-value.ts
 #           ^ inline-template.ng
 #            ^ inline-template.ng string
-#             ^^ inline-template.ng text.html punctuation.definition.block.ts
-#               ^^^^^^^^ inline-template.ng text.html expression.ng variable.other.readwrite.ts
-#                       ^^ inline-template.ng text.html punctuation.definition.block.ts
+#             ^^ inline-template.ng text.html.derivative punctuation.definition.block.ts
+#               ^^^^^^^^ inline-template.ng text.html.derivative expression.ng variable.other.readwrite.ts
+#                       ^^ inline-template.ng text.html.derivative punctuation.definition.block.ts
 #                         ^ inline-template.ng string
 #                          ^^ inline-template.ng
 >})


### PR DESCRIPTION
note: template.tag.ng isn't used here and needs to be directly injected into source.ts scopes at the top level because it relies entirely on the injectionSelector to filter its matching out of non-html tag contexts. Since we don't have any scopes that match HTML tags, we rely entirely on the text.html.derivative pattern matching and apply the tag scope via injectionSelector only rather than being able to include it in a pattern list of another match.

fixes #2053