### PR TITLE
fix: replace the closing symbol for inputs/outputs.

### DIFF
--- a/server/src/session.ts
+++ b/server/src/session.ts
@@ -1236,12 +1236,8 @@ export class Session {
     if (!completions) {
       return null;
     }
-    const clientSupportsInsertReplaceCompletion =
-        this.clientCapabilities.textDocument?.completion?.completionItem?.insertReplaceSupport ??
-        false;
     return completions.entries.map(
-        (e) => tsCompletionEntryToLspCompletionItem(
-            e, params.position, scriptInfo, clientSupportsInsertReplaceCompletion));
+        (e) => tsCompletionEntryToLspCompletionItem(e, params.position, scriptInfo));
   }
 
   private onCompletionResolve(item: lsp.CompletionItem): lsp.CompletionItem {


### PR DESCRIPTION
The Angular Language Service does not return `InsertReplaceEdit`. There is no need to allow the developer to choose how to insert the completion.

```
For example, `<button (c|) />`.
                      ^^__________Insert edit
                      ^^ ^________Replace edit
```
If the LS returns the `InsertReplaceEdit` as shown above, selecting "Insert" by the developer results in `(click)="")`, and selecting "Replace" results in `(click)=""`.

Now in the vscode, the default `editor.suggest.insertMode` value for HTML is `Replace`, for ts is `Insert`, So this leads to a bug in the ts file.

Fixes https://github.com/angular/vscode-ng-language-service/issues/2137