### PR TITLE
fix(syntaxes): Semicolons not tokenized

### DIFF
--- a/syntaxes/expression.json
+++ b/syntaxes/expression.json
@@ -35,6 +35,9 @@
           "include": "#punctuationComma"
         },
         {
+          "include": "#punctuationSemicolon"
+        },
+        {
           "include": "#punctuationAccessor"
         }
       ]

--- a/syntaxes/src/expression.ts
+++ b/syntaxes/src/expression.ts
@@ -42,6 +42,9 @@ export const Expression: GrammarDefinition = {
               include: '#punctuationComma',
             },
             {
+              include: '#punctuationSemicolon',
+            },
+            {
               include: '#punctuationAccessor',
             },
           ],

--- a/syntaxes/test/data/expression.html.snap
+++ b/syntaxes/test/data/expression.html.snap
@@ -305,7 +305,8 @@
 #   ^^^^ template.ng expression.ng entity.name.function.ts
 #       ^ template.ng expression.ng meta.brace.round.ts
 #        ^ template.ng expression.ng meta.brace.round.ts
-#         ^^ template.ng expression.ng
+#         ^ template.ng expression.ng punctuation.terminator.statement.ts
+#          ^ template.ng expression.ng
 #           ^^ template.ng punctuation.definition.block.ts
 >{{ call().object }}
 #^^ template.ng punctuation.definition.block.ts
@@ -325,7 +326,8 @@
 #        ^ template.ng expression.ng meta.brace.round.ts
 #         ^ template.ng expression.ng punctuation.accessor.ts
 #          ^^^^^^ template.ng expression.ng variable.other.property.ts
-#                ^^ template.ng expression.ng
+#                ^ template.ng expression.ng punctuation.terminator.statement.ts
+#                 ^ template.ng expression.ng
 #                  ^^ template.ng punctuation.definition.block.ts
 >{{ call()?.conditional }}
 #^^ template.ng punctuation.definition.block.ts
@@ -345,7 +347,8 @@
 #        ^ template.ng expression.ng meta.brace.round.ts
 #         ^^ template.ng expression.ng punctuation.accessor.ts
 #           ^^^^^^^^^^^ template.ng expression.ng variable.other.property.ts
-#                      ^^ template.ng expression.ng
+#                      ^ template.ng expression.ng punctuation.terminator.statement.ts
+#                       ^ template.ng expression.ng
 #                        ^^ template.ng punctuation.definition.block.ts
 >{{ call()!.conditional }}
 #^^ template.ng punctuation.definition.block.ts
@@ -367,7 +370,8 @@
 #         ^ template.ng expression.ng keyword.operator.logical.ts
 #          ^ template.ng expression.ng punctuation.accessor.ts
 #           ^^^^^^^^^^^ template.ng expression.ng variable.other.property.ts
-#                      ^^ template.ng expression.ng
+#                      ^ template.ng expression.ng punctuation.terminator.statement.ts
+#                       ^ template.ng expression.ng
 #                        ^^ template.ng punctuation.definition.block.ts
 >
 ><!-- Property read and method call: received -->
@@ -390,7 +394,8 @@
 #          ^^^^ template.ng expression.ng entity.name.function.ts
 #              ^ template.ng expression.ng meta.brace.round.ts
 #               ^ template.ng expression.ng meta.brace.round.ts
-#                ^^ template.ng expression.ng
+#                ^ template.ng expression.ng punctuation.terminator.statement.ts
+#                 ^ template.ng expression.ng
 #                  ^^ template.ng punctuation.definition.block.ts
 >{{ object.call().object }}
 #^^ template.ng punctuation.definition.block.ts
@@ -414,7 +419,8 @@
 #               ^ template.ng expression.ng meta.brace.round.ts
 #                ^ template.ng expression.ng punctuation.accessor.ts
 #                 ^^^^^^ template.ng expression.ng variable.other.property.ts
-#                       ^^ template.ng expression.ng
+#                       ^ template.ng expression.ng punctuation.terminator.statement.ts
+#                        ^ template.ng expression.ng
 #                         ^^ template.ng punctuation.definition.block.ts
 >{{ object?.call()?.conditional }}
 #^^ template.ng punctuation.definition.block.ts
