### PR TITLE
feat(language-service): Allow specific diagnostics to be suppressed

### DIFF
--- a/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
+++ b/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
@@ -2,7 +2,7 @@
 # Input hashes for repository rule npm_translate_lock(name = "npm", pnpm_lock = "//:pnpm-lock.yaml").
 # This file should be checked into version control along with the pnpm-lock.yaml file.
 .npmrc=974837034
-pnpm-lock.yaml=1398347878
-yarn.lock=-1005893296
-package.json=-657448584
+pnpm-lock.yaml=917719234
+yarn.lock=-619082575
+package.json=-1482224139
 pnpm-workspace.yaml=1711114604

--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -355,6 +355,12 @@ export class AngularLanguageClient implements vscode.Disposable {
       args.push('--forceStrictTemplates');
     }
 
+    const suppressAngularDiagnosticCodes =
+        config.get<string>('angular.suppressAngularDiagnosticCodes');
+    if (suppressAngularDiagnosticCodes) {
+      args.push('--suppressAngularDiagnosticCodes', suppressAngularDiagnosticCodes);
+    }
+
     const tsdk = config.get('typescript.tsdk', '');
     if (tsdk.trim().length > 0) {
       args.push('--tsdk', tsdk);

--- a/package.json
+++ b/package.json
@@ -135,6 +135,11 @@
           "type": "boolean",
           "default": false,
           "markdownDescription": "Enabling this option will force the language service to use [strictTemplates](https://angular.io/guide/angular-compiler-options#stricttemplates) and ignore the user settings in the `tsconfig.json`."
+        },
+        "angular.suppressAngularDiagnosticCodes": {
+          "type": "string",
+          "default": "",
+          "markdownDescription": "A comma-separated list of error codes in templates whose diagnostics should be ignored."
         }
       }
     },
