### PR TITLE
release: cut pre-release `v19.0.0-next.1` for vscode extension

### DIFF
--- a/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
+++ b/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
@@ -2,7 +2,7 @@
 # Input hashes for repository rule npm_translate_lock(name = "npm", pnpm_lock = "//:pnpm-lock.yaml").
 # This file should be checked into version control along with the pnpm-lock.yaml file.
 .npmrc=974837034
-pnpm-lock.yaml=-669844848
-yarn.lock=-1354378917
-package.json=1362856573
+pnpm-lock.yaml=1558677558
+yarn.lock=1032887011
+package.json=-54516055
 pnpm-workspace.yaml=1711114604

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# 19.0.0-next.1
+This release upgrades `@angular/language-service` to v19.0.0-next.11.
+
+* **feat**: Code refactoring action to migrate `@Input` to signal inputs.
+  * https://v19.angular.dev/reference/migrations/signal-inputs
+* **feat**: Code refactoring action to migrate decorator queries to signal queries.
+e.g. `@ViewChild` to `viewChild()`.
+  * https://v19.angular.dev/reference/migrations/signal-queries
+
+To use any of the new code refactoring actions, click on an input or query, and wait for
+the code refactoring lightbulb to appear. You can also click on the class header to update
+inputs or queries for the full class!
+
 # 19.0.0-next.0
 This release upgrades `@angular/language-service` to v19.0.0-next.6.
 