@@ -440,7 +446,8 @@
 #                ^ template.ng expression.ng meta.brace.round.ts
 #                 ^^ template.ng expression.ng punctuation.accessor.ts
 #                   ^^^^^^^^^^^ template.ng expression.ng variable.other.property.ts
-#                              ^^ template.ng expression.ng
+#                              ^ template.ng expression.ng punctuation.terminator.statement.ts
+#                               ^ template.ng expression.ng
 #                                ^^ template.ng punctuation.definition.block.ts
 >{{ object!.call()!.conditional }}
 #^^ template.ng punctuation.definition.block.ts
@@ -468,7 +475,8 @@
 #                 ^ template.ng expression.ng keyword.operator.logical.ts
 #                  ^ template.ng expression.ng punctuation.accessor.ts
 #                   ^^^^^^^^^^^ template.ng expression.ng variable.other.property.ts
-#                              ^^ template.ng expression.ng
+#                              ^ template.ng expression.ng punctuation.terminator.statement.ts
+#                               ^ template.ng expression.ng
 #                                ^^ template.ng punctuation.definition.block.ts
 >
 ><!-- Method call with parameters -->
@@ -664,7 +672,8 @@
 #                    ^ template.ng expression.ng keyword.operator.ternary.ts
 #                     ^ template.ng expression.ng
 #                      ^^^^^ template.ng expression.ng constant.language.boolean.false.ts
-#                           ^^ template.ng expression.ng
+#                           ^ template.ng expression.ng punctuation.terminator.statement.ts
+#                            ^ template.ng expression.ng
 #                             ^^ template.ng punctuation.definition.block.ts
 >{{ condition() ? call(1 + 2 + 3) : call() }}
 #^^ template.ng punctuation.definition.block.ts
@@ -722,7 +731,8 @@
 #                                   ^^^^ template.ng expression.ng entity.name.function.ts
 #                                       ^ template.ng expression.ng meta.brace.round.ts
 #                                        ^ template.ng expression.ng meta.brace.round.ts
-#                                         ^^ template.ng expression.ng
+#                                         ^ template.ng expression.ng punctuation.terminator.statement.ts
+#                                          ^ template.ng expression.ng
 #                                           ^^ template.ng punctuation.definition.block.ts
 >{{ condition()?.object ? call()!.test() : false }}
 #^^ template.ng punctuation.definition.block.ts
@@ -1078,7 +1088,8 @@
 #                                                                                                     ^^^^^^^^^ template.ng expression.ng meta.array.literal.ts string.quoted.single.ts
 #                                                                                                              ^ template.ng expression.ng meta.array.literal.ts string.quoted.single.ts punctuation.definition.string.end.ts
 #                                                                                                               ^ template.ng expression.ng meta.array.literal.ts meta.brace.square.ts
-#                                                                                                                ^^ template.ng expression.ng
+#                                                                                                                ^ template.ng expression.ng punctuation.terminator.statement.ts
+#                                                                                                                 ^ template.ng expression.ng
 #                                                                                                                  ^^^^^ template.ng expression.ng variable.other.readwrite.ts
 >as i }}
 #^^ template.ng expression.ng storage.type.as.ts
@@ -1115,7 +1126,8 @@
 #                                                              ^^ template.ng expression.ng storage.type.as.ts
 #                                                                ^ template.ng expression.ng
 #                                                                 ^ template.ng expression.ng entity.name.type.ts
-#                                                                  ^^ template.ng expression.ng
+#                                                                  ^ template.ng expression.ng punctuation.terminator.statement.ts
+#                                                                   ^ template.ng expression.ng
 #                                                                    ^^^ template.ng expression.ng storage.type.ts
 #                                                                       ^ template.ng expression.ng
 #                                                                        ^ template.ng expression.ng variable.other.readwrite.ts
