### PR TITLE
build: cut 19.0.1 vscode extension release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 19.0.1
+
+* **fix**: [improve detection of Angular core version in monorepo setup](https://github.com/angular/vscode-ng-language-service/commit/6692c40500cabe7f1fae9cc12e6298946a2e37ee)
+
 # 19.0.0
 This release upgrades `@angular/language-service` to v19.0.0-rc.1.
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ng-template",
   "displayName": "Angular Language Service",
   "description": "Editor services for Angular templates",
-  "version": "19.0.0",
+  "version": "19.0.1",
   "publisher": "Angular",
   "icon": "angular.png",
   "license": "MIT",


### PR DESCRIPTION
Cuts a v19.0.1 vscode extension release with a fix for the Angular core version detection.