### PR TITLE
fix(syntaxes): `keyword` token for `track`

### DIFF
--- a/syntaxes/src/template-blocks.ts
+++ b/syntaxes/src/template-blocks.ts
@@ -45,11 +45,44 @@ export const TemplateBlocks: GrammarDefinition = {
         0: {name: 'meta.brace.round.ts'},
       },
       contentName: 'control.block.expression.ng',
-      patterns: [{include: 'expression.ng'}],
+      patterns: [
+        {include: '#blockExpressionOfClause'},
+        {include: '#blockExpressionLetBinding'},
+        {include: '#blockExpressionTrackClause'},
+        {include: 'expression.ng'},
+      ],
       end: /\)/,
       endCaptures: {
         0: {name: 'meta.brace.round.ts'},
       },
+    },
+
+    blockExpressionOfClause: {
+      begin: /([_$[:alpha:]][_$[:alnum:]]*)\s+(of)\b/,
+      beginCaptures: {
+        1: {name: 'variable.other.constant.ng'},
+        2: {name: 'keyword.operator.expression.of.ng'},
+      },
+      end: /(?=[$)])|(?<=;)/,
+      patterns: [{include: 'expression.ng'}],
+    },
+
+    blockExpressionLetBinding: {
+      begin: /\blet\b/,
+      beginCaptures: {
+        0: {name: 'storage.type.ng'},
+      },
+      end: /(?=[$)])|(?<=;)/,
+      patterns: [{include: 'expression.ng'}],
+    },
+
+    blockExpressionTrackClause: {
+      begin: /\btrack\b/,
+      beginCaptures: {
+        0: {name: 'keyword.control.track.ng'},
+      },
+      end: /(?=[$)])|(?<=;)/,
+      patterns: [{include: 'expression.ng'}],
     },
 
     blockBody: {

--- a/syntaxes/template-blocks.json
+++ b/syntaxes/template-blocks.json
@@ -46,6 +46,15 @@
       "contentName": "control.block.expression.ng",
       "patterns": [
         {
+          "include": "#blockExpressionOfClause"
+        },
+        {
+          "include": "#blockExpressionLetBinding"
+        },
+        {
+          "include": "#blockExpressionTrackClause"
+        },
+        {
           "include": "expression.ng"
         }
       ],
@@ -55,6 +64,51 @@
           "name": "meta.brace.round.ts"
         }
       }
+    },
+    "blockExpressionOfClause": {
+      "begin": "([_$[:alpha:]][_$[:alnum:]]*)\\s+(of)\\b",
+      "beginCaptures": {
+        "1": {
+          "name": "variable.other.constant.ng"
+        },
+        "2": {
+          "name": "keyword.operator.expression.of.ng"
+        }
+      },
+      "end": "(?=[$)])|(?<=;)",
+      "patterns": [
+        {
+          "include": "expression.ng"
+        }
+      ]
+    },
+    "blockExpressionLetBinding": {
+      "begin": "\\blet\\b",
+      "beginCaptures": {
+        "0": {
+          "name": "storage.type.ng"
+        }
+      },
+      "end": "(?=[$)])|(?<=;)",
+      "patterns": [
+        {
+          "include": "expression.ng"
+        }
+      ]
+    },
+    "blockExpressionTrackClause": {
+      "begin": "\\btrack\\b",
+      "beginCaptures": {
+        "0": {
+          "name": "keyword.control.track.ng"
+        }
+      },
+      "end": "(?=[$)])|(?<=;)",
+      "patterns": [
+        {
+          "include": "expression.ng"
+        }
+      ]
     },
     "blockBody": {
       "begin": "\\{",

--- a/syntaxes/test/data/template-blocks.html
+++ b/syntaxes/test/data/template-blocks.html
@@ -52,6 +52,10 @@
 
 }
 
+<!-- `track` is only a keyword at the start of the clause -->
+@for (item of items; let track = $index; track item.track) { }
+@for (track of tracks; track track) { }
+
 <!-- Should not highlight -->
 
 some.email@google.com ({}) {}