@@ -1123,7 +1135,8 @@
 #                                                                          ^ template.ng expression.ng keyword.operator.assignment.ts
 #                                                                           ^ template.ng expression.ng
 #                                                                            ^^^^^ template.ng expression.ng variable.other.readwrite.ts
-#                                                                                 ^^ template.ng expression.ng
+#                                                                                 ^ template.ng expression.ng punctuation.terminator.statement.ts
+#                                                                                  ^ template.ng expression.ng
 #                                                                                   ^^^ template.ng expression.ng storage.type.ts
 #                                                                                      ^ template.ng expression.ng
 #                                                                                       ^^^^^ template.ng expression.ng variable.other.readwrite.ts
@@ -1177,7 +1190,8 @@
 #                                                                                                     ^^^^^^^^^ template.ng expression.ng meta.array.literal.ts string.quoted.single.ts
 #                                                                                                              ^ template.ng expression.ng meta.array.literal.ts string.quoted.single.ts punctuation.definition.string.end.ts
 #                                                                                                               ^ template.ng expression.ng meta.array.literal.ts meta.brace.square.ts
-#                                                                                                                ^^ template.ng expression.ng
+#                                                                                                                ^ template.ng expression.ng punctuation.terminator.statement.ts
+#                                                                                                                 ^ template.ng expression.ng
 #                                                                                                                  ^^^ template.ng expression.ng storage.type.ts
 #                                                                                                                     ^ template.ng expression.ng
 #                                                                                                                      ^ template.ng expression.ng variable.other.readwrite.ts
@@ -1185,7 +1199,8 @@
 #^ template.ng expression.ng keyword.operator.assignment.ts
 # ^ template.ng expression.ng
 #  ^^^^^ template.ng expression.ng variable.other.readwrite.ts
-#       ^^ template.ng expression.ng
+#       ^ template.ng expression.ng punctuation.terminator.statement.ts
+#        ^ template.ng expression.ng
 #         ^^ template.ng punctuation.definition.block.ts
 >
 >

--- a/syntaxes/test/data/template-blocks.html.snap
+++ b/syntaxes/test/data/template-blocks.html.snap
@@ -150,7 +150,8 @@
 #               ^^ template.blocks.ng control.block.ng control.block.expression.ng keyword.operator.expression.of.ts
 #                 ^ template.blocks.ng control.block.ng control.block.expression.ng
 #                  ^^^^^ template.blocks.ng control.block.ng control.block.expression.ng variable.other.readwrite.ts
-#                       ^^ template.blocks.ng control.block.ng control.block.expression.ng
+#                       ^ template.blocks.ng control.block.ng control.block.expression.ng punctuation.terminator.statement.ts
+#                        ^ template.blocks.ng control.block.ng control.block.expression.ng
 #                         ^^^^^ template.blocks.ng control.block.ng control.block.expression.ng variable.other.readwrite.ts
 #                              ^ template.blocks.ng control.block.ng control.block.expression.ng
 #                               ^^^^^^ template.blocks.ng control.block.ng control.block.expression.ng variable.other.readwrite.ts
@@ -170,13 +171,13 @@
 >    items;
 #^^^^ template.blocks.ng control.block.ng control.block.expression.ng
 #    ^^^^^ template.blocks.ng control.block.ng control.block.expression.ng variable.other.readwrite.ts
-#         ^^ template.blocks.ng control.block.ng control.block.expression.ng
+#         ^ template.blocks.ng control.block.ng control.block.expression.ng punctuation.terminator.statement.ts
 >    track $index;
 #^^^^ template.blocks.ng control.block.ng control.block.expression.ng
 #    ^^^^^ template.blocks.ng control.block.ng control.block.expression.ng variable.other.readwrite.ts
 #         ^ template.blocks.ng control.block.ng control.block.expression.ng
 #          ^^^^^^ template.blocks.ng control.block.ng control.block.expression.ng variable.other.readwrite.ts
-#                ^^ template.blocks.ng control.block.ng control.block.expression.ng
+#                ^ template.blocks.ng control.block.ng control.block.expression.ng punctuation.terminator.statement.ts
 >    let o = $odd
 #^^^^ template.blocks.ng control.block.ng control.block.expression.ng
 #    ^^^ template.blocks.ng control.block.ng control.block.expression.ng storage.type.ts