@@ -111,7 +124,7 @@ This release upgrades `@angular/language-service` to v17.0.0-next.6.
 This release upgrades the `@angular/language-service` to v16.2.8
 
 * fix: Retain correct language service when ts.Project reloads ([#51912](https://github.com/angular/angular/commit/08482f2c7dcbcd100981dfb266a6e63f64432328))
-* fix(server): support to show the tag info in the jsDoc (#1904) 
+* fix(server): support to show the tag info in the jsDoc (#1904)
 * fix(client): fix detection of Angular context after string interpolation (#1922)
 
 # 16.1.8
@@ -208,8 +221,8 @@ This release upgrades `@angular/language-service` to v14.0.0
 * feat(extension): Support renaming from TypeScript files (#1589)
 * feat(extension): Add option to force strict templates (#1646) (17fdb9ec6)
 * feat: add command to run ngcc manually (#1621) (dd0e0009b)
-* Fix detection of Angular for v14+ projects ([#45998](https://github.com/angular/angular/pull/45998)) 
-* Prevent TSServer from removing templates from project ([#45965](https://github.com/angular/angular/pull/45965)) 
+* Fix detection of Angular for v14+ projects ([#45998](https://github.com/angular/angular/pull/45998))
+* Prevent TSServer from removing templates from project ([#45965](https://github.com/angular/angular/pull/45965))
 
 # v13.3.4
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ng-template",
   "displayName": "Angular Language Service",
   "description": "Editor services for Angular templates",
-  "version": "19.0.0-next.0",
+  "version": "19.0.0-next.1",
   "publisher": "Angular",
   "icon": "angular.png",
   "license": "MIT",
@@ -246,7 +246,7 @@
   },
   "dependencies": {
     "@angular/language-service": "~19.0.0-next.11",
-    "typescript": "5.6.1-rc",
+    "typescript": "5.6.2",
     "vscode-html-languageservice": "^4.2.5",
     "vscode-jsonrpc": "6.0.0",
     "vscode-languageclient": "7.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ~19.0.0-next.11
         version: 19.0.0-next.11
       typescript:
-        specifier: 5.6.1-rc
-        version: 5.6.1-rc
+        specifier: 5.6.2
+        version: 5.6.2
       vscode-html-languageservice:
         specifier: ^4.2.5
         version: 4.2.5
@@ -74,13 +74,13 @@ importers:
         version: 6.6.7
       ts-node:
         specifier: ^10.8.1
-        version: 10.9.2(@types/node@18.19.39)(typescript@5.6.1-rc)
+        version: 10.9.2(@types/node@18.19.39)(typescript@5.6.2)
       tslint:
         specifier: 6.1.3
-        version: 6.1.3(typescript@5.6.1-rc)
+        version: 6.1.3(typescript@5.6.2)
       tslint-eslint-rules:
         specifier: 5.4.0
-        version: 5.4.0(tslint@6.1.3)(typescript@5.6.1-rc)
+        version: 5.4.0(tslint@6.1.3)(typescript@5.6.2)
       vsce:
         specifier: 1.100.1
         version: 1.100.1
@@ -155,7 +155,7 @@ packages:
       '@angular-devkit/architect': 0.1401.0-next.1
       '@angular-devkit/build-webpack': 0.1401.0-next.1(webpack-dev-server@4.9.1)(webpack@5.73.0)
       '@angular-devkit/core': 14.1.0-next.1
-      '@angular/compiler-cli': 14.3.0(@angular/compiler@14.3.0)(typescript@5.6.1-rc)
+      '@angular/compiler-cli': 14.3.0(@angular/compiler@14.3.0)(typescript@5.6.2)
       '@babel/core': 7.18.2
       '@babel/generator': 7.18.2
       '@babel/helper-annotate-as-pure': 7.16.7
@@ -276,7 +276,7 @@ packages:
       - zone.js
     dev: true
 
-  /@angular/compiler-cli@14.3.0(@angular/compiler@14.3.0)(typescript@5.6.1-rc):
+  /@angular/compiler-cli@14.3.0(@angular/compiler@14.3.0)(typescript@5.6.2):
     resolution: {integrity: sha512-eoKpKdQ2X6axMgzcPUMZVYl3bIlTMzMeTo5V29No4BzgiUB+QoOTYGNJZkGRyqTNpwD9uSBJvmT2vG9+eC4ghQ==}
     engines: {node: ^14.15.0 || >=16.10.0}
     hasBin: true
@@ -294,7 +294,7 @@ packages:
       semver: 7.6.2
       sourcemap-codec: 1.4.8
       tslib: 2.6.3
-      typescript: 5.6.1-rc
+      typescript: 5.6.2
       yargs: 17.7.2
     transitivePeerDependencies:
       - supports-color
@@ -2021,7 +2021,7 @@ packages:
       typescript: '>=4.6.2 <4.8'
       webpack: ^5.54.0
     dependencies:
-      '@angular/compiler-cli': 14.3.0(@angular/compiler@14.3.0)(typescript@5.6.1-rc)
+      '@angular/compiler-cli': 14.3.0(@angular/compiler@14.3.0)(typescript@5.6.2)
       typescript: 4.7.4
       webpack: 5.73.0(esbuild@0.14.39)
     dev: true
@@ -8208,7 +8208,7 @@ packages:
     resolution: {integrity: sha512-0z3j8R7MCjy10kc/g+qg7Ln3alJTodw9aDuVWZa3uiWqfuBMKeAeP2ocWcxoyM3D73yz3Jt/Pu4qPr4wHSdB/Q==}
     dev: true
 
-  /ts-node@10.9.2(@types/node@18.19.39)(typescript@5.6.1-rc):
+  /ts-node@10.9.2(@types/node@18.19.39)(typescript@5.6.2):
     resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
     hasBin: true
     peerDependencies:
@@ -8234,7 +8234,7 @@ packages:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 5.6.1-rc
+      typescript: 5.6.2
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     dev: true
@@ -8255,7 +8255,7 @@ packages:
     resolution: {integrity: sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==}
     dev: true
 
-  /tslint-eslint-rules@5.4.0(tslint@6.1.3)(typescript@5.6.1-rc):
+  /tslint-eslint-rules@5.4.0(tslint@6.1.3)(typescript@5.6.2):
     resolution: {integrity: sha512-WlSXE+J2vY/VPgIcqQuijMQiel+UtmXS+4nvK4ZzlDiqBfXse8FAvkNnTcYhnQyOTW5KFM+uRRGXxYhFpuBc6w==}
     peerDependencies:
       tslint: ^5.0.0
@@ -8263,12 +8263,12 @@ packages:
     dependencies:
       doctrine: 0.7.2
       tslib: 1.9.0
-      tslint: 6.1.3(typescript@5.6.1-rc)
-      tsutils: 3.21.0(typescript@5.6.1-rc)
-      typescript: 5.6.1-rc
+      tslint: 6.1.3(typescript@5.6.2)
+      tsutils: 3.21.0(typescript@5.6.2)
+      typescript: 5.6.2
     dev: true
 
-  /tslint@6.1.3(typescript@5.6.1-rc):
+  /tslint@6.1.3(typescript@5.6.2):
     resolution: {integrity: sha512-IbR4nkT96EQOvKE2PW/djGz8iGNeJ4rF2mBfiYaR/nvUWYKJhLwimoJKgjIFEIDibBtOevj7BqCRL4oHeWWUCg==}
     engines: {node: '>=4.8.0'}
     deprecated: TSLint has been deprecated in favor of ESLint. Please see https://github.com/palantir/tslint/issues/4534 for more information.
@@ -8288,17 +8288,17 @@ packages:
       resolve: 1.22.8
       semver: 5.7.2
       tslib: 1.14.1
-      tsutils: 2.29.0(typescript@5.6.1-rc)
-      typescript: 5.6.1-rc
+      tsutils: 2.29.0(typescript@5.6.2)
+      typescript: 5.6.2
     dev: true
 
-  /tsutils@2.29.0(typescript@5.6.1-rc):
+  /tsutils@2.29.0(typescript@5.6.2):
     resolution: {integrity: sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==}
     peerDependencies:
       typescript: '>=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >= 3.0.0-dev || >= 3.1.0-dev'
     dependencies:
       tslib: 1.14.1
-      typescript: 5.6.1-rc
+      typescript: 5.6.2
     dev: true
 
   /tsutils@3.21.0(typescript@4.7.4):
@@ -8311,14 +8311,14 @@ packages:
       typescript: 4.7.4
     dev: true
 
-  /tsutils@3.21.0(typescript@5.6.1-rc):
+  /tsutils@3.21.0(typescript@5.6.2):
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
-      typescript: 5.6.1-rc
+      typescript: 5.6.2
     dev: true
 
   /tunnel-agent@0.6.0:
@@ -8373,8 +8373,8 @@ packages:
     hasBin: true
     dev: true
 
-  /typescript@5.6.1-rc:
-    resolution: {integrity: sha512-E3b2+1zEFu84jB0YQi9BORDjz9+jGbwwy1Zi3G0LUNw7a7cePUrHMRNy8aPh53nXpkFGVHSxIZo5vKTfYaFiBQ==}
+  /typescript@5.6.2:
+    resolution: {integrity: sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==}
     engines: {node: '>=14.17'}
     hasBin: true
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7258,10 +7258,10 @@ typed-rest-client@^1.8.4:
     tunnel "0.0.6"
     underscore "^1.12.1"
 
-typescript@5.6.1-rc:
-  version "5.6.1-rc"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.6.1-rc.tgz#d5e4d7d8170174fed607b74cc32aba3d77018e02"
-  integrity sha512-E3b2+1zEFu84jB0YQi9BORDjz9+jGbwwy1Zi3G0LUNw7a7cePUrHMRNy8aPh53nXpkFGVHSxIZo5vKTfYaFiBQ==
+typescript@5.6.2:
+  version "5.6.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.6.2.tgz#d1de67b6bef77c41823f822df8f0b3bcff60a5a0"
+  integrity sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==
 
 typescript@~4.6.3:
   version "4.6.4"


### PR DESCRIPTION
Cuts a new pre-release for the v19 VSCode extension.