--- a/syntaxes/test/data/template-blocks.html.snap
+++ b/syntaxes/test/data/template-blocks.html.snap
@@ -143,7 +143,7 @@
 # ^^^ template.blocks.ng control.block.ng keyword.control.block.kind.ng
 #    ^ template.blocks.ng control.block.ng
 #     ^ template.blocks.ng control.block.ng meta.brace.round.ts
-#      ^^^ template.blocks.ng control.block.ng control.block.expression.ng storage.type.ts
+#      ^^^ template.blocks.ng control.block.ng control.block.expression.ng storage.type.ng
 #         ^ template.blocks.ng control.block.ng control.block.expression.ng
 #          ^^^^ template.blocks.ng control.block.ng control.block.expression.ng variable.other.readwrite.ts
 #              ^ template.blocks.ng control.block.ng control.block.expression.ng
@@ -152,7 +152,7 @@
 #                  ^^^^^ template.blocks.ng control.block.ng control.block.expression.ng variable.other.readwrite.ts
 #                       ^ template.blocks.ng control.block.ng control.block.expression.ng punctuation.terminator.statement.ts
 #                        ^ template.blocks.ng control.block.ng control.block.expression.ng
-#                         ^^^^^ template.blocks.ng control.block.ng control.block.expression.ng variable.other.readwrite.ts
+#                         ^^^^^ template.blocks.ng control.block.ng control.block.expression.ng keyword.control.track.ng
 #                              ^ template.blocks.ng control.block.ng control.block.expression.ng
 #                               ^^^^^^ template.blocks.ng control.block.ng control.block.expression.ng variable.other.readwrite.ts
 #                                     ^ template.blocks.ng control.block.ng meta.brace.round.ts
@@ -174,13 +174,13 @@
 #         ^ template.blocks.ng control.block.ng control.block.expression.ng punctuation.terminator.statement.ts
 >    track $index;
 #^^^^ template.blocks.ng control.block.ng control.block.expression.ng
-#    ^^^^^ template.blocks.ng control.block.ng control.block.expression.ng variable.other.readwrite.ts
+#    ^^^^^ template.blocks.ng control.block.ng control.block.expression.ng keyword.control.track.ng
 #         ^ template.blocks.ng control.block.ng control.block.expression.ng
 #          ^^^^^^ template.blocks.ng control.block.ng control.block.expression.ng variable.other.readwrite.ts
 #                ^ template.blocks.ng control.block.ng control.block.expression.ng punctuation.terminator.statement.ts
 >    let o = $odd
 #^^^^ template.blocks.ng control.block.ng control.block.expression.ng
-#    ^^^ template.blocks.ng control.block.ng control.block.expression.ng storage.type.ts
+#    ^^^ template.blocks.ng control.block.ng control.block.expression.ng storage.type.ng
 #       ^ template.blocks.ng control.block.ng control.block.expression.ng
 #        ^ template.blocks.ng control.block.ng control.block.expression.ng variable.other.readwrite.ts
 #         ^ template.blocks.ng control.block.ng control.block.expression.ng
@@ -217,14 +217,14 @@
 #    ^^ template.blocks.ng control.block.ng
 >(item of items; track $index) { }
 #^ template.blocks.ng control.block.ng meta.brace.round.ts
-# ^^^^ template.blocks.ng control.block.ng control.block.expression.ng variable.other.readwrite.ts
+# ^^^^ template.blocks.ng control.block.ng control.block.expression.ng variable.other.constant.ng
 #     ^ template.blocks.ng control.block.ng control.block.expression.ng
-#      ^^ template.blocks.ng control.block.ng control.block.expression.ng keyword.operator.expression.of.ts
+#      ^^ template.blocks.ng control.block.ng control.block.expression.ng keyword.operator.expression.of.ng
 #        ^ template.blocks.ng control.block.ng control.block.expression.ng
 #         ^^^^^ template.blocks.ng control.block.ng control.block.expression.ng variable.other.readwrite.ts
 #              ^ template.blocks.ng control.block.ng control.block.expression.ng punctuation.terminator.statement.ts
 #               ^ template.blocks.ng control.block.ng control.block.expression.ng