@@ -221,7 +222,8 @@
 #      ^^ template.blocks.ng control.block.ng control.block.expression.ng keyword.operator.expression.of.ts
 #        ^ template.blocks.ng control.block.ng control.block.expression.ng
 #         ^^^^^ template.blocks.ng control.block.ng control.block.expression.ng variable.other.readwrite.ts
-#              ^^ template.blocks.ng control.block.ng control.block.expression.ng
+#              ^ template.blocks.ng control.block.ng control.block.expression.ng punctuation.terminator.statement.ts
+#               ^ template.blocks.ng control.block.ng control.block.expression.ng
 #                ^^^^^ template.blocks.ng control.block.ng control.block.expression.ng variable.other.readwrite.ts
 #                     ^ template.blocks.ng control.block.ng control.block.expression.ng
 #                      ^^^^^^ template.blocks.ng control.block.ng control.block.expression.ng variable.other.readwrite.ts
@@ -241,7 +243,8 @@
 #           ^^ template.blocks.ng control.block.ng control.block.expression.ng keyword.operator.expression.of.ts
 #             ^ template.blocks.ng control.block.ng control.block.expression.ng
 #              ^^^^^ template.blocks.ng control.block.ng control.block.expression.ng variable.other.readwrite.ts
-#                   ^^ template.blocks.ng control.block.ng control.block.expression.ng
+#                   ^ template.blocks.ng control.block.ng control.block.expression.ng punctuation.terminator.statement.ts
+#                    ^ template.blocks.ng control.block.ng control.block.expression.ng
 #                     ^^^^^ template.blocks.ng control.block.ng control.block.expression.ng variable.other.readwrite.ts
 #                          ^ template.blocks.ng control.block.ng control.block.expression.ng
 #                           ^^^^^^ template.blocks.ng control.block.ng control.block.expression.ng variable.other.readwrite.ts

--- a/syntaxes/test/data/template-tag.html.snap
+++ b/syntaxes/test/data/template-tag.html.snap
@@ -192,7 +192,7 @@
 #                    ^ template.tag.ng meta.ng-binding.event.html expression.ng meta.brace.round.ts
 #                     ^^^^^^ template.tag.ng meta.ng-binding.event.html expression.ng variable.other.readwrite.ts
 #                           ^ template.tag.ng meta.ng-binding.event.html expression.ng meta.brace.round.ts
-#                            ^^ template.tag.ng meta.ng-binding.event.html expression.ng
+#                            ^ template.tag.ng meta.ng-binding.event.html expression.ng punctuation.terminator.statement.ts
 >    } else {
 #^^^^^^ template.tag.ng meta.ng-binding.event.html expression.ng
 #      ^^^^ template.tag.ng meta.ng-binding.event.html expression.ng keyword.control.else.ts
@@ -203,7 +203,7 @@
 #                     ^ template.tag.ng meta.ng-binding.event.html expression.ng meta.brace.round.ts
 #                      ^^^^^^ template.tag.ng meta.ng-binding.event.html expression.ng variable.other.readwrite.ts
 #                            ^ template.tag.ng meta.ng-binding.event.html expression.ng meta.brace.round.ts
-#                             ^^ template.tag.ng meta.ng-binding.event.html expression.ng
+#                             ^ template.tag.ng meta.ng-binding.event.html expression.ng punctuation.terminator.statement.ts
 >    }
 #^^^^^^ template.tag.ng meta.ng-binding.event.html expression.ng
 >"></div>
@@ -437,7 +437,7 @@
 #                   ^ template.tag.ng meta.ng-binding.template.html expression.ng keyword.operator.assignment.ts
 #                    ^ template.tag.ng meta.ng-binding.template.html expression.ng
 #                     ^^^^^ template.tag.ng meta.ng-binding.template.html expression.ng variable.other.readwrite.ts
