### PR TITLE
fix(syntaxes): `variable` token for `@let` binding

### DIFF
--- a/syntaxes/let-declaration.json
+++ b/syntaxes/let-declaration.json
@@ -8,13 +8,14 @@
   ],
   "repository": {
     "letDeclaration": {
+      "name": "meta.definition.variable.ng",
       "begin": "(@let)\\s+([_$[:alpha:]][_$[:alnum:]]*)\\s*(=)?",
       "beginCaptures": {
         "1": {
           "name": "storage.type.ng"
         },
         "2": {
-          "name": "meta.definition.variable.ng"
+          "name": "variable.other.constant.ng"
         },
         "3": {
           "name": "keyword.operator.assignment.ng"
@@ -25,7 +26,6 @@
           "include": "#letInitializer"
         }
       ],
-      "contentName": "meta.definition.variable.ng",
       "end": "(?<=;)"
     },
     "letInitializer": {

--- a/syntaxes/src/template-let-declaration.ts
+++ b/syntaxes/src/template-let-declaration.ts
@@ -16,16 +16,16 @@ export const LetDeclaration: GrammarDefinition = {
   ],
   repository: {
     letDeclaration: {
+      name: 'meta.definition.variable.ng',
       // Equals group is optional so that we start highlighting as
       // soon as the user starts writing a valid name.
       begin: /(@let)\s+([_$[:alpha:]][_$[:alnum:]]*)\s*(=)?/,
       beginCaptures: {
         1: {name: 'storage.type.ng'},
-        2: {name: 'meta.definition.variable.ng'},
+        2: {name: 'variable.other.constant.ng'},
         3: {name: 'keyword.operator.assignment.ng'},
       },
       patterns: [{include: '#letInitializer'}],
-      contentName: 'meta.definition.variable.ng',
       end: /(?<=;)/,
     },
 

--- a/syntaxes/test/data/let-declaration.html.snap
+++ b/syntaxes/test/data/let-declaration.html.snap
@@ -1,9 +1,9 @@
 >@let basicLet = 123 + 456;
-#^^^^ template.let.ng storage.type.ng
-#    ^ template.let.ng
-#     ^^^^^^^^ template.let.ng meta.definition.variable.ng
-#             ^ template.let.ng
-#              ^ template.let.ng keyword.operator.assignment.ng
+#^^^^ template.let.ng meta.definition.variable.ng storage.type.ng
+#    ^ template.let.ng meta.definition.variable.ng
+#     ^^^^^^^^ template.let.ng meta.definition.variable.ng variable.other.constant.ng
+#             ^ template.let.ng meta.definition.variable.ng
+#              ^ template.let.ng meta.definition.variable.ng keyword.operator.assignment.ng
 #               ^ template.let.ng meta.definition.variable.ng keyword.operator.assignment.ng
 #                ^^^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng constant.numeric.decimal.ts
 #                   ^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng
@@ -13,37 +13,37 @@
 #                         ^ template.let.ng meta.definition.variable.ng punctuation.terminator.statement.ng
 >
 >@let noSpaceAfterEquals =true;
-#^^^^ template.let.ng storage.type.ng
-#    ^ template.let.ng
-#     ^^^^^^^^^^^^^^^^^^ template.let.ng meta.definition.variable.ng
-#                       ^ template.let.ng
-#                        ^ template.let.ng keyword.operator.assignment.ng
+#^^^^ template.let.ng meta.definition.variable.ng storage.type.ng
+#    ^ template.let.ng meta.definition.variable.ng
+#     ^^^^^^^^^^^^^^^^^^ template.let.ng meta.definition.variable.ng variable.other.constant.ng
+#                       ^ template.let.ng meta.definition.variable.ng
+#                        ^ template.let.ng meta.definition.variable.ng keyword.operator.assignment.ng
 #                         ^^^^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng constant.language.boolean.true.ts
 #                             ^ template.let.ng meta.definition.variable.ng punctuation.terminator.statement.ng
 >
 >@let noSpaceBeforeEquals= true;
-#^^^^ template.let.ng storage.type.ng
-#    ^ template.let.ng
-#     ^^^^^^^^^^^^^^^^^^^ template.let.ng meta.definition.variable.ng
-#                        ^ template.let.ng keyword.operator.assignment.ng
+#^^^^ template.let.ng meta.definition.variable.ng storage.type.ng
+#    ^ template.let.ng meta.definition.variable.ng
+#     ^^^^^^^^^^^^^^^^^^^ template.let.ng meta.definition.variable.ng variable.other.constant.ng
+#                        ^ template.let.ng meta.definition.variable.ng keyword.operator.assignment.ng
 #                         ^ template.let.ng meta.definition.variable.ng keyword.operator.assignment.ng
 #                          ^^^^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng constant.language.boolean.true.ts
 #                              ^ template.let.ng meta.definition.variable.ng punctuation.terminator.statement.ng
 >
 >@let noSpaceAroundEquals=true;
-#^^^^ template.let.ng storage.type.ng
-#    ^ template.let.ng
-#     ^^^^^^^^^^^^^^^^^^^ template.let.ng meta.definition.variable.ng
-#                        ^ template.let.ng keyword.operator.assignment.ng
+#^^^^ template.let.ng meta.definition.variable.ng storage.type.ng
+#    ^ template.let.ng meta.definition.variable.ng
+#     ^^^^^^^^^^^^^^^^^^^ template.let.ng meta.definition.variable.ng variable.other.constant.ng
+#                        ^ template.let.ng meta.definition.variable.ng keyword.operator.assignment.ng
 #                         ^^^^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng constant.language.boolean.true.ts
 #                             ^ template.let.ng meta.definition.variable.ng punctuation.terminator.statement.ng
 >
 >@let                    lotOfSpaceAroundEquals      =            true;
-#^^^^ template.let.ng storage.type.ng
-#    ^^^^^^^^^^^^^^^^^^^^ template.let.ng
-#                        ^^^^^^^^^^^^^^^^^^^^^^ template.let.ng meta.definition.variable.ng
-#                                              ^^^^^^ template.let.ng
-#                                                    ^ template.let.ng keyword.operator.assignment.ng
+#^^^^ template.let.ng meta.definition.variable.ng storage.type.ng
+#    ^^^^^^^^^^^^^^^^^^^^ template.let.ng meta.definition.variable.ng
+#                        ^^^^^^^^^^^^^^^^^^^^^^ template.let.ng meta.definition.variable.ng variable.other.constant.ng
+#                                              ^^^^^^ template.let.ng meta.definition.variable.ng
+#                                                    ^ template.let.ng meta.definition.variable.ng keyword.operator.assignment.ng
 #                                                     ^^^^^^^^^^^^ template.let.ng meta.definition.variable.ng keyword.operator.assignment.ng
 #                                                                 ^^^^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng constant.language.boolean.true.ts
 #                                                                     ^ template.let.ng meta.definition.variable.ng punctuation.terminator.statement.ng
@@ -51,9 +51,9 @@
 >@let #invalid = true;
 #^^^^^^^^^^^^^^^^^^^^^^ template.let.ng
 >@let invalidIn#TheMiddle = true;
-#^^^^ template.let.ng storage.type.ng
-#    ^ template.let.ng
-#     ^^^^^^^^^ template.let.ng meta.definition.variable.ng
+#^^^^ template.let.ng meta.definition.variable.ng storage.type.ng
+#    ^ template.let.ng meta.definition.variable.ng
+#     ^^^^^^^^^ template.let.ng meta.definition.variable.ng variable.other.constant.ng
 #              ^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng
 #               ^^^^^^^^^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng variable.other.readwrite.ts
 #                        ^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng
@@ -65,11 +65,11 @@
 #^^^^^^^^^^^^^^^^^^^^ template.let.ng
 >
 >@let stringContainingSemicolon = 'hello ;' + 'world';
-#^^^^ template.let.ng storage.type.ng
-#    ^ template.let.ng
-#     ^^^^^^^^^^^^^^^^^^^^^^^^^ template.let.ng meta.definition.variable.ng
-#                              ^ template.let.ng
-#                               ^ template.let.ng keyword.operator.assignment.ng
+#^^^^ template.let.ng meta.definition.variable.ng storage.type.ng
+#    ^ template.let.ng meta.definition.variable.ng
+#     ^^^^^^^^^^^^^^^^^^^^^^^^^ template.let.ng meta.definition.variable.ng variable.other.constant.ng
+#                              ^ template.let.ng meta.definition.variable.ng
+#                               ^ template.let.ng meta.definition.variable.ng keyword.operator.assignment.ng
 #                                ^ template.let.ng meta.definition.variable.ng keyword.operator.assignment.ng
 #                                 ^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng string.quoted.single.ts punctuation.definition.string.begin.ts
 #                                  ^^^^^^^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng string.quoted.single.ts
@@ -83,11 +83,11 @@
 #                                                    ^ template.let.ng meta.definition.variable.ng punctuation.terminator.statement.ng
 >
 >@let complexExpression = something ? 123 : {prop: 'hello' + true + 'world'};
-#^^^^ template.let.ng storage.type.ng
-#    ^ template.let.ng
-#     ^^^^^^^^^^^^^^^^^ template.let.ng meta.definition.variable.ng
-#                      ^ template.let.ng
-#                       ^ template.let.ng keyword.operator.assignment.ng
+#^^^^ template.let.ng meta.definition.variable.ng storage.type.ng
+#    ^ template.let.ng meta.definition.variable.ng
+#     ^^^^^^^^^^^^^^^^^ template.let.ng meta.definition.variable.ng variable.other.constant.ng
+#                      ^ template.let.ng meta.definition.variable.ng
+#                       ^ template.let.ng meta.definition.variable.ng keyword.operator.assignment.ng
 #                        ^ template.let.ng meta.definition.variable.ng keyword.operator.assignment.ng
 #                         ^^^^^^^^^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng variable.other.readwrite.ts
 #                                  ^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng
@@ -116,11 +116,11 @@
 #                                                                           ^ template.let.ng meta.definition.variable.ng punctuation.terminator.statement.ng
 >
 >@let usingPipes = 123 + foo | async | multiply: 2 | separator: ';';
-#^^^^ template.let.ng storage.type.ng
-#    ^ template.let.ng
-#     ^^^^^^^^^^ template.let.ng meta.definition.variable.ng
-#               ^ template.let.ng
-#                ^ template.let.ng keyword.operator.assignment.ng
+#^^^^ template.let.ng meta.definition.variable.ng storage.type.ng
+#    ^ template.let.ng meta.definition.variable.ng
+#     ^^^^^^^^^^ template.let.ng meta.definition.variable.ng variable.other.constant.ng
+#               ^ template.let.ng meta.definition.variable.ng
+#                ^ template.let.ng meta.definition.variable.ng keyword.operator.assignment.ng
 #                 ^ template.let.ng meta.definition.variable.ng keyword.operator.assignment.ng
 #                  ^^^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng constant.numeric.decimal.ts
 #                     ^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng
@@ -151,11 +151,11 @@
 #^^^^^^^^^^^^^^^^^^^^^^^^^ template.let.ng
 >  @let inBlock = true;
 #^^ template.let.ng
-#  ^^^^ template.let.ng storage.type.ng
-#      ^ template.let.ng
-#       ^^^^^^^ template.let.ng meta.definition.variable.ng
-#              ^ template.let.ng
-#               ^ template.let.ng keyword.operator.assignment.ng
+#  ^^^^ template.let.ng meta.definition.variable.ng storage.type.ng
+#      ^ template.let.ng meta.definition.variable.ng
+#       ^^^^^^^ template.let.ng meta.definition.variable.ng variable.other.constant.ng
+#              ^ template.let.ng meta.definition.variable.ng
+#               ^ template.let.ng meta.definition.variable.ng keyword.operator.assignment.ng
 #                ^ template.let.ng meta.definition.variable.ng keyword.operator.assignment.ng
 #                 ^^^^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng constant.language.boolean.true.ts
 #                     ^ template.let.ng meta.definition.variable.ng punctuation.terminator.statement.ng
@@ -164,11 +164,11 @@
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.let.ng
 >    @let inNestedBlock = 123;
 #^^^^ template.let.ng
-#    ^^^^ template.let.ng storage.type.ng
-#        ^ template.let.ng
-#         ^^^^^^^^^^^^^ template.let.ng meta.definition.variable.ng
-#                      ^ template.let.ng
-#                       ^ template.let.ng keyword.operator.assignment.ng
+#    ^^^^ template.let.ng meta.definition.variable.ng storage.type.ng
+#        ^ template.let.ng meta.definition.variable.ng
+#         ^^^^^^^^^^^^^ template.let.ng meta.definition.variable.ng variable.other.constant.ng
+#                      ^ template.let.ng meta.definition.variable.ng
+#                       ^ template.let.ng meta.definition.variable.ng keyword.operator.assignment.ng
 #                        ^ template.let.ng meta.definition.variable.ng keyword.operator.assignment.ng
 #                         ^^^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng constant.numeric.decimal.ts
 #                            ^ template.let.ng meta.definition.variable.ng punctuation.terminator.statement.ng
@@ -178,9 +178,9 @@
 #^^ template.let.ng
 >
 >@let noEquals
-#^^^^ template.let.ng storage.type.ng
-#    ^ template.let.ng
-#     ^^^^^^^^ template.let.ng meta.definition.variable.ng
+#^^^^ template.let.ng meta.definition.variable.ng storage.type.ng
+#    ^ template.let.ng meta.definition.variable.ng
+#     ^^^^^^^^ template.let.ng meta.definition.variable.ng variable.other.constant.ng
 >
 >@let noValue =
 #^ template.let.ng meta.definition.variable.ng meta.definition.variable.initializer.ng


### PR DESCRIPTION
This PR tweaks the TM scopes applied to `@let` declarations to tokenize the bound identifier as a variable. This brings the grammar into closer alignment with, e.g., TypeScript's TM grammar.

### Changes made
- The bound identifier gets its own scope, `variable.other.constant.ng`.
- `meta.definition.variable.ng` scope now covers the entire declaration instead of just the identifier and the initializer expression.

### Screenshots

#### Before:
![let-highlighting-before](https://github.com/user-attachments/assets/96b54043-42a3-43a8-9e85-d498a83ae5a7)

#### After:
![let-highlighting-after](https://github.com/user-attachments/assets/da598313-1d68-46da-9da8-b2d520e275c9)

### Note

I went with `variable.other.constant.ng` instead of `variable.other.readwrite.ng` because it's technically correct (you cannot reassign a `@let` binding), but it does make it inconsistent with the rest of the grammar, which uses `readwrite` everywhere. I'd be happy to change it if there's a preference for consistency over correctness. My daily driver theme (and likely most themes on the marketplace) doesn't distinguish between the two, but the default VS Code theme renders constants with a slightly different shade of blue.