@@ -164,7 +169,10 @@
       {
         "path": "./syntaxes/template.json",
         "scopeName": "template.ng",
-        "injectTo": ["text.html.derivative", "source.ts"],
+        "injectTo": [
+          "text.html.derivative",
+          "source.ts"
+        ],
         "embeddedLanguages": {
           "text.html": "html",
           "source.css": "css",
@@ -174,7 +182,10 @@
       {
         "path": "./syntaxes/template-blocks.json",
         "scopeName": "template.blocks.ng",
-        "injectTo": ["text.html.derivative", "source.ts"],
+        "injectTo": [
+          "text.html.derivative",
+          "source.ts"
+        ],
         "embeddedLanguages": {
           "text.html": "html",
           "control.block.expression.ng": "javascript",
@@ -184,7 +195,10 @@
       {
         "path": "./syntaxes/let-declaration.json",
         "scopeName": "template.let.ng",
-        "injectTo": ["text.html.derivative", "source.ts"]
+        "injectTo": [
+          "text.html.derivative",
+          "source.ts"
+        ]
       },
       {
         "path": "./syntaxes/template-tag.json",
@@ -231,7 +245,7 @@
     "test:legacy-syntaxes": "yarn compile:syntaxes-test && yarn build:syntaxes && jasmine dist/syntaxes/test/driver.js"
   },
   "dependencies": {
-    "@angular/language-service": "~19.0.0-next.3",
+    "@angular/language-service": "~19.0.0-next.4",
     "typescript": "5.6.1-rc",
     "vscode-html-languageservice": "^4.2.5",
     "vscode-jsonrpc": "6.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@angular/language-service':
-        specifier: ~19.0.0-next.3
-        version: 19.0.0-next.3
+        specifier: ~19.0.0-next.4
+        version: 19.0.0-next.4
       typescript:
         specifier: 5.6.1-rc
         version: 5.6.1-rc
@@ -335,8 +335,8 @@ packages:
       tslib: 2.6.3
     dev: true
 
-  /@angular/language-service@19.0.0-next.3:
-    resolution: {integrity: sha512-9xu7dn6nEj9msJTS9TK9CJbmn4D26EMk3ONlVwqmzeNe/m98V5WKcYI/ouAchR9ZC5HKU6SOppPjb3RjK0HAEA==}
+  /@angular/language-service@19.0.0-next.4:
+    resolution: {integrity: sha512-LPNvgTeOe4icJSy2ryYdkqekxYmqPtjqbbPyo5HPH8jH7fcSDhXHKqMk5U/ho1quEvrBosGXE+sx+MO0u2mQqg==}
     engines: {node: ^18.19.1 || ^20.11.1 || >=22.0.0}
     dev: false
 

--- a/server/package.json
+++ b/server/package.json
@@ -15,7 +15,7 @@
     "ngserver": "./bin/ngserver"
   },
   "dependencies": {
-    "@angular/language-service": "19.0.0-next.3",
+    "@angular/language-service": "19.0.0-next.4",
     "vscode-html-languageservice": "^4.2.5",
     "vscode-jsonrpc": "6.0.0",
     "vscode-languageserver": "7.0.0",

--- a/server/src/cmdline_utils.ts
+++ b/server/src/cmdline_utils.ts
@@ -40,6 +40,7 @@ interface CommandLineOptions {
   disableBlockSyntax: boolean;
   disableLetSyntax: boolean;
   angularCoreVersion?: string;
+  suppressAngularDiagnosticCodes?: string;
 }
 
 export function parseCommandLine(argv: string[]): CommandLineOptions {
@@ -58,6 +59,7 @@ export function parseCommandLine(argv: string[]): CommandLineOptions {
     disableBlockSyntax: hasArgument(argv, '--disableBlockSyntax'),
     disableLetSyntax: hasArgument(argv, '--disableLetSyntax'),
     angularCoreVersion: findArgument(argv, '--angularCoreVersion'),
+    suppressAngularDiagnosticCodes: findArgument(argv, '--suppressAngularDiagnosticCodes'),
   };
 }
 
@@ -76,6 +78,7 @@ export function generateHelpMessage(argv: string[]) {
     --includeAutomaticOptionalChainCompletions: Shows completions on potentially undefined values that insert an optional chain call. Requires TS 3.7+ and strict null checks to be enabled.
     --includeCompletionsWithSnippetText: Enables snippet completions from Angular language server;
     --forceStrictTemplates: Forces the language service to use strictTemplates and ignore the user settings in the 'tsconfig.json'.
+    --suppressAngularDiagnosticCodes: A comma-separated list of error codes in templates whose diagnostics should be ignored.
 
   Additional options supported by vscode-languageserver:
     --clientProcessId=<number>: Automatically kills the server if the client process dies.

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -51,6 +51,7 @@ function main() {
     disableBlockSyntax: options.disableBlockSyntax,
     disableLetSyntax: options.disableLetSyntax,
     angularCoreVersion: options.angularCoreVersion ?? null,
+    suppressAngularDiagnosticCodes: options.suppressAngularDiagnosticCodes ?? null,
   });
 
   // Log initialization info

--- a/server/src/session.ts
+++ b/server/src/session.ts
@@ -36,6 +36,7 @@ export interface SessionOptions {
   disableBlockSyntax: boolean;
   disableLetSyntax: boolean;
   angularCoreVersion: string|null;
+  suppressAngularDiagnosticCodes: string|null;
 }
 
 enum LanguageId {
@@ -51,6 +52,11 @@ const defaultFormatOptions: ts.FormatCodeSettings = {};
 const defaultPreferences: ts.UserPreferences = {};
 
 const htmlLS = getHTMLLanguageService();
+
+const alwaysSuppressDiagnostics: number[] = [
+  // Diagnostics codes whose errors should always be suppressed, regardless of the options
+  // configuration.
+];
 
 /**
  * Session is a wrapper around lsp.IConnection, with all the necessary protocol
@@ -164,6 +170,12 @@ export class Session {
     }
     if (options.angularCoreVersion !== null) {
       pluginConfig.angularCoreVersion = options.angularCoreVersion;
+    }
+    if (options.suppressAngularDiagnosticCodes !== null) {
+      const parsedDiagnosticCodes =
+          options.suppressAngularDiagnosticCodes.split(',').map(c => parseInt(c));
+      pluginConfig.suppressAngularDiagnosticCodes =
+          [...alwaysSuppressDiagnostics, ...parsedDiagnosticCodes];
     }
     projSvc.configurePlugin({
       pluginName: options.ngPlugin,

--- a/yarn.lock
+++ b/yarn.lock
@@ -173,10 +173,10 @@
     uuid "^8.3.2"
     yargs "^17.0.0"
 
-"@angular/language-service@~19.0.0-next.3":
-  version "19.0.0-next.3"
-  resolved "https://registry.yarnpkg.com/@angular/language-service/-/language-service-19.0.0-next.3.tgz#d58460785969470ae0108d59c7c9d4030551b162"
-  integrity sha512-9xu7dn6nEj9msJTS9TK9CJbmn4D26EMk3ONlVwqmzeNe/m98V5WKcYI/ouAchR9ZC5HKU6SOppPjb3RjK0HAEA==
+"@angular/language-service@~19.0.0-next.4":
+  version "19.0.0-next.4"
+  resolved "https://registry.yarnpkg.com/@angular/language-service/-/language-service-19.0.0-next.4.tgz#137b256262d50ef4d023254ab72d7a00e4bfde27"
+  integrity sha512-LPNvgTeOe4icJSy2ryYdkqekxYmqPtjqbbPyo5HPH8jH7fcSDhXHKqMk5U/ho1quEvrBosGXE+sx+MO0u2mQqg==
 
 "@assemblyscript/loader@^0.10.1":
   version "0.10.1"


### PR DESCRIPTION
Allow the language service plugin to pass diagnostic codes that should be ignored via the PluginConfig.

This change corresponds to PR angular/angular#57675.

In addition to providing an easily patchable array and a command-line option, it's also wired up to the extension settings:
<img width="626" alt="ng-ignore-diagnostic" src="https://github.com/user-attachments/assets/bbb96356-7057-4ecd-954d-656800e613bb">

Fixes #1243