-#                          ^ template.tag.ng meta.ng-binding.template.html expression.ng
+#                          ^ template.tag.ng meta.ng-binding.template.html expression.ng punctuation.terminator.statement.ts
 #                           ^ template.tag.ng meta.ng-binding.template.html string.quoted.html punctuation.definition.string.end.html
 #                            ^^^^^^^^ template.tag.ng
 ><div *ngFor="let i = index"></div>
@@ -470,11 +470,12 @@
 #                   ^ template.tag.ng meta.ng-binding.template.html expression.ng keyword.operator.assignment.ts
 #                    ^ template.tag.ng meta.ng-binding.template.html expression.ng
 #                     ^^^^^ template.tag.ng meta.ng-binding.template.html expression.ng variable.other.readwrite.ts
-#                          ^^ template.tag.ng meta.ng-binding.template.html expression.ng
+#                          ^ template.tag.ng meta.ng-binding.template.html expression.ng punctuation.terminator.statement.ts
+#                           ^ template.tag.ng meta.ng-binding.template.html expression.ng
 #                            ^^^^^^^ template.tag.ng meta.ng-binding.template.html expression.ng variable.other.readwrite.ts
 #                                   ^^ template.tag.ng meta.ng-binding.template.html expression.ng
 #                                     ^^^^ template.tag.ng meta.ng-binding.template.html expression.ng variable.other.readwrite.ts
-#                                         ^ template.tag.ng meta.ng-binding.template.html expression.ng
+#                                         ^ template.tag.ng meta.ng-binding.template.html expression.ng punctuation.terminator.statement.ts
 #                                          ^ template.tag.ng meta.ng-binding.template.html string.quoted.html punctuation.definition.string.end.html
 #                                           ^^^^^^^^ template.tag.ng
 ><div *ngFor="let i = index; trackBy: hash"></div>
@@ -490,7 +491,8 @@
 #                   ^ template.tag.ng meta.ng-binding.template.html expression.ng keyword.operator.assignment.ts
 #                    ^ template.tag.ng meta.ng-binding.template.html expression.ng
 #                     ^^^^^ template.tag.ng meta.ng-binding.template.html expression.ng variable.other.readwrite.ts
-#                          ^^ template.tag.ng meta.ng-binding.template.html expression.ng
+#                          ^ template.tag.ng meta.ng-binding.template.html expression.ng punctuation.terminator.statement.ts
+#                           ^ template.tag.ng meta.ng-binding.template.html expression.ng
 #                            ^^^^^^^ template.tag.ng meta.ng-binding.template.html expression.ng variable.other.readwrite.ts
 #                                   ^^ template.tag.ng meta.ng-binding.template.html expression.ng
 #                                     ^^^^ template.tag.ng meta.ng-binding.template.html expression.ng variable.other.readwrite.ts
@@ -509,7 +511,7 @@
 #                       ^^ template.tag.ng meta.ng-binding.template.html expression.ng keyword.operator.expression.of.ts
 #                         ^ template.tag.ng meta.ng-binding.template.html expression.ng
 #                          ^^^^^^ template.tag.ng meta.ng-binding.template.html expression.ng variable.other.readwrite.ts
-#                                ^ template.tag.ng meta.ng-binding.template.html expression.ng
+#                                ^ template.tag.ng meta.ng-binding.template.html expression.ng punctuation.terminator.statement.ts
 #                                 ^ template.tag.ng meta.ng-binding.template.html string.quoted.html punctuation.definition.string.end.html
 #                                  ^^^^^^^^ template.tag.ng
 ><div *ngFor="let param of params"></div>
@@ -542,13 +544,14 @@
 #                       ^^ template.tag.ng meta.ng-binding.template.html expression.ng keyword.operator.expression.of.ts
 #                         ^ template.tag.ng meta.ng-binding.template.html expression.ng
 #                          ^^^^^^ template.tag.ng meta.ng-binding.template.html expression.ng variable.other.readwrite.ts
