### PR TITLE
fix: add support for @angular/core/types/core.d.ts path

### DIFF
--- a/server/src/session.ts
+++ b/server/src/session.ts
@@ -1499,7 +1499,11 @@ function isAngularCore(path: string): boolean {
 }
 
 function isExternalAngularCore(path: string): boolean {
-  return path.endsWith('@angular/core/core.d.ts') || path.endsWith('@angular/core/index.d.ts');
+  return (
+    path.endsWith('@angular/core/core.d.ts') ||
+    path.endsWith('@angular/core/index.d.ts') ||
+    path.endsWith('@angular/core/types/core.d.ts')
+  );
 }
 
 function isInternalAngularCore(path: string): boolean {


### PR DESCRIPTION
## Description
This PR fixes an issue where the Angular Language Service extension does not recognize `@angular/core` when its declaration file is located at `@angular/core/types/core.d.ts`.

## Problem
The extension only checked for Angular core at these two paths:
- `@angular/core/core.d.ts`
- `@angular/core/index.d.ts`

When Angular core is at `@angular/core/types/core.d.ts`, the extension fails to detect it and does not initialize the language service.

## Solution
Added `@angular/core/types/core.d.ts` to the list of checked paths in the `isExternalAngularCore(...)` function.