### PR TITLE
docs: change links in markdown descriptions to adev

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
         "angular.enable-strict-mode-prompt": {
           "type": "boolean",
           "default": true,
-          "markdownDescription": "Prompt to enable the [strictTemplates](https://angular.io/guide/angular-compiler-options#stricttemplates) flag in [angularCompilerOptions](https://angular.io/guide/angular-compiler-options). Note that strict mode is only available when using Ivy."
+          "markdownDescription": "Prompt to enable the [strictTemplates](https://angular.dev/reference/configs/angular-compiler-options#stricttemplates) flag in [angularCompilerOptions](https://angular.dev/reference/configs/angular-compiler-options). Note that strict mode is only available when using Ivy."
         },
         "angular.trace.server": {
           "type": "string",
@@ -134,7 +134,7 @@
         "angular.forceStrictTemplates": {
           "type": "boolean",
           "default": false,
-          "markdownDescription": "Enabling this option will force the language service to use [strictTemplates](https://angular.io/guide/angular-compiler-options#stricttemplates) and ignore the user settings in the `tsconfig.json`."
+          "markdownDescription": "Enabling this option will force the language service to use [strictTemplates](https://angular.dev/reference/configs/angular-compiler-options#stricttemplates) and ignore the user settings in the `tsconfig.json`."
         },
         "angular.suppressAngularDiagnosticCodes": {
           "type": "string",


### PR DESCRIPTION
Replaces links in the markdown descriptions from aio to adev