-#                                ^^ template.tag.ng meta.ng-binding.template.html expression.ng
+#                                ^ template.tag.ng meta.ng-binding.template.html expression.ng punctuation.terminator.statement.ts
+#                                 ^ template.tag.ng meta.ng-binding.template.html expression.ng
 #                                  ^^^^^ template.tag.ng meta.ng-binding.template.html expression.ng variable.other.readwrite.ts
 #                                       ^ template.tag.ng meta.ng-binding.template.html expression.ng
 #                                        ^^ template.tag.ng meta.ng-binding.template.html expression.ng storage.type.as.ts
 #                                          ^ template.tag.ng meta.ng-binding.template.html expression.ng
 #                                           ^ template.tag.ng meta.ng-binding.template.html expression.ng entity.name.type.ts
-#                                            ^ template.tag.ng meta.ng-binding.template.html expression.ng
+#                                            ^ template.tag.ng meta.ng-binding.template.html expression.ng punctuation.terminator.statement.ts
 #                                             ^ template.tag.ng meta.ng-binding.template.html string.quoted.html punctuation.definition.string.end.html
 #                                              ^^^^^^^^ template.tag.ng
 ><div *ngFor="let param of params; index as i"></div>
@@ -564,7 +567,8 @@
 #                       ^^ template.tag.ng meta.ng-binding.template.html expression.ng keyword.operator.expression.of.ts
 #                         ^ template.tag.ng meta.ng-binding.template.html expression.ng
 #                          ^^^^^^ template.tag.ng meta.ng-binding.template.html expression.ng variable.other.readwrite.ts
-#                                ^^ template.tag.ng meta.ng-binding.template.html expression.ng
+#                                ^ template.tag.ng meta.ng-binding.template.html expression.ng punctuation.terminator.statement.ts
+#                                 ^ template.tag.ng meta.ng-binding.template.html expression.ng
 #                                  ^^^^^ template.tag.ng meta.ng-binding.template.html expression.ng variable.other.readwrite.ts
 #                                       ^ template.tag.ng meta.ng-binding.template.html expression.ng
 #                                        ^^ template.tag.ng meta.ng-binding.template.html expression.ng storage.type.as.ts
@@ -600,7 +604,8 @@
 #                       ^^ template.tag.ng meta.ng-binding.template.html expression.ng keyword.operator.expression.of.ts
 #                         ^ template.tag.ng meta.ng-binding.template.html expression.ng
 #                          ^^^^^^ template.tag.ng meta.ng-binding.template.html expression.ng variable.other.readwrite.ts
-#                                ^^ template.tag.ng meta.ng-binding.template.html expression.ng
+#                                ^ template.tag.ng meta.ng-binding.template.html expression.ng punctuation.terminator.statement.ts
+#                                 ^ template.tag.ng meta.ng-binding.template.html expression.ng
 #                                  ^^^ template.tag.ng meta.ng-binding.template.html expression.ng storage.type.ts
 #                                     ^ template.tag.ng meta.ng-binding.template.html expression.ng
 #                                      ^ template.tag.ng meta.ng-binding.template.html expression.ng variable.other.readwrite.ts
@@ -608,7 +613,8 @@
 #                                        ^ template.tag.ng meta.ng-binding.template.html expression.ng keyword.operator.assignment.ts
 #                                         ^ template.tag.ng meta.ng-binding.template.html expression.ng
 #                                          ^^^^^ template.tag.ng meta.ng-binding.template.html expression.ng variable.other.readwrite.ts
-#                                               ^^ template.tag.ng meta.ng-binding.template.html expression.ng
+#                                               ^ template.tag.ng meta.ng-binding.template.html expression.ng punctuation.terminator.statement.ts
+#                                                ^ template.tag.ng meta.ng-binding.template.html expression.ng
 #                                                 ^^^ template.tag.ng meta.ng-binding.template.html expression.ng storage.type.ts
 #                                                    ^ template.tag.ng meta.ng-binding.template.html expression.ng
 #                                                     ^^^^ template.tag.ng meta.ng-binding.template.html expression.ng variable.other.readwrite.ts
@@ -631,7 +637,8 @@
 #                       ^^ template.tag.ng meta.ng-binding.template.html expression.ng keyword.operator.expression.of.ts
 #                         ^ template.tag.ng meta.ng-binding.template.html expression.ng
 #                          ^^^^^^ template.tag.ng meta.ng-binding.template.html expression.ng variable.other.readwrite.ts