-#                ^^^^^ template.blocks.ng control.block.ng control.block.expression.ng variable.other.readwrite.ts
+#                ^^^^^ template.blocks.ng control.block.ng control.block.expression.ng keyword.control.track.ng
 #                     ^ template.blocks.ng control.block.ng control.block.expression.ng
 #                      ^^^^^^ template.blocks.ng control.block.ng control.block.expression.ng variable.other.readwrite.ts
 #                            ^ template.blocks.ng control.block.ng meta.brace.round.ts
@@ -238,14 +238,14 @@
 # ^^^ template.blocks.ng control.block.ng keyword.control.block.kind.ng
 #    ^ template.blocks.ng control.block.ng
 #     ^ template.blocks.ng control.block.ng meta.brace.round.ts
-#      ^^^^ template.blocks.ng control.block.ng control.block.expression.ng variable.other.readwrite.ts
+#      ^^^^ template.blocks.ng control.block.ng control.block.expression.ng variable.other.constant.ng
 #          ^ template.blocks.ng control.block.ng control.block.expression.ng
-#           ^^ template.blocks.ng control.block.ng control.block.expression.ng keyword.operator.expression.of.ts
+#           ^^ template.blocks.ng control.block.ng control.block.expression.ng keyword.operator.expression.of.ng
 #             ^ template.blocks.ng control.block.ng control.block.expression.ng
 #              ^^^^^ template.blocks.ng control.block.ng control.block.expression.ng variable.other.readwrite.ts
 #                   ^ template.blocks.ng control.block.ng control.block.expression.ng punctuation.terminator.statement.ts
 #                    ^ template.blocks.ng control.block.ng control.block.expression.ng
-#                     ^^^^^ template.blocks.ng control.block.ng control.block.expression.ng variable.other.readwrite.ts
+#                     ^^^^^ template.blocks.ng control.block.ng control.block.expression.ng keyword.control.track.ng
 #                          ^ template.blocks.ng control.block.ng control.block.expression.ng
 #                           ^^^^^^ template.blocks.ng control.block.ng control.block.expression.ng variable.other.readwrite.ts
 #                                 ^ template.blocks.ng control.block.ng meta.brace.round.ts
@@ -265,6 +265,60 @@
 >
 >}
 #^ template.blocks.ng control.block.ng punctuation.definition.block.ts
