### PR TITLE
docs: update nvim-lspconfig link

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,6 @@ code --install-extension /path/to/ngls.vsix
 ## Angular Language Service for Other Editors
 
 - [coc-angular](https://github.com/iamcco/coc-angular) for ([Neo](https://neovim.io))[vim](https://www.vim.org/)
-- [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#angularls) for [Neovim](https://neovim.io)
+- [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig/blob/master/doc/configs.md#angularls) for [Neovim](https://neovim.io)
 - [Wild Web Developer](https://github.com/eclipse/wildwebdeveloper) for Eclipse
 - [lsp-mode](https://github.com/emacs-lsp/lsp-mode) for Emacs


### PR DESCRIPTION
Updates the link in README for `nvim-lspconfig` configuration.