-#                                ^^ template.tag.ng meta.ng-binding.template.html expression.ng
+#                                ^ template.tag.ng meta.ng-binding.template.html expression.ng punctuation.terminator.statement.ts
+#                                 ^ template.tag.ng meta.ng-binding.template.html expression.ng
 #                                  ^^^ template.tag.ng meta.ng-binding.template.html expression.ng storage.type.ts
 #                                     ^ template.tag.ng meta.ng-binding.template.html expression.ng
 #                                      ^ template.tag.ng meta.ng-binding.template.html expression.ng variable.other.readwrite.ts
@@ -639,7 +646,8 @@
 #                                        ^ template.tag.ng meta.ng-binding.template.html expression.ng keyword.operator.assignment.ts
 #                                         ^ template.tag.ng meta.ng-binding.template.html expression.ng
 #                                          ^^^^^ template.tag.ng meta.ng-binding.template.html expression.ng variable.other.readwrite.ts
-#                                               ^^ template.tag.ng meta.ng-binding.template.html expression.ng
+#                                               ^ template.tag.ng meta.ng-binding.template.html expression.ng punctuation.terminator.statement.ts
+#                                                ^ template.tag.ng meta.ng-binding.template.html expression.ng
 #                                                 ^^^ template.tag.ng meta.ng-binding.template.html expression.ng storage.type.ts
 #                                                    ^ template.tag.ng meta.ng-binding.template.html expression.ng
 #                                                     ^^^^ template.tag.ng meta.ng-binding.template.html expression.ng variable.other.readwrite.ts
@@ -647,7 +655,7 @@
 #                                                          ^ template.tag.ng meta.ng-binding.template.html expression.ng keyword.operator.assignment.ts
 #                                                           ^ template.tag.ng meta.ng-binding.template.html expression.ng
 #                                                            ^^^^ template.tag.ng meta.ng-binding.template.html expression.ng variable.other.readwrite.ts
-#                                                                ^ template.tag.ng meta.ng-binding.template.html expression.ng
+#                                                                ^ template.tag.ng meta.ng-binding.template.html expression.ng punctuation.terminator.statement.ts
 #                                                                 ^ template.tag.ng meta.ng-binding.template.html string.quoted.html punctuation.definition.string.end.html
 #                                                                  ^^^^^^^^ template.tag.ng
 ><div *ngFor="let param of params; let i = index; last as last"></div>
@@ -663,7 +671,8 @@
 #                       ^^ template.tag.ng meta.ng-binding.template.html expression.ng keyword.operator.expression.of.ts
 #                         ^ template.tag.ng meta.ng-binding.template.html expression.ng
 #                          ^^^^^^ template.tag.ng meta.ng-binding.template.html expression.ng variable.other.readwrite.ts
-#                                ^^ template.tag.ng meta.ng-binding.template.html expression.ng
+#                                ^ template.tag.ng meta.ng-binding.template.html expression.ng punctuation.terminator.statement.ts
+#                                 ^ template.tag.ng meta.ng-binding.template.html expression.ng
 #                                  ^^^ template.tag.ng meta.ng-binding.template.html expression.ng storage.type.ts
 #                                     ^ template.tag.ng meta.ng-binding.template.html expression.ng
 #                                      ^ template.tag.ng meta.ng-binding.template.html expression.ng variable.other.readwrite.ts
@@ -671,7 +680,8 @@
 #                                        ^ template.tag.ng meta.ng-binding.template.html expression.ng keyword.operator.assignment.ts
 #                                         ^ template.tag.ng meta.ng-binding.template.html expression.ng
 #                                          ^^^^^ template.tag.ng meta.ng-binding.template.html expression.ng variable.other.readwrite.ts
