### PR TITLE
fix(syntaxes): add back block syntaxes to injection for entire TS file

### DIFF
--- a/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
+++ b/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
@@ -4,5 +4,5 @@
 .npmrc=974837034
 pnpm-lock.yaml=1988059937
 yarn.lock=448809282
-package.json=-1372627236
+package.json=172429918
 pnpm-workspace.yaml=1711114604

--- a/package.json
+++ b/package.json
@@ -164,17 +164,17 @@
       {
         "path": "./syntaxes/template.json",
         "scopeName": "template.ng",
-        "injectTo": ["text.html.derivative"]
+        "injectTo": ["text.html.derivative", "source.ts"]
       },
       {
         "path": "./syntaxes/template-blocks.json",
         "scopeName": "template.blocks.ng",
-        "injectTo": ["text.html.derivative"]
+        "injectTo": ["text.html.derivative", "source.ts"]
       },
       {
         "path": "./syntaxes/let-declaration.json",
         "scopeName": "template.let.ng",
-        "injectTo": ["text.html.derivative"]
+        "injectTo": ["text.html.derivative", "source.ts"]
       },
       {
         "path": "./syntaxes/template-tag.json",

--- a/syntaxes/inline-template.json
+++ b/syntaxes/inline-template.json
@@ -69,12 +69,6 @@
         },
         {
           "include": "template.ng"
-        },
-        {
-          "include": "template.blocks.ng"
-        },
-        {
-          "include": "template.let.ng"
         }
       ]
     }

--- a/syntaxes/src/inline-template.ts
+++ b/syntaxes/src/inline-template.ts
@@ -39,14 +39,8 @@ export const InlineTemplate: GrammarDefinition = {
       endCaptures: {0: {name: 'string'}},
       contentName: 'text.html.derivative',
       patterns: [
-        {include: 'text.html.derivative'}, {include: 'template.ng'},
-        {include: 'template.blocks.ng'}, {include: 'template.let.ng'},
-        // note: template.tag.ng isn't used here and needs to be directly injected into source.ts
-        // scopes at the top level because it relies entirely on the injectionSelector to filter its
-        // matching out of non-html tag contexts. Since we don't have any scopes that match HTML
-        // tags, we rely entirely on the text.html.derivative pattern matching and apply the tag
-        // scope via injectionSelector only rather than being able to include it in a pattern list
-        // of another match.
+        {include: 'text.html.derivative'},
+        {include: 'template.ng'},
       ]
     }
   }


### PR DESCRIPTION
We rely on the `injectionSelector` to prevent matching our grammars in contexts which they should not apply. The `injectionSelector` only applies when the grammar is injected to the file via `injectTo`. Otherwise, the grammer is applied directly when it is included in the `patterns` array of another match.

fixes #2062