+>
+><!-- `track` is only a keyword at the start of the clause -->
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.blocks.ng
+>@for (item of items; let track = $index; track item.track) { }
+#^ template.blocks.ng control.block.ng keyword.control.block.transition.ng
+# ^^^ template.blocks.ng control.block.ng keyword.control.block.kind.ng
+#    ^ template.blocks.ng control.block.ng
+#     ^ template.blocks.ng control.block.ng meta.brace.round.ts
+#      ^^^^ template.blocks.ng control.block.ng control.block.expression.ng variable.other.constant.ng
+#          ^ template.blocks.ng control.block.ng control.block.expression.ng
+#           ^^ template.blocks.ng control.block.ng control.block.expression.ng keyword.operator.expression.of.ng
+#             ^ template.blocks.ng control.block.ng control.block.expression.ng
+#              ^^^^^ template.blocks.ng control.block.ng control.block.expression.ng variable.other.readwrite.ts
+#                   ^ template.blocks.ng control.block.ng control.block.expression.ng punctuation.terminator.statement.ts
+#                    ^ template.blocks.ng control.block.ng control.block.expression.ng
+#                     ^^^ template.blocks.ng control.block.ng control.block.expression.ng storage.type.ng
+#                        ^ template.blocks.ng control.block.ng control.block.expression.ng
+#                         ^^^^^ template.blocks.ng control.block.ng control.block.expression.ng variable.other.readwrite.ts
+#                              ^ template.blocks.ng control.block.ng control.block.expression.ng
+#                               ^ template.blocks.ng control.block.ng control.block.expression.ng keyword.operator.assignment.ts
+#                                ^ template.blocks.ng control.block.ng control.block.expression.ng
+#                                 ^^^^^^ template.blocks.ng control.block.ng control.block.expression.ng variable.other.readwrite.ts
+#                                       ^ template.blocks.ng control.block.ng control.block.expression.ng punctuation.terminator.statement.ts
+#                                        ^ template.blocks.ng control.block.ng control.block.expression.ng
+#                                         ^^^^^ template.blocks.ng control.block.ng control.block.expression.ng keyword.control.track.ng
+#                                              ^ template.blocks.ng control.block.ng control.block.expression.ng
+#                                               ^^^^ template.blocks.ng control.block.ng control.block.expression.ng variable.other.object.ts
+#                                                   ^ template.blocks.ng control.block.ng control.block.expression.ng punctuation.accessor.ts
+#                                                    ^^^^^ template.blocks.ng control.block.ng control.block.expression.ng variable.other.property.ts
+#                                                         ^ template.blocks.ng control.block.ng meta.brace.round.ts
+#                                                          ^ template.blocks.ng control.block.ng
+#                                                           ^ template.blocks.ng control.block.ng punctuation.definition.block.ts
+#                                                            ^ template.blocks.ng control.block.ng control.block.body.ng
+#                                                             ^ template.blocks.ng control.block.ng punctuation.definition.block.ts
+>@for (track of tracks; track track) { }
+#^ template.blocks.ng control.block.ng keyword.control.block.transition.ng
+# ^^^ template.blocks.ng control.block.ng keyword.control.block.kind.ng
+#    ^ template.blocks.ng control.block.ng
+#     ^ template.blocks.ng control.block.ng meta.brace.round.ts
+#      ^^^^^ template.blocks.ng control.block.ng control.block.expression.ng variable.other.constant.ng
+#           ^ template.blocks.ng control.block.ng control.block.expression.ng
+#            ^^ template.blocks.ng control.block.ng control.block.expression.ng keyword.operator.expression.of.ng
+#              ^ template.blocks.ng control.block.ng control.block.expression.ng
+#               ^^^^^^ template.blocks.ng control.block.ng control.block.expression.ng variable.other.readwrite.ts
+#                     ^ template.blocks.ng control.block.ng control.block.expression.ng punctuation.terminator.statement.ts
+#                      ^ template.blocks.ng control.block.ng control.block.expression.ng
+#                       ^^^^^ template.blocks.ng control.block.ng control.block.expression.ng keyword.control.track.ng
+#                            ^ template.blocks.ng control.block.ng control.block.expression.ng
+#                             ^^^^^ template.blocks.ng control.block.ng control.block.expression.ng variable.other.readwrite.ts
+#                                  ^ template.blocks.ng control.block.ng meta.brace.round.ts
+#                                   ^ template.blocks.ng control.block.ng
+#                                    ^ template.blocks.ng control.block.ng punctuation.definition.block.ts
+#                                     ^ template.blocks.ng control.block.ng control.block.body.ng
+#                                      ^ template.blocks.ng control.block.ng punctuation.definition.block.ts
 >
 ><!-- Should not highlight -->
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.blocks.ng


### PR DESCRIPTION
This PR updates the TM grammar for flow-control block expressions to tokenize `track` as a keyword.

### Changes made
- Separate the valid sub-expressions of a `@for`/`@if` header into their own "clause" patterns (helps to avoid highlighting `track` as a keyword in the wrong context)
- Assign `keyword.control.track.ng` scope to the `track` token at the beginning of a "track-by" clause
- The `item` binding in `item of items` is now `constant` instead of `readwrite`, following the same logic mentioned in #2160. Again, happy to revert this change if that's unwanted.

### Screenshots

#### Before:
![track-highlighting-before](https://github.com/user-attachments/assets/3964ebc8-47c2-4318-9a31-c189861908e6)

#### After:
![track-highlighting-after](https://github.com/user-attachments/assets/a8baf4ea-11d7-4e3e-a422-47331c6be20e)