-#                                               ^^ template.tag.ng meta.ng-binding.template.html expression.ng
+#                                               ^ template.tag.ng meta.ng-binding.template.html expression.ng punctuation.terminator.statement.ts
+#                                                ^ template.tag.ng meta.ng-binding.template.html expression.ng
 #                                                 ^^^^ template.tag.ng meta.ng-binding.template.html expression.ng variable.other.readwrite.ts
 #                                                     ^ template.tag.ng meta.ng-binding.template.html expression.ng
 #                                                      ^^ template.tag.ng meta.ng-binding.template.html expression.ng storage.type.as.ts
@@ -692,7 +702,8 @@
 #                       ^^ template.tag.ng meta.ng-binding.template.html expression.ng keyword.operator.expression.of.ts
 #                         ^ template.tag.ng meta.ng-binding.template.html expression.ng
 #                          ^^^^^^ template.tag.ng meta.ng-binding.template.html expression.ng variable.other.readwrite.ts
-#                                ^^ template.tag.ng meta.ng-binding.template.html expression.ng
+#                                ^ template.tag.ng meta.ng-binding.template.html expression.ng punctuation.terminator.statement.ts
+#                                 ^ template.tag.ng meta.ng-binding.template.html expression.ng
 #                                  ^^^ template.tag.ng meta.ng-binding.template.html expression.ng storage.type.ts
 #                                     ^ template.tag.ng meta.ng-binding.template.html expression.ng
 #                                      ^ template.tag.ng meta.ng-binding.template.html expression.ng variable.other.readwrite.ts
@@ -700,13 +711,14 @@
 #                                        ^ template.tag.ng meta.ng-binding.template.html expression.ng keyword.operator.assignment.ts
 #                                         ^ template.tag.ng meta.ng-binding.template.html expression.ng
 #                                          ^^^^^ template.tag.ng meta.ng-binding.template.html expression.ng variable.other.readwrite.ts
-#                                               ^^ template.tag.ng meta.ng-binding.template.html expression.ng
+#                                               ^ template.tag.ng meta.ng-binding.template.html expression.ng punctuation.terminator.statement.ts
+#                                                ^ template.tag.ng meta.ng-binding.template.html expression.ng
 #                                                 ^^^^ template.tag.ng meta.ng-binding.template.html expression.ng variable.other.readwrite.ts
 #                                                     ^ template.tag.ng meta.ng-binding.template.html expression.ng
 #                                                      ^^ template.tag.ng meta.ng-binding.template.html expression.ng storage.type.as.ts
 #                                                        ^ template.tag.ng meta.ng-binding.template.html expression.ng
 #                                                         ^^^^ template.tag.ng meta.ng-binding.template.html expression.ng entity.name.type.ts
-#                                                             ^ template.tag.ng meta.ng-binding.template.html expression.ng
+#                                                             ^ template.tag.ng meta.ng-binding.template.html expression.ng punctuation.terminator.statement.ts
 #                                                              ^ template.tag.ng meta.ng-binding.template.html string.quoted.html punctuation.definition.string.end.html
 #                                                               ^^^^^^^^ template.tag.ng
 >
@@ -727,7 +739,8 @@
 #                   ^^ template.tag.ng meta.ng-binding.template.html expression.ng keyword.operator.expression.of.ts
 #                     ^ template.tag.ng meta.ng-binding.template.html expression.ng
 #                      ^^^^ template.tag.ng meta.ng-binding.template.html expression.ng variable.other.readwrite.ts
-#                          ^^ template.tag.ng meta.ng-binding.template.html expression.ng
+#                          ^ template.tag.ng meta.ng-binding.template.html expression.ng punctuation.terminator.statement.ts
+#                           ^ template.tag.ng meta.ng-binding.template.html expression.ng
 #                            ^^^^^ template.tag.ng meta.ng-binding.template.html expression.ng variable.other.readwrite.ts
 #                                 ^ template.tag.ng meta.ng-binding.template.html expression.ng
 #                                  ^^ template.tag.ng meta.ng-binding.template.html expression.ng storage.type.as.ts


### PR DESCRIPTION
This PR adds the `punctuationSemicolon` pattern to the `expression` grammar's pattern list, which ensures that the `punctuation.terminator` scope is actually applied to the matching syntax.